### PR TITLE
Feature: Static Prelude, "loadBundle" api, bundling without prelude

### DIFF
--- a/src/createCustomPack.js
+++ b/src/createCustomPack.js
@@ -5,49 +5,49 @@
 // - breakout generateFirstLine
 // - lavamoat: call loadBundle with correct args
 // - lavamoat: expect config as an argument
+// - cleanup: var -> const/let
 
 const assert = require('assert')
-var JSONStream = require('JSONStream')
-var defined = require('defined')
-var through = require('through2')
-var umd = require('umd')
-var Buffer = require('safe-buffer').Buffer
-var path = require('path')
+const JSONStream = require('JSONStream')
+const defined = require('defined')
+const through = require('through2')
+const umd = require('umd')
+const Buffer = require('safe-buffer').Buffer
+const path = require('path')
 
-var combineSourceMap = require('combine-source-map')
+const combineSourceMap = require('combine-source-map')
 
-var defaultPreludePath = path.join(__dirname, '_prelude.js')
+const defaultPreludePath = path.join(__dirname, '_prelude.js')
 
 function newlinesIn (src) {
   if (!src) return 0
-  var newlines = src.match(/\n/g)
-
+  const newlines = src.match(/\n/g)
   return newlines ? newlines.length : 0
 }
 
 module.exports = function (opts) {
   if (!opts) opts = {}
-  var parser = opts.raw ? through.obj() : JSONStream.parse([true])
-  var stream = through.obj(
-    function (buf, enc, next) { parser.write(buf); next() },
+  const parser = opts.raw ? through.obj() : JSONStream.parse([true])
+  const stream = through.obj(
+    function (buf, _, next) { parser.write(buf); next() },
     function () { parser.end() }
   )
   parser.pipe(through.obj(write, end))
   stream.standaloneModule = opts.standaloneModule
   stream.hasExports = opts.hasExports
 
-  var first = true
-  var entries = []
-  var basedir = defined(opts.basedir, process.cwd())
-  var prelude = opts.prelude
+  let first = true
+  let entries = []
+  const basedir = defined(opts.basedir, process.cwd())
+  const prelude = opts.prelude
   assert(prelude, 'must specify a prelude')
   const config = opts.config
   assert(config, 'must specify a config')
-  var preludePath = opts.preludePath ||
+  const preludePath = opts.preludePath ||
         path.relative(basedir, defaultPreludePath).replace(/\\/g, '/')
 
-  var lineno = 1 + newlinesIn(prelude)
-  var sourcemap
+  let lineno = 1 + newlinesIn(prelude)
+  let sourcemap
 
   if (opts.generateModuleInitializer && opts.bundleEntryForModule) {
     throw new Error('LavaMoat CustomPack: conflicting options for "generateModuleInitializer" and "bundleEntryForModule". Can only set one.')
@@ -105,7 +105,7 @@ module.exports = function (opts) {
       )
     }
 
-    var wrappedSource = [
+    const wrappedSource = [
       (first ? '' : ','),
       JSON.stringify(row.id),
       ':',
@@ -140,7 +140,7 @@ module.exports = function (opts) {
     }
 
     if (sourcemap) {
-      var comment = sourcemap.comment()
+      let comment = sourcemap.comment()
       if (opts.sourceMapPrefix) {
         comment = comment.replace(
           /^\/\/#/, function () { return opts.sourceMapPrefix }

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,9 @@ function getConfigurationFromPluginOpts (pluginOpts) {
         primaryConfig = JSON.parse(configSource)
       } else if (typeof pluginOpts.config === 'object') {
         primaryConfig = pluginOpts.config
+      } else if (pluginOpts.config === undefined) {
+        // set primaryConfig as an empty config
+        primaryConfig = { resources: {} }
       }
       // if override specified, merge
       if (pluginOpts.configOverride) {
@@ -111,7 +114,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
         } else if (typeof configOverride !== 'object') {
           throw new Error('LavaMoat - Config Override must be a function, string or object')
         }
-        //Ensure override config was written correctly
+        // Ensure override config was written correctly
         validateConfig(configOverride)
         const mergedConfig = mergeDeep(primaryConfig, configOverride)
         return mergedConfig
@@ -187,11 +190,12 @@ function getConfigPath (pluginOpts) {
   return defaultConfig
 }
 
-function createLavamoatPacker (opts) {
-  const onSourcemap = opts.onSourcemap || (row => row.sourceFile)
+function createLavamoatPacker (configuration) {
+  const onSourcemap = configuration.onSourcemap || (row => row.sourceFile)
   const defaults = {
     raw: true,
-    prelude: generatePrelude(opts),
+    config: configuration.getConfig(),
+    prelude: generatePrelude(configuration),
     bundleEntryForModule: (entry) => {
       const { package: packageName, source, deps } = entry
       const wrappedBundle = wrapIntoModuleInitializer(source)
@@ -207,7 +211,7 @@ function createLavamoatPacker (opts) {
     }
   }
 
-  const packOpts = Object.assign({}, defaults, opts)
+  const packOpts = Object.assign({}, defaults, configuration)
   const customPack = createCustomPack(packOpts)
   return customPack
 }
@@ -231,16 +235,16 @@ function applySesTransforms (browserify) {
   browserify.transform(changeImportString, { global: true })
 }
 
-function validateConfig(configOverride) {
+function validateConfig (configOverride) {
   if (typeof configOverride !== 'object') {
-    throw new Error("LavaMoat - Expected config override to be an object")
+    throw new Error('LavaMoat - Expected config override to be an object')
   }
-  
+
   if (!Object.keys(configOverride).includes('resources')) {
     throw new Error("LavaMoat - Expected label 'resources' for configuration key")
   }
 
-  Object.entries(configOverride['resources']).forEach(([packageName, packageOpts], index) => {
+  Object.entries(configOverride.resources).forEach(([packageName, packageOpts], index) => {
     const packageOptions = Object.keys(packageOpts)
     const packageEntries = Object.values(packageOpts)
     const optionsWhitelist = ['globals', 'packages']
@@ -259,4 +263,3 @@ function validateConfig(configOverride) {
     })
   })
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
     'writeAutoConfig',
     'config',
     'configOverride',
+    'includePrelude',
     '_' // Browserify adds this as the first option when running from the command line
   ])
   const invalidKeys = Reflect.ownKeys(pluginOpts).filter(key => !allowedKeys.has(key))
@@ -65,7 +66,8 @@ function getConfigurationFromPluginOpts (pluginOpts) {
   const configuration = {
     writeAutoConfig: undefined,
     getConfig: undefined,
-    configPath: getConfigPath(pluginOpts)
+    configPath: getConfigPath(pluginOpts),
+    includePrelude: pluginOpts.includePrelude
   }
 
   const defaultOverrideConfig = '/lavamoat-config-override.json'

--- a/test/basic.js
+++ b/test/basic.js
@@ -76,11 +76,11 @@ test('basic - lavamoat config and bundle', async (t) => {
     source: 'module.exports = () => location.href'
   }]
   const getConfig = await generateConfigFromFiles({ files: clone(files) })
-  const prelude = generatePrelude({ getConfig })
+  const prelude = generatePrelude()
   const config = getConfig
   const bundle = await createBundleFromRequiresArray(clone(files), { config })
 
-  t.assert(prelude.includes('"banana": true'), 'prelude includes banana config')
+  t.assert(bundle.includes('"banana":true'), 'prelude includes banana config')
   t.assert(bundle.includes(prelude), 'bundle includes expected prelude')
 
   const testHref = 'https://funky.town.gov/yolo?snake=yes'

--- a/test/config.js
+++ b/test/config.js
@@ -6,7 +6,7 @@ const tmp = require('tmp')
 const mkdirp = require('mkdirp')
 const rimraf = require('rimraf')
 
-const { 
+const {
   createBundleFromRequiresArray,
   generateConfigFromFiles,
   createWatchifyBundle,
@@ -106,7 +106,7 @@ test('config - default config path is generated with autoconfig if path is not s
   const tmpObj = tmp.dirSync();
   const defaults = {
     cwd: tmpObj.name,
-    stdio: 'inherit' 
+    stdio: 'inherit'
   };
 
   const expectedPath = path.join(tmpObj.name, 'lavamoat/lavamoat-config.json')
@@ -192,7 +192,7 @@ test('Config - Applies config override', async (t) => {
   mkdirp.sync(configDir)
   fs.writeFileSync(configFilePath, JSON.stringify(config))
   fs.writeFileSync(overrideFilePath, JSON.stringify(configOverride))
-  
+
   const bundle = await createBundleFromRequiresArray([], {
     config: configFilePath,
     configOverride
@@ -210,10 +210,10 @@ test('Config - Applies config override', async (t) => {
     configOverride: () => configOverride
   })
 
-  t.assert(bundle.includes('"three": true'), "Applies override, provided as object")
-  t.assert(stringBundle.includes('"three": true'), "Applies override, provided as string")
-  t.assert(functionBundle.includes('"three": true'), "Applies override, provided as function")
-  t.assert(configObjectBundle.includes('"three": true'), "Applies override, primary config provided as object")
+  t.assert(bundle.includes('"three":true'), "Applies override, provided as object")
+  t.assert(stringBundle.includes('"three":true'), "Applies override, provided as string")
+  t.assert(functionBundle.includes('"three":true'), "Applies override, provided as function")
+  t.assert(configObjectBundle.includes('"three":true'), "Applies override, primary config provided as object")
 })
 
 test('Config override is applied if not specified and already exists at default path', async (t) => {
@@ -252,7 +252,7 @@ test('Config override is applied if not specified and already exists at default 
   const buildProcess = execSync(`node ${scriptPath}`, defaults)
   const outputString = buildProcess.toString()
 
-  t.assert(outputString.includes('"three": 12345678'), "Applies override if exists but not specified")
+  t.assert(outputString.includes('"three":12345678'), "Applies override if exists but not specified")
 })
 
 test('Config edits trigger re-bundle if using watchify', async (t) => {
@@ -276,14 +276,14 @@ test('Config edits trigger re-bundle if using watchify', async (t) => {
 
   const overridePath = './lavamoat/lavamoat-config-override.json'
   const configPath = './lavamoat/lavamoat-config.json'
-  
+
   bundler.emit('file', './lavamoat/lavamoat-config-override.json')
-  
+
   await new Promise(resolve => setTimeout(resolve, 1000))
 
   const configFile = fs.readFileSync(configPath)
   const configFileString = configFile.toString()
-  
+
   await new Promise((resolve) => {
     bundler.once('update', () => resolve())
     const overrideString = JSON.stringify(configDefault)

--- a/test/util.js
+++ b/test/util.js
@@ -5,7 +5,7 @@ const through2 = require('through2').obj
 const mergeDeep = require('merge-deep')
 const watchify = require('watchify')
 
-const sesifyPlugin = require('../src/index')
+const lavamoatPlugin = require('../src/index')
 
 
 module.exports = {
@@ -23,9 +23,9 @@ module.exports = {
 
 async function createBundleFromEntry (path, pluginOpts = {}) {
   pluginOpts.config = pluginOpts.config || {}
-  const bundler = browserify([], sesifyPlugin.args)
+  const bundler = browserify([], lavamoatPlugin.args)
   bundler.add(path)
-  bundler.plugin(sesifyPlugin, pluginOpts)
+  bundler.plugin(lavamoatPlugin, pluginOpts)
   return bundleAsync(bundler)
 }
 
@@ -41,9 +41,9 @@ async function createBundleFromRequiresArray (files, pluginOpts) {
 
 function createBrowserifyFromRequiresArray ({ files, pluginOpts = {} }) {
   // empty bundle but inject modules at bundle time
-  const bifyOpts = Object.assign({}, sesifyPlugin.args)
+  const bifyOpts = Object.assign({}, lavamoatPlugin.args)
   const bundler = browserify([], bifyOpts)
-  bundler.plugin(sesifyPlugin, pluginOpts)
+  bundler.plugin(lavamoatPlugin, pluginOpts)
 
   // override browserify's module resolution
   const mdeps = bundler.pipeline.get('deps').get(0)
@@ -106,8 +106,8 @@ async function createWatchifyBundle (pluginOpts) {
     cache: {},
     packageCache: {},
     plugin: [
-      [sesifyPlugin, pluginOpts],
-      //poll option is needed to ensure the 'update' event is properly fired after the config override file changes. Without it, the firing behavior is unpredictable due to filesystem watch not always detecting the change. 
+      [lavamoatPlugin, pluginOpts],
+      //poll option is needed to ensure the 'update' event is properly fired after the config override file changes. Without it, the firing behavior is unpredictable due to filesystem watch not always detecting the change.
       [watchify, {poll: true}]
     ]
   })


### PR DESCRIPTION
- Config has been moved out of the prelude, it is now static (takes no options, not app specific)
- Bundles are now loaded into the prelude via `LavaMoat.loadBundle(...)`
- Prelude can be optionally not included in bundle via `{ includePrelude: false }` pluginOpts
- (untested) Using the 3 features above, apps can be run by loading separate bundle files