### PR TITLE
lavamoat-protect changes round 2

### DIFF
--- a/packages/protect/.eslintrc.json
+++ b/packages/protect/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../.eslintrc.json"
+  "extends": "../../.eslintrc.json",
+  "rules": {
+    "quotes": ["error", "single"],
+    "semi": ["error", "never"]
+  }
 }

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@lavamoat/allow-scripts": "^2.1.0",
     "promptly": "^3.2.0",
-    "semver": "^7.3.8"
+    "semver": "^7.3.8",
+    "yargs": "^17.3.1"
   },
   "keywords": [],
   "author": "MetaMask security research team",

--- a/packages/protect/src/cli.js
+++ b/packages/protect/src/cli.js
@@ -4,6 +4,7 @@
 
 const yargs = require('yargs')
 
+const { detectPkgManager } = require('./lib/utils.js')
 const { protectProject, SUPPORTED_PKG_MANAGERS } = require('./index.js')
 
 async function parseArgs () {
@@ -15,37 +16,40 @@ async function parseArgs () {
         describe: 'prompt for protections and parameters',
         type: 'boolean',
         default: false,
-      }),
-      project_.option('dry-run', {
+      })
+      .option('dry-run', {
         alias: 'n',
         describe: 'output actions; don\'t actually perform changes',
         type: 'boolean',
         default: false,
       })
-      project_.option('setup-scripts', {
+      .option('setup-scripts', {
         // TODO: better description
         describe: 'set up preinstall lifecycle hook',
         type: 'boolean',
         default: false,
       })
-      project_.option('setup-node', {
+      .option('setup-node', {
         // TODO: better description
         describe: 'set up lavamoat-node for runtime protection',
         type: 'boolean',
         default: false,
       })
-      project_.option('package-manager', {
+      .option('package-manager', {
         alias: 'p',
         describe: 'package manager to configure',
         choices: SUPPORTED_PKG_MANAGERS,
         requiresArg: false,
       })
-      project_.option('force', {
+      .option('force', {
         alias: 'f',
         describe: 'overwrite existing files without prompting',
         type: 'boolean',
         default: false,
       })
+      .coerce('package-manager', pm =>
+        pm ?? detectPkgManager()
+      )
     }, async (argv) => {
       await protectProject(argv)
     })

--- a/packages/protect/src/cli.js
+++ b/packages/protect/src/cli.js
@@ -5,7 +5,7 @@
 const yargs = require('yargs')
 
 const { detectPkgManager } = require('./lib/utils.js')
-const { protectProject, SUPPORTED_PKG_MANAGERS } = require('./index.js')
+const { protectEnv, protectProject, SUPPORTED_PKG_MANAGERS } = require('./index.js')
 
 async function parseArgs () {
   const argsParser = yargs
@@ -35,6 +35,7 @@ async function parseArgs () {
         type: 'boolean',
         default: false,
       })
+      // TODO: enforce only single
       .option('package-manager', {
         alias: 'p',
         describe: 'package manager to configure',
@@ -52,6 +53,28 @@ async function parseArgs () {
       )
     }, async (argv) => {
       await protectProject(argv)
+    })
+    .command('env', 'set up host-level protections', (env_) => {
+      env_.option('dry-run', {
+        alias: 'n',
+        describe: 'output actions; don\'t actually perform changes',
+        type: 'boolean',
+        default: false,
+      })
+      .option('package-manager', {
+        alias: 'p',
+        describe: 'package manager to configure',
+        choices: SUPPORTED_PKG_MANAGERS,
+        requiresArg: false,
+      })
+      .option('force', {
+        alias: 'f',
+        describe: 'overwrite existing files without prompting',
+        type: 'boolean',
+        default: false,
+      })
+    }, async (argv) => {
+      await protectEnv(argv)
     })
     .demandCommand(1, 1)
     .help()

--- a/packages/protect/src/cli.js
+++ b/packages/protect/src/cli.js
@@ -2,20 +2,62 @@
 
 //@ts-check
 
-const { protectProject } = require('./index.js')
+const yargs = require('yargs')
 
-const command = process.argv[2]
+const { protectProject, SUPPORTED_PKG_MANAGERS } = require('./index.js')
 
-switch (command) {
-  case 'project':
-    protectProject()
+async function parseArgs () {
+  const argsParser = yargs
+    .usage('Usage: $0 <command> [options]')
+    .command('project', 'set up project-level protections', (project_) => {
+      project_.option('interactive', {
+        alias: 'i',
+        describe: 'prompt for protections and parameters',
+        type: 'boolean',
+        default: false,
+      }),
+      project_.option('dry-run', {
+        alias: 'n',
+        describe: 'output actions; don\'t actually perform changes',
+        type: 'boolean',
+        default: false,
+      })
+      project_.option('setup-scripts', {
+        // TODO: better description
+        describe: 'set up preinstall lifecycle hook',
+        type: 'boolean',
+        default: false,
+      })
+      project_.option('setup-node', {
+        // TODO: better description
+        describe: 'set up lavamoat-node for runtime protection',
+        type: 'boolean',
+        default: false,
+      })
+      project_.option('package-manager', {
+        alias: 'p',
+        describe: 'package manager to configure',
+        choices: SUPPORTED_PKG_MANAGERS,
+        requiresArg: false,
+      })
+      project_.option('force', {
+        alias: 'f',
+        describe: 'overwrite existing files without prompting',
+        type: 'boolean',
+        default: false,
+      })
+    }, async (argv) => {
+      await protectProject(argv)
+    })
+    .demandCommand(1, 1)
+    .help()
+    .strict()
 
-  break
-  case 'env':
-  case 'devenv':
-  case 'dev':
-
-  break
-  default:
-    console.log('Choose one of the subcommands: project devenv')
+  await argsParser.parse(process.argv.slice(2))
 }
+
+async function main () {
+  await parseArgs()
+}
+
+main().catch((err) => console.error(err))

--- a/packages/protect/src/cli.js
+++ b/packages/protect/src/cli.js
@@ -40,6 +40,7 @@ async function parseArgs () {
         alias: 'p',
         describe: 'package manager to configure',
         choices: SUPPORTED_PKG_MANAGERS,
+        nargs: 1,
         requiresArg: false,
       })
       .option('force', {
@@ -50,6 +51,11 @@ async function parseArgs () {
       })
       .coerce('package-manager', pm =>
         pm ?? detectPkgManager()
+      )
+      .check(argv =>
+        !argv.interactive && !argv.setupNode && !argv.setupScripts
+          ? new Error('No action specified')
+          : true
       )
     }, async (argv) => {
       await protectProject(argv)
@@ -63,7 +69,8 @@ async function parseArgs () {
       })
       .option('package-manager', {
         alias: 'p',
-        describe: 'package manager to configure',
+        type: 'array',
+        describe: 'package managers to configure',
         choices: SUPPORTED_PKG_MANAGERS,
         requiresArg: false,
       })

--- a/packages/protect/src/index.js
+++ b/packages/protect/src/index.js
@@ -1,4 +1,5 @@
 //@ts-check
+const { spawnSync } = require('child_process')
 const promptly = require('promptly')
 const setupScripts = require('./lib/setup-scripts')
 const installLavamoat = require('./lib/install-lavamoat')
@@ -33,8 +34,43 @@ module.exports = {
       console.error('Sorry, that didn\'t work out...', error)
     }
   },
-  async protectEnv({ dryRun, force, interactive, ...argv }) {
+  async protectEnv({ dryRun, force, ...argv }) {
     try {
+      // TODO: move to cli
+      const pms = new Set(
+        typeof argv.packageManager  === 'string' ? [argv.packageManager] : argv.packageManager
+      )
+      pms.forEach(pm => {
+        switch (pm) {
+          case 'npm': {
+            const result = spawnSync('npm', ['config', '-g', 'get', 'ignore-scripts'])
+              .stdout.toString('utf-8').trim()
+            if (result === 'false') {
+              const cmdArgs = ['config', '-g', 'set', 'ignore-scripts', 'true']
+              console.info(`@lavamoat/protect env running \`npm ${cmdArgs.join(' ')}\``)
+              const { stderr, stdout } = spawnSync('npm', cmdArgs)
+              const [err, out] = [stderr, stdout].map(b => b.toString('utf-8').trim())
+              if (out) {
+                console.warn('@lavamoat/protect env npm-config INFO:', out)
+              }
+              if (err) {
+                console.error('@lavamoat/protect env npm-config ERROR:', err)
+              }
+            }
+            return
+          }
+          case 'pnpm': {
+            throw new Error('TODO')
+          }
+          case 'yarn1': {
+            throw new Error('TODO')
+          }
+          case 'yarn3': {
+            throw new Error('TODO')
+          }
+        }
+      })
+
     } catch (error) {
       console.error('Sorry, that didn\'t work out...', error)
     }

--- a/packages/protect/src/index.js
+++ b/packages/protect/src/index.js
@@ -41,10 +41,7 @@ module.exports = {
   },
   async protectEnv({ dryRun, force, ...argv }) {
     try {
-      // TODO: move to cli
-      const pms = new Set(
-        typeof argv.packageManager  === 'string' ? [argv.packageManager] : argv.packageManager
-      )
+      const pms = new Set(argv.packageManager)
       pms.forEach(pm => {
         switch (pm) {
           case 'npm': {

--- a/packages/protect/src/index.js
+++ b/packages/protect/src/index.js
@@ -68,7 +68,7 @@ module.exports = {
             throw new Error('TODO')
           }
           case 'yarn1': {
-            // yarn1 has no interface to query global config explicitly
+            // yarn has no interface to query global config explicitly
             const cwd = makeTmpDir()
             try {
               const result = spawnSync('yarn', ['config', 'get', 'ignore-scripts'], { cwd })
@@ -79,10 +79,10 @@ module.exports = {
                 const { stderr, stdout } = spawnSync('yarn', cmdArgs)
                 const [err, out] = [stderr, stdout].map(b => b.toString('utf-8').trim())
                 if (!out.match(/success/)) {
-                  console.warn('@lavamoat/protect env npm-config INFO:', out)
+                  console.warn('@lavamoat/protect env yarn-config INFO:', out)
                 }
                 if (err) {
-                  console.error('@lavamoat/protect env npm-config ERROR:', err)
+                  console.error('@lavamoat/protect env yarn-config ERROR:', err)
                 }
               }
             } finally {
@@ -91,7 +91,26 @@ module.exports = {
             return
           }
           case 'yarn3': {
-            throw new Error('TODO')
+            const cwd = makeTmpDir()
+            try {
+              const result = spawnSync('yarn', ['config', 'get', 'enableScripts'], { cwd })
+                .stdout.toString('utf-8').trim()
+              if (result !== 'false') {
+                const cmdArgs = ['config', 'set', '-H', 'enableScripts', 'false']
+                console.info(`@lavamoat/protect env running \`yarn ${cmdArgs.join(' ')}\``)
+                const { stderr, stdout } = spawnSync('yarn', cmdArgs)
+                const [err, out] = [stderr, stdout].map(b => b.toString('utf-8').trim())
+                if (!out.match(/YN0000/)) {
+                  console.warn('@lavamoat/protect env yarn-config INFO:', out)
+                }
+                if (err) {
+                  console.error('@lavamoat/protect env yarn-config ERROR:', err)
+                }
+              }
+            } finally {
+              rmdirSync(cwd)
+            }
+            return
           }
         }
       })

--- a/packages/protect/src/index.js
+++ b/packages/protect/src/index.js
@@ -1,12 +1,7 @@
 //@ts-check
-const semver = require('semver')
 const promptly = require('promptly')
-const { existsSync } = require('fs')
 const setupScripts = require('./lib/setup-scripts')
 const installLavamoat = require('./lib/install-lavamoat')
-const { getPackageJson,
-  projectRelative,
-} = require('./lib/utils')
 
 const SUPPORTED_PKG_MANAGERS = ['npm','pnpm','yarn1','yarn3']
 
@@ -15,14 +10,11 @@ module.exports = {
   async protectProject({ dryRun, force, interactive, ...argv }){
     try {
       const packageManager = interactive
-        ? await (async () => {
-        const pkgManagerDefault = argv.packageManager ?? detectPkgManager()
-        return await promptly.choose(
-          `Which package manager are you using? [${SUPPORTED_PKG_MANAGERS.map(p => p === pkgManagerDefault ? '*'+p : p)}]`,
+        ? await promptly.choose(
+          `Which package manager are you using? [${SUPPORTED_PKG_MANAGERS.map(p => p === argv.packageManager ? '*'+p : p)}]`,
           SUPPORTED_PKG_MANAGERS, {
-            default: pkgManagerDefault
+            default: argv.packageManager
           })
-        })()
         : argv.packageManager
       const doSetupScripts = interactive
         ? await promptly.confirm('Would you like to install protection against malicious scripts? [y/n]')
@@ -40,87 +32,12 @@ module.exports = {
     } catch (error) {
       console.error('Sorry, that didn\'t work out...', error)
     }
-  }
-}
-
-/**
- * @typedef {'npm' | 'pnpm' | 'yarn1' | 'yarn3'} PkgM
- */
-/**
- * @return {PkgM}
- */
-function detectPkgManager(){
-  const pkgManagersFound = new Set()
-  const cfg = detectConfigFiles()
-  if (cfg['yarn.lock']) {
-    pkgManagersFound.add('yarnUncertain')
-  }
-  if (cfg['.yarnrc']) {
-    pkgManagersFound.add('yarn1')
-  }
-  if (cfg['yarnrc.yml']) {
-    pkgManagersFound.add('yarn3')
-  }
-  if (cfg['package-log.json'] || cfg['.npmrc']) {
-    pkgManagersFound.add('npm')
-  }
-  if (cfg['.pnpmfile.cjs'] || cfg['pnpm-workspace.yml']) {
-    pkgManagersFound.add('pnpm')
-  }
-
-  const pkgConf = getPackageJson()
-  ;(['npm', 'yarn', 'pnpm']).map(engine => ([engine, pkgConf?.engines?.[engine]]))
-    .filter(([,version]) => !!version)
-    .map(([e, v]) => {
-      if (e === 'yarn') {
-        switch (semver.major(v)) {
-          case 1:
-            return 'yarn1'
-          case 3:
-            return 'yarn3'
-          default:
-            return 'yarnUncertain'
-        }
-      }
-      return e
-    }).forEach(e => {
-      pkgManagersFound.add(e)
-    })
-
-    if (pkgManagersFound['yarn1'] || pkgManagersFound['yarn3']) {
-      pkgManagersFound.delete('yarnUncertain')
+  },
+  async protectEnv({ dryRun, force, interactive, ...argv }) {
+    try {
+    } catch (error) {
+      console.error('Sorry, that didn\'t work out...', error)
     }
-
-  /*
-   "engines": {
-    "node": ">=4.4.7 <7.0.0",
-    "zlib": "^1.2.8",
-    "yarn": "^0.14.0"
-  }
-   "engines": {
-        "node": ">=10",
-        "pnpm": ">=3"
-    }
-     */
-
-  if (pkgManagersFound.has('yarnUncertain')) {
-    // ok, so which yarn could that be? more likely yarn1
-    pkgManagersFound.delete('yarnUncertain')
-    pkgManagersFound.add('yarn1')
-  }
-
-  return /** @type {PkgM} */  (Object.keys(pkgManagersFound).sort().reverse()[0] || 'npm')
-}
-
-function detectConfigFiles(){
-  return {
-    '.pnpmfile.cjs': existsSync(projectRelative('.pnpmfile.cjs')),
-    'pnpm-workspace.yml': existsSync(projectRelative('pnpm-workspace.yaml')) || existsSync(projectRelative('pnpm-workspace.yml')),
-    '.yarnrc': existsSync(projectRelative('.yarnrc')),
-    'yarnrc.yml': existsSync(projectRelative('.yarnrc.yml')),
-    'yarn.lock': existsSync(projectRelative('yarn.lock')),
-    '.npmrc': existsSync(projectRelative('.npmrc')),
-    'package-lock.json': existsSync(projectRelative('package-lock.json')),
   }
 }
 

--- a/packages/protect/src/lib/setup-lint.js
+++ b/packages/protect/src/lib/setup-lint.js
@@ -1,3 +1,0 @@
-module.exports = async function setupLockfileLint(pkgManager){
-
-}

--- a/packages/protect/src/lib/setup-scripts.js
+++ b/packages/protect/src/lib/setup-scripts.js
@@ -7,18 +7,19 @@ const {
   getPackageJson,
 } = require('./utils')
 
-module.exports = async function setupScripts(pkgManager) {
+module.exports = async function setupScripts({dryRun, interactive, force, packageManager}) {
   const pkgConf = getPackageJson()
   if (pkgConf.scripts['lavamoat-postinstall']) {
     console.warn('Existing script `lavamoat-postinstall` detected. This is indicative of inconsistently configured LavaMoat')
-
-    if(!(await promptly.confirm('Would you like to override the existing script?'))) {
+    if (interactive && !force && !(await promptly.confirm('Would you like to override the existing script? [y/n]'))) {
       throw new Error('User exit')
+    } else if (!interactive) {
+      throw new Error('Not overwriting existing script')
     }
   }
 
   // Generate the RC files setup
-  writeRcFile(pkgManager)
+  writeRcFile(packageManager, dryRun)
 
-  patchPackageJson()
+  patchPackageJson(dryRun)
 }

--- a/packages/protect/src/lib/utils.js
+++ b/packages/protect/src/lib/utils.js
@@ -1,5 +1,6 @@
 //@ts-check
-const { readFileSync, writeFileSync } = require('fs')
+const semver = require('semver')
+const { existsSync, readFileSync, writeFileSync } = require('fs')
 const path = require('path')
 
 let packageJsonCache
@@ -31,7 +32,75 @@ const writePackageJson = (data) => {
   }
 }
 
+/**
+ * @typedef {'npm' | 'pnpm' | 'yarn1' | 'yarn3'} PkgM
+ */
+/**
+ * @return {PkgM}
+ */
+function detectPkgManager() {
+  const configFilesMapping = {
+    yarnUncertain: [
+      'yarn.lock',
+    ],
+    yarn1: [
+      '.yarnrc',
+    ],
+    yarn3: [
+      '.yarnrc.yml',
+    ],
+    npm: [
+      '.npmrc',
+      'package-lock.json',
+    ],
+    pnpm: [
+      'pnpm-workspace.yaml',
+      '.pnpmfile.cjs',
+    ],
+  }
+  // detect by presence of configuration files
+  const pkgManagersFound = new Set(Object.entries(configFilesMapping)
+    .filter(
+      ([_, files]) => files.map(projectRelative).some(existsSync)
+    )
+    .map(([name]) => name)
+  )
+
+  // detect by configured engines in package.json
+  const pkgConf = getPackageJson()
+  ;(['npm', 'yarn', 'pnpm']).map(engine => ([engine, pkgConf?.engines?.[engine]]))
+    .filter(([,version]) => !!version)
+    .map(([e, v]) => {
+      if (e === 'yarn') {
+        switch (semver.major(v)) {
+          case 1:
+            return 'yarn1'
+          case 3:
+            return 'yarn3'
+          default:
+            return 'yarnUncertain'
+        }
+      }
+      return e
+    }).forEach(e => {
+      pkgManagersFound.add(e)
+    })
+
+  if (pkgManagersFound['yarn1'] || pkgManagersFound['yarn3']) {
+    pkgManagersFound.delete('yarnUncertain')
+  }
+
+  if (pkgManagersFound.has('yarnUncertain')) {
+    // ok, so which yarn could that be? more likely yarn1
+    pkgManagersFound.delete('yarnUncertain')
+    pkgManagersFound.add('yarn1')
+  }
+
+  return /** @type {PkgM} */  (Array.from(pkgManagersFound).sort().reverse()[0] || 'npm')
+}
+
 module.exports = {
+  detectPkgManager,
   getPackageJson,
   projectRelative,
   writePackageJson,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,11 +1088,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@lavamoat/preinstall-always-fail@latest":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@lavamoat/preinstall-always-fail/-/preinstall-always-fail-1.0.0.tgz#e78a6e3d9e212a4fef869ec37d4f5fb498dea373"
-  integrity sha512-vD2DcC0ffJj1w2y1Lu0OU39wHmlPEd2tCDW04Bm6Kf4LyRnCHCezTsS8yzeSJ+4so7XP+TITuR5FGJRWxPb+GA==
-
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"


### PR DESCRIPTION
#387 

follow-up on #407 

### Summary
  * `allow-scripts`: Add `dryRun` parameter to setup functions (5b547e678ceabd1536d8c7a30519c6f9a37d9b47)
  * minor cleanup
  * add yargs, refactor cli interface (764739395b2401c4be5ebb817481a9a324a85c87)

A major change I'm proposing vs original issue: the default is now a non-interactive cli. Adding the `-i`/`--interactive` flag retains the wizard. Any parameters specified on the cli will still be prompted for in interactive mode, with the specified value as default.

This enables the tool to easily be used for scripting and bulk application, as well as convenient partial setup. 

Also added `--dryrun` and `--force` flags.