### PR TITLE
export functionality for building runtime with scuttling config

### DIFF
--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint src/**/*.js test/**/*.js --fix",
     "lint:deps": "depcheck",
     "test": "ava --timeout=30s test/index.js",
-    "build": "node ./src/build-runtime.js"
+    "build": "node ./src/build-runtime.js build"
   },
   "author": "kumavis",
   "license": "MIT",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint src/**/*.js test/**/*.js --fix",
     "lint:deps": "depcheck",
     "test": "ava --timeout=30s test/index.js",
-    "build": "node ./src/build-runtime.js"
+    "build": "node ./src/builder-runtime.js"
   },
   "author": "kumavis",
   "license": "MIT",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint src/**/*.js test/**/*.js --fix",
     "lint:deps": "depcheck",
     "test": "ava --timeout=30s test/index.js",
-    "build": "node ./src/builder-runtime.js"
+    "build": "node ./src/build-runtime.js"
   },
   "author": "kumavis",
   "license": "MIT",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint src/**/*.js test/**/*.js --fix",
     "lint:deps": "depcheck",
     "test": "ava --timeout=30s test/index.js",
-    "build": "node ./src/build-runtime.js build"
+    "build": "node ./src/build-runtime.js"
   },
   "author": "kumavis",
   "license": "MIT",

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -1,6 +1,28 @@
-const build = require('./builder-runtime')
+const { join: pathJoin } = require('path')
+const { promises: { readFile, writeFile } } = require('fs')
+const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
 
-build().catch(err => {
-  console.error(err)
-  process.exit(1)
-})
+module.exports = build
+
+async function build (opts = {}) {
+  const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
+  let output = runtimeTemplate
+  // inline kernel
+  const kernelCode = generateKernel()
+  output = stringReplace(output, '__createKernel__', kernelCode)
+  // inline reportStatsHook
+  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
+  output = stringReplace(output, '__reportStatsHook__', statsCode)
+  // inline scuttle config
+  if (opts.hasOwnProperty('scuttle')) {
+    const scuttleMode = JSON.stringify(opts.scuttle)
+    output = stringReplace(output, '__lavamoatScuttle__', scuttleMode)
+  }
+  await writeFile(pathJoin(__dirname, 'runtime.js'), output)
+}
+
+// String.prototype.replace has special behavior for some characters, so we use split join instead
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
+function stringReplace (src, target, replacement) {
+  return src.split(target).join(replacement)
+}

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -1,26 +1,6 @@
-const { join: pathJoin } = require('path')
-const { promises: { readFile, writeFile } } = require('fs')
-const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
+const build = require('./builder-runtime')
 
-start().catch(err => {
+build().catch(err => {
   console.error(err)
   process.exit(1)
 })
-
-async function start () {
-  const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
-  let output = runtimeTemplate
-  // inline kernel
-  const kernelCode = generateKernel()
-  output = stringReplace(output, '__createKernel__', kernelCode)
-  // inline reportStatsHook
-  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
-  output = stringReplace(output, '__reportStatsHook__', statsCode)
-  await writeFile(pathJoin(__dirname, 'runtime.js'), output)
-}
-
-// String.prototype.replace has special behavior for some characters, so we use split join instead
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
-function stringReplace (src, target, replacement) {
-  return src.split(target).join(replacement)
-}

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -4,7 +4,7 @@ const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
 
 module.exports = start
 
-start().catch(err => {
+process.argv[2] === 'build' && start().catch(err => {
   console.error(err)
   process.exit(1)
 })

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -1,5 +1,5 @@
 const { join: pathJoin } = require('path')
-const { readFileSync, writeFileSync } = require('fs')
+const fs = require('fs')
 const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
 
 module.exports = start
@@ -10,7 +10,7 @@ start().catch(err => {
 })
 
 async function start (opts = {}) {
-  const runtimeTemplate = readFileSync(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
+  const runtimeTemplate = await fs.promises.readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
   let output = runtimeTemplate
   // inline kernel
   const kernelCode = generateKernel(opts)
@@ -18,7 +18,7 @@ async function start (opts = {}) {
   // inline reportStatsHook
   const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
   output = stringReplace(output, '__reportStatsHook__', statsCode)
-  writeFileSync(pathJoin(__dirname, 'runtime.js'), output)
+  await fs.promises.writeFile(pathJoin(__dirname, 'runtime.js'), output)
 }
 
 // String.prototype.replace has special behavior for some characters, so we use split join instead

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -1,16 +1,16 @@
 const { join: pathJoin } = require('path')
-const { promises: { readFile, writeFile } } = require('fs')
+const { readFileSync, writeFileSync } = require('fs')
 const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
 
 module.exports = start
 
-process.argv[2] === 'build' && start().catch(err => {
+start().catch(err => {
   console.error(err)
   process.exit(1)
 })
 
 async function start (opts = {}) {
-  const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
+  const runtimeTemplate = readFileSync(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
   let output = runtimeTemplate
   // inline kernel
   const kernelCode = generateKernel(opts)
@@ -18,7 +18,7 @@ async function start (opts = {}) {
   // inline reportStatsHook
   const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
   output = stringReplace(output, '__reportStatsHook__', statsCode)
-  await writeFile(pathJoin(__dirname, 'runtime.js'), output)
+  writeFileSync(pathJoin(__dirname, 'runtime.js'), output)
 }
 
 // String.prototype.replace has special behavior for some characters, so we use split join instead

--- a/packages/lavapack/src/build-runtime.js
+++ b/packages/lavapack/src/build-runtime.js
@@ -1,28 +1,6 @@
-const { join: pathJoin } = require('path')
-const fs = require('fs')
-const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
-
-module.exports = start
+const start = require('./builder-runtime')
 
 start().catch(err => {
   console.error(err)
   process.exit(1)
 })
-
-async function start (opts = {}) {
-  const runtimeTemplate = await fs.promises.readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
-  let output = runtimeTemplate
-  // inline kernel
-  const kernelCode = generateKernel(opts)
-  output = stringReplace(output, '__createKernel__', kernelCode)
-  // inline reportStatsHook
-  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
-  output = stringReplace(output, '__reportStatsHook__', statsCode)
-  await fs.promises.writeFile(pathJoin(__dirname, 'runtime.js'), output)
-}
-
-// String.prototype.replace has special behavior for some characters, so we use split join instead
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
-function stringReplace (src, target, replacement) {
-  return src.split(target).join(replacement)
-}

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -1,0 +1,28 @@
+const { join: pathJoin } = require('path')
+const { promises: { readFile, writeFile } } = require('fs')
+const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
+
+module.exports = build
+
+async function build (opts = {}) {
+  const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
+  let output = runtimeTemplate
+  // inline kernel
+  const kernelCode = generateKernel()
+  output = stringReplace(output, '__createKernel__', kernelCode)
+  // inline reportStatsHook
+  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
+  output = stringReplace(output, '__reportStatsHook__', statsCode)
+  // inline scuttle config
+  if (opts.hasOwnProperty('scuttle')) {
+    const scuttleMode = JSON.stringify(opts.scuttle)
+    output = stringReplace(output, '__lavamoatScuttle__', scuttleMode)
+  }
+  await writeFile(pathJoin(__dirname, 'runtime.js'), output)
+}
+
+// String.prototype.replace has special behavior for some characters, so we use split join instead
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
+function stringReplace (src, target, replacement) {
+  return src.split(target).join(replacement)
+}

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -1,28 +1,6 @@
-const { join: pathJoin } = require('path')
-const { promises: { readFile, writeFile } } = require('fs')
-const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
+const build = require('./build-runtime')
 
-module.exports = build
-
-async function build (opts = {}) {
-  const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
-  let output = runtimeTemplate
-  // inline kernel
-  const kernelCode = generateKernel()
-  output = stringReplace(output, '__createKernel__', kernelCode)
-  // inline reportStatsHook
-  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
-  output = stringReplace(output, '__reportStatsHook__', statsCode)
-  // inline scuttle config
-  if (opts.hasOwnProperty('scuttle')) {
-    const scuttleMode = JSON.stringify(opts.scuttle)
-    output = stringReplace(output, '__lavamoatScuttle__', scuttleMode)
-  }
-  await writeFile(pathJoin(__dirname, 'runtime.js'), output)
-}
-
-// String.prototype.replace has special behavior for some characters, so we use split join instead
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
-function stringReplace (src, target, replacement) {
-  return src.split(target).join(replacement)
-}
+build().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -1,0 +1,23 @@
+const { join: pathJoin } = require('path')
+const fs = require('fs')
+const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
+
+module.exports = start
+
+async function start (opts = {}) {
+  const runtimeTemplate = await fs.promises.readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
+  let output = runtimeTemplate
+  // inline kernel
+  const kernelCode = generateKernel(opts)
+  output = stringReplace(output, '__createKernel__', kernelCode)
+  // inline reportStatsHook
+  const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
+  output = stringReplace(output, '__reportStatsHook__', statsCode)
+  await fs.promises.writeFile(pathJoin(__dirname, 'runtime.js'), output)
+}
+
+// String.prototype.replace has special behavior for some characters, so we use split join instead
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
+function stringReplace (src, target, replacement) {
+  return src.split(target).join(replacement)
+}

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -1,6 +1,0 @@
-const build = require('./build-runtime')
-
-build().catch(err => {
-  console.error(err)
-  process.exit(1)
-})

--- a/packages/lavapack/src/index.js
+++ b/packages/lavapack/src/index.js
@@ -1,3 +1,3 @@
 module.exports = require('./pack.js')
 module.exports.makePolicyLoaderStream = require('./makePolicyLoaderStream.js')
-module.exports.buildRuntime = require('./builder-runtime.js')
+module.exports.buildRuntime = require('./build-runtime.js')

--- a/packages/lavapack/src/index.js
+++ b/packages/lavapack/src/index.js
@@ -1,3 +1,3 @@
 module.exports = require('./pack.js')
 module.exports.makePolicyLoaderStream = require('./makePolicyLoaderStream.js')
-module.exports.buildRuntime = require('./build-runtime.js')
+module.exports.buildRuntime = require('./builder-runtime.js')

--- a/packages/lavapack/src/index.js
+++ b/packages/lavapack/src/index.js
@@ -1,2 +1,3 @@
 module.exports = require('./pack.js')
 module.exports.makePolicyLoaderStream = require('./makePolicyLoaderStream.js')
+module.exports.buildRuntime = require('./builder-runtime.js')


### PR DESCRIPTION
This PR is an extension to #360 PR to properly support MetaMask.

Apparently in MetaMask we don't use the proper `@lavamoat/lavapack/createPacker()` but instead we use `@lavamoat/lavapack/makePolicyLoaderStream()` to create the `LavaPack.loadPolicy()` part (instead of `LavaPack.loadBundle()`), and we copy the `runtime.js` file as-is from the `lavapack` package directory instead of building it.

PR #360 counts on the `runtime.js` going through the build process in order to inline the new scuttling config, therefore a new export introduced `@lavamoat/lavapack/buildRuntime()` which makes sure to rebuild `runtime.js` and config the scuttling mode before statically using it.

Effectively, this is a very small PR, we just separate the original `build-runtime.js` file into 2 files so that one could be called using NodeJS and the other could be called via CLI as before.

Also, the version consumable by NodeJS can now be instructed to configure the scuttling mode when building the runtime file (which is exactly what MetaMask needs) 