### PR TITLE
browserify: test: make secureBundling script POSIX-compliant

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/run.sh
+++ b/packages/browserify/test/fixtures/secureBundling/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$WRITE_AUTO_POLICY" == "1" ]; then
+if [ "$WRITE_AUTO_POLICY" = "1" ]; then
   ../node/src/cli.js test/fixtures/secureBundling/build.js --projectRoot './' --policyPath test/fixtures/secureBundling/lavamoat/node/policy.json --writeAutoPolicy
 else
   ../node/src/cli.js test/fixtures/secureBundling/build.js --projectRoot './' --policyPath test/fixtures/secureBundling/lavamoat/node/policy.json


### PR DESCRIPTION
Prior version is not valid syntax in Dash. This browserify test, and test:prep, have therefore not been working on Debian/Ubuntu as of #402.