### PR TITLE
change shell script shebangs from /bin/bash to /bin/sh

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/run.sh
+++ b/packages/browserify/test/fixtures/secureBundling/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ "$WRITE_AUTO_POLICY" == "1" ]; then

--- a/packages/survey/src/download.sh
+++ b/packages/survey/src/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # exit when any command fails
 set -e

--- a/packages/survey/src/prepareHook.js
+++ b/packages/survey/src/prepareHook.js
@@ -13,7 +13,7 @@ const lavamoat = require.resolve('lavamoat/src/index.js')
 const lockdown = new URL('../src/lockdown.cjs', `file://${__filename}`).pathname;
 const mitm = new URL('../mitm/node', `file://${__filename}`).pathname;
 
-const script = `#!/bin/bash
+const script = `#!/bin/sh
 set -xueo pipefail
 
 npxpath="${npxPath}"


### PR DESCRIPTION
Makes scripts runnable in e.g. `node:alpine` docker images without installing bash. Performed basic manual functional testing of each script.