### PR TITLE
core/ses - update ses to 0.10.3

### DIFF
--- a/packages/browserify/test/config.js
+++ b/packages/browserify/test/config.js
@@ -261,7 +261,7 @@ test('Config override is applied if not specified and already exists at default 
 
   const scriptPath = require.resolve('./fixtures/runBrowserifyNoOpts')
 
-  const buildProcess = execSync(`node ${scriptPath}`, { cwd: tmpObj.name })
+  const buildProcess = execSync(`node ${scriptPath}`, { cwd: tmpObj.name, maxBuffer: 5 * 1024 * 1024 })
   const outputString = buildProcess.toString()
 
   t.assert(outputString.includes('"three":12345678'), 'Applies override if exists but not specified')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "json-stable-stringify": "^1.0.1",
     "lavamoat-tofu": "^5.1.0",
     "resolve": "^1.15.1",
-    "ses": "^0.7.7"
+    "ses": "^0.10.3"
   },
   "devDependencies": {
     "merge-deep": "^3.0.2",

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -126,17 +126,17 @@
           // take every property on globalRef
           Object.entries(Object.getOwnPropertyDescriptors(membraneWrappedEndowments))
             // ignore properties already defined on compartment global
-            .filter(([key]) => !(key in moduleCompartment.global))
+            .filter(([key]) => !(key in moduleCompartment.globalThis))
             // define property on compartment global
-            .forEach(([key, desc]) => Reflect.defineProperty(moduleCompartment.global, key, desc))
+            .forEach(([key, desc]) => Reflect.defineProperty(moduleCompartment.globalThis, key, desc))
         } else {
           // sets up read/write access as configured
           const globalsConfig = configForModule.globals
-          prepareCompartmentGlobalFromConfig(moduleCompartment.global, globalsConfig, membraneWrappedEndowments, globalStore)
+          prepareCompartmentGlobalFromConfig(moduleCompartment.globalThis, globalsConfig, membraneWrappedEndowments, globalStore)
         }
         // expose membrane for debugging
         if (debugMode) {
-          moduleCompartment.global.membrane = membrane
+          moduleCompartment.globalThis.membrane = membrane
         }
         // execute in module compartment with modified compartment global
         try {

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -12,15 +12,18 @@
 
     // create the SES rootRealm
     // "templateRequire" calls are inlined in "generatePrelude"
-    const { lockdown } = templateRequire('ses')
-    const lockdownOptions = {
-      // this is introduces non-determinism, but is otherwise safe
-      noTameMath: true,
-    }
+    // load-bearing semi-colon, do not remove
+    ;templateRequire('ses')
 
-    // only reveal error stacks in debug mode
-    if (debugMode === true) {
-      lockdownOptions.noTameError = true
+    const lockdownOptions = {
+      // gives a semi-high resolution timer
+      dateTaming: 'unsafe',
+      // gives code excessive introspection, but meh
+      errorTaming: 'unsafe',
+      // this is introduces non-determinism, but is otherwise safe
+      mathTaming: 'unsafe',
+      // ?
+      // regExpTaming: 'unsafe',
     }
 
     lockdown(lockdownOptions)

--- a/packages/core/test/builtin.js
+++ b/packages/core/test/builtin.js
@@ -262,6 +262,7 @@ function evaluateWithSourceUrl (filename, content, baseContext) {
   const context = Object.assign({}, baseContext)
   // circular ref (used by SES)
   context.global = context
+  context.console = console
   // perform eval
   const result = runInNewContext(`${content}\n//# sourceURL=${filename}`, context)
   // pull out test result value from context (not always used)

--- a/packages/node/src/parseForConfig.js
+++ b/packages/node/src/parseForConfig.js
@@ -52,8 +52,6 @@ function makeResolveHook ({ cwd, resolutions = {}, rootPackageName = '<root>' })
       }
       // return "null" to mean failed to resolve
       return null
-      // throw unknown error
-      throw err
     }
     return resolved
   }

--- a/packages/tofu/src/findGlobals.js
+++ b/packages/tofu/src/findGlobals.js
@@ -30,6 +30,7 @@ function findGlobals (ast) {
       if (parentType === 'MemberExpression' && path.parent.property === path.node) return
       // skip if this is the key side of an object pattern
       if (parentType === 'ObjectProperty' && path.parent.key === path.node) return
+      if (parentType === 'ObjectMethod' && path.parent.key === path.node) return
 
       // skip if it refers to an existing variable
       const name = path.node.name

--- a/packages/tofu/test/findGlobals.js
+++ b/packages/tofu/test/findGlobals.js
@@ -35,6 +35,10 @@ function read(file) {
 //   return namePath.join('.');
 // }
 
+test('object method', (t) => {
+  t.deepEqual(detect('const x = { xyz () {} }'), []);
+  t.end()
+});
 test('argument.js - parameters from inline arguments', (t) => {
   t.deepEqual(detect(read('argument.js')), []);
   t.end()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@agoric/babel-standalone@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.9.5.tgz#1ca0c17844924199d31e49d6b67e8b2a629b8599"
+  integrity sha512-1Aa23oPuRi4kywUyZODo8zey9Gq2NpD2xUnNvgJLoT8orMQRlVOtvbG3JeHq5sjJERlF/q6csg4/P8t8/5IABA==
+
 "@agoric/make-hardener@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.8.tgz#7f9e9d6874600b2e1b0543ce9456fbf62463be2d"
@@ -11,6 +16,16 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.6.tgz#5903748a71381bc37e23d571390aaff9973c37b2"
   integrity sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ==
+
+"@agoric/make-hardener@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.1.tgz#9b887da47aeec6637d9db4f0a92a4e740b8262bb"
+  integrity sha512-3emNc+yWJoFK5JMLoEFPs6rCzkntWQKxpR4gt3jaZYLKoUG4LrTmID3XNe8y40B6SJ3k/wLPodKa0ToQGlhrwQ==
+
+"@agoric/transform-module@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@agoric/transform-module/-/transform-module-0.4.1.tgz#9fb152364faf372e1bda535cb4ef89717724f57c"
+  integrity sha512-4TJJHXeXAWu1FCA7yXCAZmhBNoGTB/BEAe2pv+J2X8W/mJTr9b395OkDCSRMpzvmSshLfBx6wT0D7dqWIWEC1w==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -7385,6 +7400,15 @@ serve@^11.3.0:
     compression "1.7.3"
     serve-handler "6.1.3"
     update-check "1.5.2"
+
+ses@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.10.3.tgz#1a9e532d24c3676ce67e693e92f6c582b1d53c81"
+  integrity sha512-z9aBNQFsPxc6VOqYig2a3GSGpG5ull+Qz9i99iMQMPavQ3z+wk//zoAAsKLo9+Xj1orHt4qTofHvfLOIqhDlCw==
+  dependencies:
+    "@agoric/babel-standalone" "^7.9.5"
+    "@agoric/make-hardener" "^0.1.0"
+    "@agoric/transform-module" "^0.4.1"
 
 ses@^0.7.7:
   version "0.7.7"


### PR DESCRIPTION
- [x] update ses :rocket: includes some expansion of override mistake workarounds
- [ ] ses here includes whole of babel for esm, likely has init perf impact, maybe should use ses-lite