### PR TITLE
feat: merge overrides into policy on each run, not just on autopolicy

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,7 +4,7 @@ const {
 const { createModuleInspector, getDefaultPaths } = require('./generatePolicy')
 const { parseForPolicy } = require('./parseForPolicy')
 const { LavamoatModuleRecord } = require('./moduleRecord')
-const { loadPolicy } = require('./loadPolicy')
+const { loadPolicy, loadPolicyAndApplyOverrides } = require('./loadPolicy')
 const { mergePolicy } = require('./mergePolicy')
 const { applySourceTransforms } = require('./sourceTransforms')
 const { makeInitStatsHook } = require('./makeInitStatsHook')
@@ -17,6 +17,7 @@ module.exports = {
   parseForPolicy,
   loadPolicy,
   mergePolicy,
+  loadPolicyAndApplyOverrides,
   getDefaultPaths,
   applySourceTransforms,
   // module record class

--- a/packages/core/src/loadPolicy.js
+++ b/packages/core/src/loadPolicy.js
@@ -11,7 +11,7 @@ async function loadPolicy ({ debugMode, policyPath }) {
     const configSource = fs.readFileSync(policyPath, 'utf8')
     policy = JSON.parse(configSource)
   } else {
-    if (debugMode) console.warn('Lavamoat could not find policy')
+    if (debugMode) console.warn(`Lavamoat could not find policy at ${policyPath}`)
   }
   return policy
 }

--- a/packages/core/src/loadPolicy.js
+++ b/packages/core/src/loadPolicy.js
@@ -1,17 +1,36 @@
 const fs = require('fs')
+const { mergePolicy } = require('./mergePolicy')
+const jsonStringify = require('json-stable-stringify')
 
-module.exports = { loadPolicy }
+module.exports = { loadPolicy, loadPolicyAndApplyOverrides }
 
+async function readPolicyFile ({ debugMode, policyPath }) {
+  if (debugMode) console.warn(`Lavamoat looking for policy at'${policyPath}'`)
+  const configSource = fs.readFileSync(policyPath, 'utf8')
+  return JSON.parse(configSource)
+}
 
 async function loadPolicy ({ debugMode, policyPath }) {
   let policy = { resources: {} }
-  // try policy
   if (fs.existsSync(policyPath)) {
-    if (debugMode) console.warn(`Lavamoat looking for policy at ${policyPath}`)
-    const configSource = fs.readFileSync(policyPath, 'utf8')
-    policy = JSON.parse(configSource)
+    policy = readPolicyFile ({ debugMode, policyPath }) 
   } else {
-    if (debugMode) console.warn(`Lavamoat could not find policy at ${policyPath}`)
+    if (debugMode) console.warn(`Lavamoat could not find policy at '${policyPath}'`)
   }
   return policy
+}
+
+async function loadPolicyAndApplyOverrides({ debugMode, policyPath, policyOverridePath }){
+  const policy = await loadPolicy({ debugMode, policyPath })
+  let lavamoatPolicy = policy
+  if (fs.existsSync(policyOverridePath)) {
+    if (debugMode) console.warn(`Merging policy-override.json into policy.json`)
+    const policyOverride = await readPolicyFile({ debugMode, policyPath: policyOverridePath })
+    lavamoatPolicy = mergePolicy(policy, policyOverride)
+    // TODO: Only write if merge results in changes.
+    // Would have to make a deep equal check on whole policy, which is a waste of time.
+    // mergePolicy() should be able to do it in one pass.
+    fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
+  }
+  return lavamoatPolicy;
 }


### PR DESCRIPTION
This is one option to do it.

We could also have a special switch to enable that (but people might suffer instead of looking it up) 
We could make the merge function give us hints whether anything changed as a result of the merge to avoid unnecessary writes.

I've tested and for my testcase project autopolicy with overrides produced the same exact result as running lavamoat with a clean policy and overrides getting merged into it.