### PR TITLE
fix how we decide between .npmrc and .yarnrc

### DIFF
--- a/packages/allow-scripts/src/setup.js
+++ b/packages/allow-scripts/src/setup.js
@@ -20,14 +20,16 @@ function addInstallParentDir(filename) {
 function writeRcFile () {
   const yarnRcExists = existsSync(addInstallParentDir('.yarnrc'))
   const npmRcExists = existsSync(addInstallParentDir('.npmrc'))
+  const yarnLockExists = existsSync(addInstallParentDir('yarn.lock'))
 
   let rcFile, rcEntry
-  if (npmRcExists) {
-    rcFile = '.npmrc'
-    rcEntry = 'ignore-scripts=true'
-  } else {
+  if (yarnRcExists || yarnLockExists) {
     rcFile = '.yarnrc'
     rcEntry = 'ignore-scripts true'
+  } else {
+    // if no lockfiles exixt, default to npm, because that's what everyone has anyway
+    rcFile = '.npmrc'
+    rcEntry = 'ignore-scripts=true'
   }
 
   let rcPath = addInstallParentDir(rcFile)


### PR DESCRIPTION
I had a project with package-lock and not a single mention of yarn, but the current algo is that if .npmrc is not present, use yarn for everything. It'd even spawn a yarn.lock because it proceeds to use yarn for adding the always-fail package.

Now we're a bit more precise. 

Decided to not loog for package-lock and instead assume if no clear signs of yarn, it must be npm.