### PR TITLE
Dogfood allow-scripts workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
-        run: yarn --frozen-lockfile --ignore-scripts
+        run: yarn --frozen-lockfile
       - name: Test
         run: yarn test
       - name: Lint

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true


### PR DESCRIPTION
- Pending review of `allow-scripts`
```
TypeError [ERR_INVALID_URL]: Invalid URL: undefined
    at onParseError (internal/url.js:259:9)
    at new URL (internal/url.js:335:5)
    at getCanonicalNameInfo (/Users/Etienne/Desktop/lavamoat-stuff/lavamoat/packages/node/test/projects/2/node_modules/@lavamoat/allow-scripts/src/index.js:258:15)
    at getCanonicalNameInfoForTreeNode (/Users/Etienne/Desktop/lavamoat-stuff/lavamoat/packages/node/test/projects/2/node_modules/@lavamoat/allow-scripts/src/index.js:443:12)
    at loadAllPackageConfigurations (/Users/Etienne/Desktop/lavamoat-stuff/lavamoat/packages/node/test/projects/2/node_modules/@lavamoat/allow-scripts/src/index.js:452:42)
    at async setDefaultConfiguration (/Users/Etienne/Desktop/lavamoat-stuff/lavamoat/packages/node/test/projects/2/node_modules/@lavamoat/allow-scripts/src/index.js:159:7)
    at async start (/Users/Etienne/Desktop/lavamoat-stuff/lavamoat/packages/node/test/projects/2/node_modules/@lavamoat/allow-scripts/src/cli.js:26:7) {
  input: 'undefined',
  code: 'ERR_INVALID_URL'
}
```