### PR TITLE
Support re exp for scuttling avoid props

### DIFF
--- a/packages/browserify/examples/01-simple-js/build.js
+++ b/packages/browserify/examples/01-simple-js/build.js
@@ -5,7 +5,7 @@ const browserify = require('browserify')
 const lavamoatOpts = {
   writeAutoPolicy: false,
   scuttleGlobalThis: true,
-  scuttleGlobalThisExceptions: ['print', '/HTML[a-zA-Z]*Element/', 'prompt'],
+  scuttleGlobalThisExceptions: ['print', /HTML[a-zA-Z]*Element/, 'prompt'],
 }
 
 // enable policy autogen if specified

--- a/packages/browserify/examples/01-simple-js/build.js
+++ b/packages/browserify/examples/01-simple-js/build.js
@@ -5,7 +5,7 @@ const browserify = require('browserify')
 const lavamoatOpts = {
   writeAutoPolicy: false,
   scuttleGlobalThis: true,
-  scuttleGlobalThisExceptions: ['print'],
+  scuttleGlobalThisExceptions: ['print', '/HTML[a-zA-Z]*Element/', 'prompt'],
 }
 
 // enable policy autogen if specified

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -118,8 +118,10 @@ async function runBrowserify ({
   bundleWithPrecompiledModules = true,
   ...additionalOpts
 }) {
-  for (let i = 0; i < (additionalOpts.scuttleGlobalThisExceptions).length; i++) {
-    additionalOpts.scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+  if (additionalOpts?.scuttleGlobalThisExceptions) {
+    for (let i = 0; i < additionalOpts.scuttleGlobalThisExceptions.length; i++) {
+      additionalOpts.scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+    }
   }
   const lavamoatParams = {
     entries: scenario.entries,

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -119,8 +119,9 @@ async function runBrowserify ({
   ...additionalOpts
 }) {
   if (additionalOpts?.scuttleGlobalThisExceptions) {
+    // toString regexps if there's any
     for (let i = 0; i < additionalOpts.scuttleGlobalThisExceptions.length; i++) {
-      additionalOpts.scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+      additionalOpts.scuttleGlobalThisExceptions[i] = String(additionalOpts.scuttleGlobalThisExceptions[i])
     }
   }
   const lavamoatParams = {

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -118,6 +118,9 @@ async function runBrowserify ({
   bundleWithPrecompiledModules = true,
   ...additionalOpts
 }) {
+  for (let i = 0; i < (additionalOpts.scuttleGlobalThisExceptions).length; i++) {
+    additionalOpts.scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+  }
   const lavamoatParams = {
     entries: scenario.entries,
     opts: {

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -35,6 +35,9 @@ function generateKernel (opts = {}) {
     // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
     const {scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
+    for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
+      scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+    }
     output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
       scuttleGlobalThis,
       scuttleGlobalThisExceptions,

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -36,8 +36,9 @@ function generateKernel (opts = {}) {
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
     const {scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
     if (scuttleGlobalThisExceptions) {
+      // toString regexps if there's any
       for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
-        scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+        scuttleGlobalThisExceptions[i] = String(scuttleGlobalThisExceptions[i])
       }
     }
     output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -35,8 +35,10 @@ function generateKernel (opts = {}) {
     // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
     const {scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
-    for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
-      scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+    if (scuttleGlobalThisExceptions) {
+      for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
+        scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+      }
     }
     output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
       scuttleGlobalThis,

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -110,7 +110,7 @@
           continue
         }
         const parts = prop.split('/');
-        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1), parts[parts.length - 1])
+        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1).join('/'), parts[parts.length - 1])
       }
 
       // support LM,SES exported APIs and polyfills

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -110,7 +110,9 @@
           continue
         }
         const parts = prop.split('/');
-        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1).join('/'), parts[parts.length - 1])
+        const pattern = parts.slice(1, -1).join('/')
+        const flags = parts[parts.length - 1]
+        extraPropsToAvoid[i] = new RegExp(pattern, flags)
       }
 
       // support LM,SES exported APIs and polyfills

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -15,7 +15,7 @@ module.exports = [
       defineOne: one,
       expectedResult: Math.PI,
       scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', '/[0-9]+/', 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
+      scuttleGlobalThisExceptions: ['process', /[0-9]+/, 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
     })
     await autoConfigForScenario({ scenario })
     return scenario

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -5,7 +5,7 @@ const one = () => {
   if (globalThis.getTrueGlobalThisForTestsOnly) {
     globalObject = globalThis.getTrueGlobalThisForTestsOnly()
   }
-  module.exports = globalObject.Math.SQRT2
+  module.exports = (globalObject.Float32Array , globalObject.Math.PI)
 }
 
 module.exports = [
@@ -13,9 +13,9 @@ module.exports = [
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is scuttled to work',
       defineOne: one,
-      expectedResult: Math.SQRT2,
+      expectedResult: Math.PI,
       scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
+      scuttleGlobalThisExceptions: ['process', '/[0-9]+/', 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
     })
     await autoConfigForScenario({ scenario })
     return scenario
@@ -25,7 +25,7 @@ module.exports = [
       name: 'scuttle - host env global object is too scuttled to work',
       defineOne: one,
       scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
+      scuttleGlobalThisExceptions: ['process', '/[0-9]+/', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
       expectedFailure: true,
       expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z]*" of globalThis is inaccessible under scuttling mode/,
     })

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -5,7 +5,10 @@ const one = () => {
   if (globalThis.getTrueGlobalThisForTestsOnly) {
     globalObject = globalThis.getTrueGlobalThisForTestsOnly()
   }
-  module.exports = (globalObject.Float32Array , globalObject.Math.PI)
+  // this will throw if regex scuttling fails
+  if (globalObject.Float32Array) {
+    module.exports = globalObject.Math.PI
+  }
 }
 
 module.exports = [

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -27,7 +27,7 @@ module.exports = [
       scuttleGlobalThis: true,
       scuttleGlobalThisExceptions: ['process', '/[0-9]+/', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
       expectedFailure: true,
-      expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z]*" of globalThis is inaccessible under scuttling mode/,
+      expectedFailureMessageRegex: /LavaMoat - property "[A-Za-z0-9]*" of globalThis is inaccessible under scuttling mode/,
     })
     await autoConfigForScenario({ scenario })
     return scenario

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -79,6 +79,10 @@ function createPacker({
   }
   assert(policy, 'must specify a policy')
 
+  for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
+    scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+  }
+
   prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({
     scuttleGlobalThis,
     scuttleGlobalThisExceptions,

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -79,8 +79,9 @@ function createPacker({
   }
   assert(policy, 'must specify a policy')
 
+  // toString regexps if there's any
   for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
-    scuttleGlobalThisExceptions[i] += '' // toString regexps if there's any
+    scuttleGlobalThisExceptions[i] = String(scuttleGlobalThisExceptions[i])
   }
 
   prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({

--- a/packages/lavapack/src/runtime-template.js
+++ b/packages/lavapack/src/runtime-template.js
@@ -3,6 +3,7 @@
   // therefore this is our way of capturing access to basic APIs LavaMoat
   // uses to still be accessible only to LavaMoat after scuttling occurs
   const {
+    RegExp,
     Reflect,
     Object,
     Error,

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -10993,7 +10993,9 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
           continue
         }
         const parts = prop.split('/');
-        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1).join('/'), parts[parts.length - 1])
+        const pattern = parts.slice(1, -1).join('/')
+        const flags = parts[parts.length - 1]
+        extraPropsToAvoid[i] = new RegExp(pattern, flags)
       }
 
       // support LM,SES exported APIs and polyfills

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -10993,7 +10993,7 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
           continue
         }
         const parts = prop.split('/');
-        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1), parts[parts.length - 1])
+        extraPropsToAvoid[i] = new RegExp(parts.slice(1, -1).join('/'), parts[parts.length - 1])
       }
 
       // support LM,SES exported APIs and polyfills


### PR DESCRIPTION
* This PR comes to allow passing regular expressions values in the `scuttleGlobalThisExceptions` optional argument in addition to the already existing string values support.

Before:

```javascript
scuttleGlobalThisExceptions = ['alert', 'HTMLSpanElement', 'HTMLDivElement', 'HTMLAnchorElement']
```

After:

```javascript
scuttleGlobalThisExceptions = ['alert', /HTML[a-zA-Z]*Element/]
```

* (both `/HTML[a-zA-Z]*Element/` and `"/HTML[a-zA-Z]*Element/"` will work)

* Any property that starts with `/` will be interpreted as a RE and not as a standard string property 

* To get more context on scuttling feature visit #360 