### PR TITLE
feat: add lavamoat-run-command for running scripts from node_modules/.bin conveniently

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,8 @@
 {
   "name": "lavamoat",
   "bin": {
-    "lavamoat": "src/index.js"
+    "lavamoat": "src/index.js",
+    "lavamoat-run-command": "src/run-command.js"
   },
   "version": "6.2.0",
   "main": "index.js",

--- a/packages/node/src/yargsFlags.js
+++ b/packages/node/src/yargsFlags.js
@@ -1,0 +1,64 @@
+module.exports = (yargs, defaultPaths) => {
+  // the path for the policy file
+  yargs.option('policy', {
+    alias: ['p', 'policyPath'],
+    describe: 'Pass in policy. Accepts a filepath string to the existing policy. When used in conjunction with --autopolicy, specifies where to write the policy. Default: ./lavamoat/node/policy.json',
+    type: 'string',
+    default: defaultPaths.primary
+  })
+  // the path for the policy override file
+  yargs.option('policyOverride', {
+    alias: ['o', 'override', 'policyOverridePath'],
+    describe: 'Pass in override policy. Accepts a filepath string to the existing override policy. Default: ./lavamoat/node/policy-override.json',
+    type: 'string',
+    default: defaultPaths.override
+  })
+  // the path for the policy debug file
+  yargs.option('policyDebug', {
+    alias: ['pd', 'policydebug', 'policyDebugPath'],
+    describe: 'Pass in debug policy. Accepts a filepath string to the existing debug policy. Default: ./lavamoat/node/policy-debug.json',
+    type: 'string',
+    default: defaultPaths.debug
+  })
+  // parsing mode, write policy to policy path
+  yargs.option('writeAutoPolicy', {
+    alias: ['a', 'autopolicy'],
+    describe: 'Generate a "policy.json" and "policy-override.json" in the current working         directory. Overwrites any existing policy files. The override policy is for making manual policy changes and always takes precedence over the automatically generated policy.',
+    type: 'boolean',
+    default: false
+  })
+  // parsing + run mode, write policy to policy path then execute with new policy
+  yargs.option('writeAutoPolicyAndRun', {
+    alias: ['ar', 'autorun'],
+    describe: 'parse + generate a LavaMoat policy file then execute with the new policy.',
+    type: 'boolean',
+    default: false
+  })
+  // parsing mode, write policy debug info to specified or default path
+  yargs.option('writeAutoPolicyDebug', {
+    alias: ['dp', 'debugpolicy'],
+    describe: 'when writeAutoPolicy is enabled, write policy debug info to specified or default path',
+    type: 'boolean',
+    default: false
+  })
+  // parsing mode, write policy debug info to specified or default path
+  yargs.option('projectRoot', {
+    describe: 'specify the director from where packages should be resolved',
+    type: 'string',
+    default: process.cwd()
+  })
+  // debugMode, disable some protections for easier debugging
+  yargs.option('debugMode', {
+    alias: ['d', 'debug'],
+    describe: 'Disable some protections and extra logging for easier debugging.',
+    type: 'boolean',
+    default: false
+  })
+  // log initialization stats
+  yargs.option('statsMode', {
+    alias: ['stats'],
+    describe: 'enable writing and logging of stats',
+    type: 'boolean',
+    default: false
+  })
+}


### PR DESCRIPTION
I pondered adding it to existing lavamoat command, but it'd be too chaotic.

I'll add docs once #362 is merged

This change makes this possible:

```js
"scripts": {
    "start": "lavamoat-run-command --debug -- react-scripts start --stats",
   
```
Note how --debug is an argument passed to lavamoat and --stats is passed to react-scripts and it works (at least when I tested)