### PR TITLE
Support inline sourcemaps without sourcesContent

### DIFF
--- a/packages/browserify/src/sourcemaps.js
+++ b/packages/browserify/src/sourcemaps.js
@@ -15,7 +15,6 @@ function extractSourceMaps (sourceCode) {
   const converter = convertSourceMap.fromSource(sourceCode)
   // if (!converter) throw new Error('Unable to find original inlined sourcemap')
   const maps = converter && converter.toObject()
-  const sourceContent = maps && maps.sourcesContent[0]
   const code = convertSourceMap.removeComments(sourceCode)
   return { code, maps }
 }


### PR DESCRIPTION
`lavamoat-browserify` would crash when passed a file with an inline sourcemap without a `sourcesContent` property. This property is optional, and not guaranteed to be present in a valid sourcemap.

It turns out that the only use of this property was to assign to an unused variable. This unused variable has been removed, and the plugin now supports sourcemaps without `sourcesContent`.