### PR TITLE
Bump minimum nodejs version to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tap-spec": "^5.0.0"
   },
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "test": "lerna run --concurrency 1 test",

--- a/packages/aa/package.json
+++ b/packages/aa/package.json
@@ -27,5 +27,8 @@
   "directories": {
     "test": "test"
   },
-  "author": "kumavis"
+  "author": "kumavis",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -37,5 +37,8 @@
     "lint:deps": "depcheck"
   },
   "author": "",
-  "homepage": "https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts"
+  "homepage": "https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">10.15.1"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "@babel/code-frame": "^7.16.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "engines": {
-    "node": ">10.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "fromentries": "^1.2.0",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -7,7 +7,7 @@
   },
   "main": "src/index.js",
   "engines": {
-    "node": ">10.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "JSONStream": "^1.3.5",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -44,5 +44,8 @@
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",
-  "description": ""
+  "description": "",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/LavaMoat/LavaMoat.git",
-    "directory":"packages/perf"
+    "directory": "packages/perf"
   },
   "dependencies": {
     "browserify": "^16.5.0",
@@ -25,5 +25,8 @@
   "devDependencies": {
     "serve": "^11.2.0"
   },
-  "gitHead": "b5908eb5b2eda4a49fb7abd4d1b6e69fb9a98d0a"
+  "gitHead": "b5908eb5b2eda4a49fb7abd4d1b6e69fb9a98d0a",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -10,12 +10,15 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/LavaMoat/LavaMoat.git",
-    "directory":"packages/preinstall-always-fail"
+    "directory": "packages/preinstall-always-fail"
   },
   "publishConfig": {
     "access": "public"
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/survey/package.json
+++ b/packages/survey/package.json
@@ -16,5 +16,8 @@
     "postinstall": "node src/prepareHook.js",
     "zzz": "node zzz.js"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },
-  "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/tofu/README.md"
+  "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/tofu/README.md",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -75,5 +75,8 @@
   "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/viz/README.md",
   "bin": {
     "lavamoat-viz": "./bin/index.js"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }

--- a/packages/yarn-plugin-allow-scripts/package.json
+++ b/packages/yarn-plugin-allow-scripts/package.json
@@ -21,5 +21,8 @@
   "scripts": {
     "build": "builder build plugin"
   },
-  "packageManager": "yarn@3.1.1"
+  "packageManager": "yarn@3.1.1",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }


### PR DESCRIPTION
The following subpackages are already broken (`?.`/`??` usage) on nodejs < 14 as of these commits:

| package     | commit     | date       |
| ----------- | ---------- | ---------- |
| node        | 9a7333e60a | 2022-04-25 |
| core        | 5977a7b2a6 | 2022-09-24 |
| lavapack    | 5977a7b2a6 | 2022-09-24 |
| tofu (test) | 5f0f9046cd | 2022-05-25 |

If nodejs v12 support is still desired to keep around, those few lines could be fixed to move it back.

Otherwise it seems prudent to mark explicit deprecation of EOL node versions. It could also make sense to add a further minor version constraint (as was already present in the root `package.json`).