### PR TITLE
Fix for PR #382 [scuttling]

### DIFF
--- a/packages/browserify/examples/01-simple-js/build.js
+++ b/packages/browserify/examples/01-simple-js/build.js
@@ -4,6 +4,8 @@ const browserify = require('browserify')
 // configure LavaMoat
 const lavamoatOpts = {
   writeAutoPolicy: false,
+  scuttleGlobalThis: true,
+  scuttleGlobalThisExceptions: ['print'],
 }
 
 // enable policy autogen if specified

--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -122,7 +122,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
 
   const nonAliasedOptions = [
     'scuttleGlobalThis',
-    'scuttleGlobalExceptions',
+    'scuttleGlobalThisExceptions',
     'bundleWithPrecompiledModules',
   ]
 

--- a/packages/browserify/test/runScenarios.js
+++ b/packages/browserify/test/runScenarios.js
@@ -6,7 +6,9 @@ const { runAndTestScenario } = require('lavamoat-core/test/util')
 test('Run scenarios with precompiled modules', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Browserify Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario }))
+    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
+    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
   }
 })
 
@@ -17,10 +19,3 @@ test('Run scenarios with precompiled modules', async (t) => {
 //     await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, bundleWithPrecompiledModules: false }))
 //   }
 // })
-
-test('Run scenarios with scuttleGlobalThis', async (t) => {
-  for await (const scenario of loadScenarios()) {
-    console.log(`Running Browserify Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, scuttleGlobalThis: true }))
-  }
-})

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -13,7 +13,12 @@ const { spawnSync } = require('child_process')
 const execFile = util.promisify(require('child_process').execFile)
 const limitConcurrency = require('throat')(1)
 
-
+const localLavaMoatDeps = {
+  lavapack: { src: 'lavapack/', dst: `@lavamoat/lavapack/` },
+  browserify: { src: 'browserify/', dst: `lavamoat-browserify/` },
+  node: { src: 'node/', dst: `lavamoat/` },
+  core: { src: 'core/', dst: `lavamoat-core/` },
+}
 
 module.exports = {
   createBundleFromEntry,
@@ -26,6 +31,33 @@ module.exports = {
   bundleAsync,
   prepareBrowserifyScenarioOnDisk,
   createBrowserifyScenarioFromScaffold
+}
+
+async function copyFolder(from, to, opts = {skip: []}) {
+  await fs.mkdir(to)
+  const elements = await fs.readdir(from)
+  for (const element of elements) {
+    if (opts.skip.includes(element)) {
+      continue
+    }
+    const f = path.join(from, element), t = path.join(to, element)
+    const stat = await fs.lstat(f)
+    if (stat.isFile()) {
+      await fs.copyFile(f, t)
+    } else {
+      await copyFolder(f, t, opts)
+    }
+  }
+}
+
+async function overrideDepsWithLocalPackages(projectDir) {
+  for (const name in localLavaMoatDeps) {
+    const dep = localLavaMoatDeps[name]
+    const src = path.resolve(__dirname, '..', '..', dep.src)
+    const dst = path.join(projectDir, 'node_modules', dep.dst)
+    await fs.rm(dst, { recursive: true, force: true })
+    await copyFolder(src, dst, {skip: ['node_modules']})
+  }
 }
 
 async function createBundleFromEntry (path, pluginOpts = {}) {
@@ -117,14 +149,12 @@ async function prepareBrowserifyScenarioOnDisk ({ scenario }) {
   console.warn(`created test project directory at "${projectDir}"`)
   // install browserify + lavamoat-plugin
   // path to project root for the browserify plugin
-  const pluginPath = path.resolve(__dirname, '..')
-  let depsToInstall = ['browserify@^17', pluginPath]
+  const depsToInstall = ['browserify@^17', path.resolve(__dirname, '..')]
   let runBrowserifyPath = `${__dirname}/fixtures/runBrowserify.js`
   if (scenario.type === 'factor') {
     depsToInstall.push(
       'through2@^3',
       'vinyl-buffer@^1',
-      path.resolve(__dirname, '..', '..', 'lavapack'),
       'bify-package-factor@^1',
     )
     runBrowserifyPath = `${__dirname}/fixtures/runBrowserifyBundleFactor.js`
@@ -133,6 +163,7 @@ async function prepareBrowserifyScenarioOnDisk ({ scenario }) {
   const installDevDepsResult = await limitConcurrency(async function () {
     return spawnSync('yarn', ['add','--network-concurrency 1', '-D', ...depsToInstall], { cwd: projectDir })
   })
+  await overrideDepsWithLocalPackages(projectDir)
   if (installDevDepsResult.status !== 0) {
     const msg = `Error while installing browserify:\n${installDevDepsResult.stderr.toString()}`
     throw new Error(msg)
@@ -163,7 +194,7 @@ async function createBundleForScenario ({
   } else {
     policy = path.join(scenario.dir, `/lavamoat/browserify/`)
   }
-  
+
   const { output: { stdout: bundle, stderr } } = await runBrowserify({ scenario, bundleWithPrecompiledModules, ...additonalOpts })
   if (stderr.length) {
     console.warn(stderr)

--- a/packages/core/lib/lockdown.umd.js
+++ b/packages/core/lib/lockdown.umd.js
@@ -9886,8 +9886,8 @@ markVirtualizedNativeFunction)
         // that we are removing it so we know to look into it, as happens when
         // the language evolves new features to existing intrinsics.
         if (subPermit !== false) {
-          // This call to `console.warn` is intentional. It is not a vestige of
-          // a debugging attempt. See the comment at top of file for an
+          // This call to `console.log` is intentional. It is not a vestige
+          // of a debugging attempt. See the comment at top of file for an
           // explanation.
           // eslint-disable-next-line @endo/no-polymorphic-call
           console.log(`Removing ${subPath}`);

--- a/packages/core/lib/lockdown.umd.js
+++ b/packages/core/lib/lockdown.umd.js
@@ -9886,16 +9886,26 @@ markVirtualizedNativeFunction)
         // that we are removing it so we know to look into it, as happens when
         // the language evolves new features to existing intrinsics.
         if (subPermit !== false) {
-          // This call to `console.log` is intentional. It is not a vestige
-          // of a debugging attempt. See the comment at top of file for an
+          // This call to `console.warn` is intentional. It is not a vestige of
+          // a debugging attempt. See the comment at top of file for an
           // explanation.
           // eslint-disable-next-line @endo/no-polymorphic-call
-          console.log(`Removing ${subPath}`);
+          console.warn(`Removing ${subPath}`);
         }
         try {
           delete obj[prop];
         } catch (err) {
           if (prop in obj) {
+            if (typeof obj === 'function' && (prop === 'prototype')) {
+              // debugger;
+              obj.prototype = undefined;
+              if (obj.prototype === undefined) {
+                // eslint-disable-next-line @endo/no-polymorphic-call
+                console.warn(`Tolerating undeletable ${subPath} === undefined`);
+                // eslint-disable-next-line no-continue
+                continue;
+              }
+            }
             // eslint-disable-next-line @endo/no-polymorphic-call
             console.error(`failed to delete ${subPath}`, err);
           } else {

--- a/packages/core/lib/lockdown.umd.js
+++ b/packages/core/lib/lockdown.umd.js
@@ -9890,18 +9890,17 @@ markVirtualizedNativeFunction)
           // a debugging attempt. See the comment at top of file for an
           // explanation.
           // eslint-disable-next-line @endo/no-polymorphic-call
-          console.warn(`Removing ${subPath}`);
+          console.log(`Removing ${subPath}`);
         }
         try {
           delete obj[prop];
         } catch (err) {
           if (prop in obj) {
-            if (typeof obj === 'function' && (prop === 'prototype')) {
-              // debugger;
+            if (typeof obj === 'function' && prop === 'prototype') {
               obj.prototype = undefined;
               if (obj.prototype === undefined) {
                 // eslint-disable-next-line @endo/no-polymorphic-call
-                console.warn(`Tolerating undeletable ${subPath} === undefined`);
+                console.log(`Tolerating undeletable ${subPath} === undefined`);
                 // eslint-disable-next-line no-continue
                 continue;
               }

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -24,21 +24,22 @@ function getSesShimSrc () {
 }
 
 // takes the kernelTemplate and populates it with the libraries
-function generateKernel ({
-  scuttleGlobalThis = false,
-  scuttleGlobalThisExceptions = [],
-  debugMode = false,
-} = {}) {
+function generateKernel (opts = {}) {
   const kernelCode = generateKernelCore()
 
   let output = kernelTemplate
   output = replaceTemplateRequire(output, 'ses', sesSrc)
   output = stringReplace(output, '__createKernelCore__', kernelCode)
-  output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
-    scuttleGlobalThis,
-    scuttleGlobalThisExceptions,
-    debugMode,
-  }))
+  output = stringReplace(output, '__lavamoatDebugOptions__', JSON.stringify({debugMode: !!opts.debugMode}))
+  if (opts.hasOwnProperty('scuttleGlobalThis')) {
+    // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
+    // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
+    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
+    output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
+      scuttleGlobalThis,
+      scuttleGlobalThisExceptions,
+    }))
+  }
 
   return output
 }

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -105,7 +105,7 @@
           props.push(...Object.getOwnPropertyNames(proto)))
 
       // support LM,SES exported APIs and polyfills
-      const avoidForLavaMoatCompatibility = ['LavaPack', 'Compartment', 'Error', 'globalThis']
+      const avoidForLavaMoatCompatibility = ['Compartment', 'Error', 'globalThis']
       const propsToAvoid = new Set([...avoidForLavaMoatCompatibility, ...extraPropsToAvoid])
 
       for (const prop of props) {

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -99,10 +99,8 @@
     return kernel
 
     function performScuttleGlobalThis (globalRef, extraPropsToAvoid = new Array()) {
-      const props = new Set(
-        getPrototypeChain(globalRef)
-        .map(obj => Object.getOwnPropertyNames(obj))
-      )
+      const props = []
+      getPrototypeChain(globalRef).forEach(proto => props.push(...Object.getOwnPropertyNames(proto)))
 
       // support LM,SES exported APIs and polyfills
       const avoidForLavaMoatCompatibility = ['LavaPack', 'Compartment', 'Error', 'globalThis']

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -99,8 +99,10 @@
     return kernel
 
     function performScuttleGlobalThis (globalRef, extraPropsToAvoid = new Array()) {
-      const props = []
-      getPrototypeChain(globalRef).forEach(proto => props.push(...Object.getOwnPropertyNames(proto)))
+      const props = new Array()
+      getPrototypeChain(globalRef)
+        .forEach(proto =>
+          props.push(...Object.getOwnPropertyNames(proto)))
 
       // support LM,SES exported APIs and polyfills
       const avoidForLavaMoatCompatibility = ['LavaPack', 'Compartment', 'Error', 'globalThis']
@@ -113,7 +115,6 @@
         if (Object.getOwnPropertyDescriptor(globalRef, prop)?.configurable === false) {
           continue
         }
-        // these props can't have getters, use undefined value instead
         const desc = {
           set: () => {
             console.warn(

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -12,11 +12,14 @@
     runWithPrecompiledModules,
     reportStatsHook,
   }) {
+    // debug options are hard-coded at build time
+    const {
+      debugMode
+    } = __lavamoatDebugOptions__
     // security options are hard-coded at build time
     const {
       scuttleGlobalThis,
       scuttleGlobalThisExceptions,
-      debugMode,
     } = __lavamoatSecurityOptions__
 
     // identify the globalRef

--- a/packages/core/test/runScenarios.js
+++ b/packages/core/test/runScenarios.js
@@ -5,20 +5,17 @@ const { runScenario, runAndTestScenario } = require('./util')
 test('Run scenarios', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Core Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, runScenario)
+    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
+    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
   }
 })
 
 test('Run scenarios with precompiled intializer', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Core Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, runWithPrecompiledModules: true }))
-  }
-})
-
-test('Run scenarios with scuttleGlobalThis', async (t) => {
-  for await (const scenario of loadScenarios()) {
-    console.log(`Running Core Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, scuttleGlobalThis: true }))
+    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
+    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions, runWithPrecompiledModules: true}
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
   }
 })

--- a/packages/core/test/scenarios/index.js
+++ b/packages/core/test/scenarios/index.js
@@ -8,9 +8,11 @@ const globalWrites = require('./globalWrites')
 const moduleExports = require('./moduleExports')
 const transforms = require('./transforms')
 const globalRef = require('./globalRef')
+const scuttle = require('./scuttle')
 
 module.exports = { loadScenarios }
 const scenarios = [
+  ...scuttle,
   ...autogen,
   ...security,
   ...basic,

--- a/packages/core/test/scenarios/index.js
+++ b/packages/core/test/scenarios/index.js
@@ -12,7 +12,6 @@ const scuttle = require('./scuttle')
 
 module.exports = { loadScenarios }
 const scenarios = [
-  ...scuttle,
   ...autogen,
   ...security,
   ...basic,
@@ -25,8 +24,12 @@ const scenarios = [
   ...globalRef,
 ]
 
-async function * loadScenarios () {
-  for (const scenarioCreator of scenarios) {
+async function * loadScenarios (loadScuttleScenarios = false) {
+  const scenarioCreators = [...scenarios, ...(loadScuttleScenarios ? scuttle : [])]
+  for (const scenarioCreator of scenarioCreators) {
+    yield await scenarioCreator()
+  }
+  for (const scenarioCreator of scuttle) {
     yield await scenarioCreator()
   }
 }

--- a/packages/core/test/scenarios/index.js
+++ b/packages/core/test/scenarios/index.js
@@ -22,11 +22,11 @@ const scenarios = [
   ...moduleExports,
   ...transforms,
   ...globalRef,
+  ...scuttle,
 ]
 
-async function * loadScenarios (loadScuttleScenarios = false) {
-  const scenarioCreators = [...scenarios, ...(loadScuttleScenarios ? scuttle : [])]
-  for (const scenarioCreator of scenarioCreators) {
+async function * loadScenarios () {
+  for (const scenarioCreator of scenarios) {
     yield await scenarioCreator()
   }
 }

--- a/packages/core/test/scenarios/index.js
+++ b/packages/core/test/scenarios/index.js
@@ -29,7 +29,4 @@ async function * loadScenarios (loadScuttleScenarios = false) {
   for (const scenarioCreator of scenarioCreators) {
     yield await scenarioCreator()
   }
-  for (const scenarioCreator of scuttle) {
-    yield await scenarioCreator()
-  }
 }

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -1,31 +1,35 @@
 const { createScenarioFromScaffold, autoConfigForScenario } = require('../util.js')
 
+const one = () => {
+  let globalObject = globalThis
+  if (globalThis.getTrueGlobalThisForTestsOnly) {
+    globalObject = globalThis.getTrueGlobalThisForTestsOnly()
+  }
+  module.exports = globalObject.Math.SQRT2
+}
+
 module.exports = [
   async () => {
     const scenario = createScenarioFromScaffold({
-      name: 'scuttle - host env global object is too scuttled to work',
-      defineOne: () => {
-        module.exports = 1
-      },
+      name: 'scuttle - host env global object is scuttled to work',
+      defineOne: one,
+      expectedResult: Math.SQRT2,
       scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', /*'console', 'Array', 'RegExp', 'Date'*/],
-      expectedFailure: true,
-      expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z]*" of globalThis is inaccessible under scuttling mode/,
+      scuttleGlobalThisExceptions: ['process', 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
     })
     await autoConfigForScenario({ scenario })
     return scenario
   },
   async () => {
     const scenario = createScenarioFromScaffold({
-      name: 'scuttle - host env global object is scuttled to work',
-      defineOne: () => {
-        module.exports = 1
-      },
-      expectedResult: 1,
+      name: 'scuttle - host env global object is too scuttled to work',
+      defineOne: one,
       scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', 'console', 'Array', 'RegExp', 'Date'],
+      scuttleGlobalThisExceptions: ['process', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
+      expectedFailure: true,
+      expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z]*" of globalThis is inaccessible under scuttling mode/,
     })
     await autoConfigForScenario({ scenario })
     return scenario
-  }
+  },
 ]

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -1,0 +1,31 @@
+const { createScenarioFromScaffold, autoConfigForScenario } = require('../util.js')
+
+module.exports = [
+  async () => {
+    const scenario = createScenarioFromScaffold({
+      name: 'scuttle - host env global object is too scuttled to work',
+      defineOne: () => {
+        module.exports = 1
+      },
+      scuttleGlobalThis: true,
+      scuttleGlobalThisExceptions: ['process', /*'console', 'Array', 'RegExp', 'Date'*/],
+      expectedFailure: true,
+      expectedFailureMessageRegex: /Error: LavaMoat - property "console" of globalThis is inaccessible under scuttling mode/,
+    })
+    await autoConfigForScenario({ scenario })
+    return scenario
+  },
+  async () => {
+    const scenario = createScenarioFromScaffold({
+      name: 'scuttle - host env global object is scuttled to work',
+      defineOne: () => {
+        module.exports = 1
+      },
+      expectedResult: 1,
+      scuttleGlobalThis: true,
+      scuttleGlobalThisExceptions: ['process', 'console', 'Array', 'RegExp', 'Date'],
+    })
+    await autoConfigForScenario({ scenario })
+    return scenario
+  }
+]

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -10,7 +10,7 @@ module.exports = [
       scuttleGlobalThis: true,
       scuttleGlobalThisExceptions: ['process', /*'console', 'Array', 'RegExp', 'Date'*/],
       expectedFailure: true,
-      expectedFailureMessageRegex: /Error: LavaMoat - property "console" of globalThis is inaccessible under scuttling mode/,
+      expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z]*" of globalThis is inaccessible under scuttling mode/,
     })
     await autoConfigForScenario({ scenario })
     return scenario

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -403,6 +403,11 @@ function evaluateWithSourceUrl (filename, content, context) {
   if (!vmGlobalThis.globalThis) {
     vmGlobalThis.globalThis = vmGlobalThis
   }
+  // Since the browserify test uses this vm util as a browser env simulation,
+  // creating actual dom nodes that can leak the real global object is not possible,
+  // therefore there is no way to access the real global object otherwise, but since we
+  // have to (for the scuttling tests) - we intentionally export this util func to solve this:
+  vmGlobalThis.getTrueGlobalThisForTestsOnly = () => vmGlobalThis
   // perform eval
   let result
   try {

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -56,6 +56,7 @@ function createScenarioFromScaffold ({
   checkError = async (t, err, scenario) => {
     if (scenario.expectedFailure) {
       t.truthy(err, `Scenario fails as expected: ${scenario.name} - ${err}`)
+      t.regex(err.message, scenario.expectedFailureMessageRegex, 'Error message expects to match regex')
     } else {
       if (err) {
         t.fail(`Unexpected error in scenario: ${scenario.name} - ${err}`)
@@ -73,6 +74,9 @@ function createScenarioFromScaffold ({
     }
   },
   expectedFailure = false,
+  expectedFailureMessageRegex = /[\s\S]*/,
+  scuttleGlobalThis = false,
+  scuttleGlobalThisExceptions = [],
   files = [],
   builtin = {},
   context = {},
@@ -218,6 +222,9 @@ function createScenarioFromScaffold ({
     builtin,
     expectedResult,
     expectedFailure,
+    expectedFailureMessageRegex,
+    scuttleGlobalThis,
+    scuttleGlobalThisExceptions,
     entries: ['entry.js'],
     files: _files,
     config: _config,

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -54,6 +54,8 @@ function createPacker({
   sourceRoot,
   sourceMapPrefix,
   bundleWithPrecompiledModules = true,
+  scuttleGlobalThis = false,
+  scuttleGlobalThisExceptions = [],
 } = {}) {
   // stream/parser wrapping incase raw: false
   const parser = raw ? through.obj() : JSONStream.parse([true])
@@ -76,6 +78,11 @@ function createPacker({
     assert(prelude, 'LavaMoat CustomPack: must specify a prelude if "includePrelude" is true (default: true)')
   }
   assert(policy, 'must specify a policy')
+
+  prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({
+    scuttleGlobalThis,
+    scuttleGlobalThisExceptions,
+  }))
 
   // note: pack stream cant started emitting data until its received its first module
   // this is because the browserify pipeline is leaky until its finished being setup

--- a/packages/lavapack/src/runtime-cjs.js
+++ b/packages/lavapack/src/runtime-cjs.js
@@ -13,7 +13,7 @@
     runModule: Object.freeze(runModule),
   })
 
-  globalThis.LavaPack = LavaPack
+  Object.defineProperty(globalThis, 'LavaPack', {value: LavaPack})
 
   function loadPolicy () {
     throw new Error('runtime-cjs: unable to enforce policy')

--- a/packages/lavapack/src/runtime-template.js
+++ b/packages/lavapack/src/runtime-template.js
@@ -34,17 +34,17 @@
   const { internalRequire } = kernel
 
   // create a lavamoat pulic API for loading modules over multiple files
-  const LavaPack = {
+  const LavaPack = Object.freeze({
     loadPolicy: Object.freeze(loadPolicy),
     loadBundle: Object.freeze(loadBundle),
     runModule: Object.freeze(runModule),
-  }
+  })
   // in debug mode, expose the kernel on the LavaPack API
   if (debugMode) {
     LavaPack._kernel = kernel
   }
 
-  globalThis.LavaPack = Object.freeze(LavaPack)
+  Object.defineProperty(globalThis, 'LavaPack', {value: LavaPack})
   return
 
 

--- a/packages/node/src/defaults.js
+++ b/packages/node/src/defaults.js
@@ -3,6 +3,8 @@ const { getDefaultPaths } = require("lavamoat-core");
 const defaultPaths = getDefaultPaths("node");
 
 module.exports = {
+  scuttleGlobalThis: false,
+  scuttleGlobalThisExceptions: [],
   writeAutoPolicy: false,
   writeAutoPolicyDebug: false,
   writeAutoPolicyAndRun: false,

--- a/packages/node/src/yargsFlags.js
+++ b/packages/node/src/yargsFlags.js
@@ -64,14 +64,14 @@ module.exports = (yargs, defaults) => {
   // scuttle global this
   yargs.option('scuttleGlobalThis', {
     alias: ['scuttleGlobalThis'],
-    describe: 'scuttle global this',
+    describe: 'whether to scuttle global this or not',
     type: 'boolean',
     default: defaults.scuttleGlobalThis
   })
   // scuttle global this exceptions array
   yargs.option('scuttleGlobalThisExceptions', {
     alias: ['scuttleGlobalThisExceptions'],
-    describe: 'scuttle global this exceptions array',
+    describe: 'scuttle global this except for the properties provided in this array',
     type: 'array',
     default: defaults.scuttleGlobalThisExceptions
   })

--- a/packages/node/src/yargsFlags.js
+++ b/packages/node/src/yargsFlags.js
@@ -61,4 +61,18 @@ module.exports = (yargs, defaults) => {
     type: 'boolean',
     default: defaults.statsMode
   })
+  // scuttle global this
+  yargs.option('scuttleGlobalThis', {
+    alias: ['scuttleGlobalThis'],
+    describe: 'scuttle global this',
+    type: 'boolean',
+    default: defaults.scuttleGlobalThis
+  })
+  // scuttle global this exceptions array
+  yargs.option('scuttleGlobalThisExceptions', {
+    alias: ['scuttleGlobalThisExceptions'],
+    describe: 'scuttle global this exceptions array',
+    type: 'array',
+    default: defaults.scuttleGlobalThisExceptions
+  })
 }

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -15,7 +15,8 @@ test('Run scenarios with scuttleGlobalThis enabled', async (t) => {
   for await (const scenario of loadScenarios()) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
-    const additionalOpts = { scuttleGlobalThis: true, scuttleGlobalThisExceptions: ['console', 'Array', 'RegExp', 'process', 'Date'] }
+    const scuttleGlobalThisExceptions = ['console', 'Array', 'RegExp', 'process', 'Date']
+    const additionalOpts = { scuttleGlobalThis: true, scuttleGlobalThisExceptions}
     await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, additionalOpts }))
   }
 })

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -4,7 +4,7 @@ const { loadScenarios } = require('lavamoat-core/test/scenarios/index')
 const { runAndTestScenario } = require('lavamoat-core/test/util')
 
 test('Run scenarios', async (t) => {
-  for await (const scenario of loadScenarios(true)) {
+  for await (const scenario of loadScenarios()) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
     const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -15,6 +15,7 @@ test('Run scenarios with scuttleGlobalThis enabled', async (t) => {
   for await (const scenario of loadScenarios()) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, additionalOpts: { scuttleGlobalThis: true } }))
+    const additionalOpts = { scuttleGlobalThis: true, scuttleGlobalThisExceptions: ['console', 'Array', 'RegExp', 'process', 'Date'] }
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, additionalOpts }))
   }
 })

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -7,16 +7,8 @@ test('Run scenarios', async (t) => {
   for await (const scenario of loadScenarios()) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, runScenario)
-  }
-})
-
-test('Run scenarios with scuttleGlobalThis enabled', async (t) => {
-  for await (const scenario of loadScenarios()) {
-    if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
-    console.log(`Running Node Scenario: ${scenario.name}`)
-    const scuttleGlobalThisExceptions = ['console', 'Array', 'RegExp', 'process', 'Date']
-    const additionalOpts = { scuttleGlobalThis: true, scuttleGlobalThisExceptions}
+    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
+    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
     await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, additionalOpts }))
   }
 })

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -4,7 +4,7 @@ const { loadScenarios } = require('lavamoat-core/test/scenarios/index')
 const { runAndTestScenario } = require('lavamoat-core/test/util')
 
 test('Run scenarios', async (t) => {
-  for await (const scenario of loadScenarios()) {
+  for await (const scenario of loadScenarios(true)) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
     const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario

--- a/packages/node/test/util.js
+++ b/packages/node/test/util.js
@@ -6,9 +6,9 @@ module.exports = {
   runScenario
 }
 
-function set(args, key, value) {
+function setOptToArgs(args, key, value) {
   if (Array.isArray(value)) {
-    value.forEach(v => set(args, key, v))
+    value.forEach(v => setOptToArgs(args, key, v))
     return
   }
   if (value === true) {
@@ -27,7 +27,7 @@ function convertOptsToArgs ({ scenario, additionalOpts = {} }) {
   const args = [firstEntry]
   Object
     .entries({ ...opts, ...additionalOpts })
-    .forEach(([key, value]) => set(args, key, value))
+    .forEach(([key, value]) => setOptToArgs(args, key, value))
   return args
 }
 

--- a/packages/node/test/util.js
+++ b/packages/node/test/util.js
@@ -6,20 +6,28 @@ module.exports = {
   runScenario
 }
 
+function set(args, key, value) {
+  if (Array.isArray(value)) {
+    value.forEach(v => set(args, key, v))
+    return
+  }
+  if (value === true) {
+    args.push(`--${key}`)
+  } else if (typeof value === 'string') {
+    args.push(`--${key}='${value}'`)
+  } else {
+    args.push(`--${key}=${value}`)
+  }
+}
+
 function convertOptsToArgs ({ scenario, additionalOpts = {} }) {
   const { entries, opts } = scenario
   if (entries.length !== 1) throw new Error('LavaMoat - invalid entries')
   const firstEntry = entries[0]
   const args = [firstEntry]
-  Object.entries({ ...opts, ...additionalOpts }).forEach(([key, value]) => {
-    if (value === true) {
-      args.push(`--${key}`)
-    } else if (typeof value === 'string') {
-      args.push(`--${key}='${value}'`)
-    } else {
-      args.push(`--${key}=${value}`)
-    }
-  })
+  Object
+    .entries({ ...opts, ...additionalOpts })
+    .forEach(([key, value]) => set(args, key, value))
   return args
 }
 

--- a/packages/node/test/util.js
+++ b/packages/node/test/util.js
@@ -40,8 +40,11 @@ async function runLavamoat ({ args = [], cwd = process.cwd() } = {}) {
 async function runScenario ({ scenario, additionalOpts }) {
   const { projectDir } = await prepareScenarioOnDisk({ scenario, policyName: 'node' })
   const args = convertOptsToArgs({ scenario, additionalOpts })
-  const { output: { stdout } } = await runLavamoat({ args, cwd: projectDir })
+  const { output: { stdout, stderr } } = await runLavamoat({ args, cwd: projectDir })
   let result
+  if (stderr) {
+    throw new Error(`Unexpected output in standard err: \n${stderr}`)
+  }
   try {
     result = JSON.parse(stdout)
   } catch (e) {


### PR DESCRIPTION
### 1) Fix the bug

PR #382 code modifications introduce a bug where the array of props to scuttle is no longer an array of props but an array of arrays of props:

```javascript
props = [a,b,c, d,e,f] // beofer bug introduced
props = [[a,b,c], [d,e,f]] // after bug introduced
```

This canceled scuttling completely, because instead of attempting to redefine a certain property `my_prop`:

```javascript
Object.defineProperty(window, 'my_prop', {})
```

We ended up with:

```javascript
Object.defineProperty(window, ['my_prop'], {})
```

commit introducing the bug [reference](https://github.com/LavaMoat/LavaMoat/pull/382/commits/63a6f8137ac2fc208df844af5a297e5dc3c71e57#diff-cbec1016c903fe52b8d76860ebf3400e172b83a3374b8796bab149b3721d8064R94)

### 2) Improve and fix tests to work with scuttling feature for packages `browserify,core,node`

Tests infra was not compatible to work in scuttling mode, and the browserify infra required further adjustments to serve us in the future more simply:

1. rewrite the scuttling tests to actually do their job
2. change `runScenarios` calls so that each scenario will determine for itself whether to apply scuttling mode or not (instead of current situation where scuttling can be turned on/off only for all scenarios)
3. fix browserify testing infra so that it'll rely on the local versions of `core`/`node`/`lavapack`/`browserify` deps rather than the ones from npm (made it very hard to test modifications to both `browserify` package and another package in a single pr)
4. extend testing infra to not only allow expected failure, but also test the failure exception to include a certain rgx
5. fix testing infra to allow passing array arguments via cli (so we can pass `scuttleGlobalThisExceptions` arg)
6. extend testing infra vm globalThis to allow access to real global object in tests exclusively ([here's why](https://github.com/LavaMoat/LavaMoat/pull/391/files#diff-730037796ec5377c28c7487e8f7c34824838e927f41783e097c337362f15f342R406))
7. split back `__lavamoatDebugOptions__` and `__lavamoatSecurityOptions__` and only replace the `__lavamoatSecurityOptions__` placeholder if was explicitly required (this is because both `lavapack` and `core` can set `__lavamoatSecurityOptions__`, but since one uses the other potentially, then one must sometimes skip the replacement in order to allow the other to successfully set it)
8. remove `LavaPack` from the `avoidForLavaMoatCompatibility`, and freeze it instead to @kumavis's request