### PR TITLE
opinion: installing lavamoat should bring in allow-scripts because at's the point otherwise

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,6 +19,7 @@
     "@babel/code-frame": "^7.10.4",
     "@babel/highlight": "^7.10.4",
     "@lavamoat/aa": "^3.1.0",
+    "@lavamoat/allow-scripts": "latest",
     "bindings": "^1.5.0",
     "htmlescape": "^1.1.1",
     "json-stable-stringify": "^1.0.1",


### PR DESCRIPTION

I'd also argue we should have a single command to set up lavamoat as a whole, which would do:
- allow-scripts setup
- allow-scripts auto
- ask which package.json>scripts entries to lavamoatize 
  - add lavamoat to each entry
  - generate policy for each entry

I don't know how to satisfy the linter though...