### PR TITLE
fix: remove redundant engine entries from package.json

### DIFF
--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -37,9 +37,6 @@
     "lint:fix": "eslint . --fix",
     "lint:deps": "depcheck"
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "author": "",
   "homepage": "https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts",
   "engines": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -44,9 +44,6 @@
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",
   "description": "",
   "engines": {

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -72,9 +72,6 @@
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/viz/README.md",
   "bin": {
     "lavamoat-viz": "./bin/index.js"


### PR DESCRIPTION
#398 did not properly remove all existing `engines` entries from `package.json`. This fixes that.