### PR TITLE
allow-scripts: export setup

### DIFF
--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -5,6 +5,10 @@
   "bin": {
     "allow-scripts": "src/cli.js"
   },
+  "exports":{
+    ".": "./src/index.js",
+    "./setup": "./src/setup.js"
+  },
   "license": "MIT",
   "dependencies": {
     "@lavamoat/aa": "^3.1.0",

--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -7,6 +7,7 @@ const normalizeBin = require('npm-normalize-package-bin')
 const { linkBinAbsolute, linkBinRelative } = require('./linker.js')
 const { FEATURE } = require('./toggles.js')
 const { loadCanonicalNameMap } = require('@lavamoat/aa')
+const setup = require('./setup')
 
 /**
  * @typedef {Object} PkgConfs
@@ -57,6 +58,7 @@ module.exports = {
   runAllowedPackages,
   setDefaultConfiguration,
   printPackagesList,
+  setup,
 }
 
 async function getOptionsForBin({ rootDir, name }) {


### PR DESCRIPTION
This is pulled out of WIP work on #387 and intends to expose setup for use in downstream dependents.