### PR TITLE
aa - memoize expensive operations in eachPackageInLogicalTree

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -18,7 +18,7 @@
     },
     "@lavamoat/aa": {
       "builtin": {
-        "fs.promises.readFile": true,
+        "fs.readFileSync": true,
         "path.dirname": true,
         "path.join": true,
         "path.relative": true


### PR DESCRIPTION
Some tests were failing for me locally, but they failed on main as well.

I think before we merge this we may need to:
- [ ] introduce cache invalidation or instantiate cache on each inbound call to aa package
- [ ] figure out why there's a weird failure in node12
