### PR TITLE
Attempt to support runtime cjs generation to adjust with SES quad-flip update

### DIFF
--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -15,6 +15,8 @@ const makeGeneralUtilsSrc = fs.readFileSync(path.join(__dirname, '/makeGeneralUt
 const strictScopeTerminatorSrc = fs.readFileSync(path.join(__dirname, '/../lib/strict-scope-terminator.js'), 'utf-8')
 
 module.exports = {
+  replaceTemplateRequire,
+  getStrictScopeTerminatorShimSrc,
   getSesShimSrc,
   generateKernel,
   generateKernelCore,
@@ -22,6 +24,10 @@ module.exports = {
 
 function getSesShimSrc () {
   return sesSrc
+}
+
+function getStrictScopeTerminatorShimSrc () {
+  return strictScopeTerminatorSrc
 }
 
 // takes the kernelTemplate and populates it with the libraries

--- a/packages/lavapack/.eslintignore
+++ b/packages/lavapack/.eslintignore
@@ -5,3 +5,4 @@
 !test/**/*.js
 
 src/runtime.js
+src/runtime-cjs.js

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -1,10 +1,18 @@
 const { join: pathJoin } = require('path')
 const { promises: { readFile, writeFile }} = require('fs')
 const { generateKernel, makeInitStatsHook } = require('lavamoat-core')
+const { getStrictScopeTerminatorShimSrc, replaceTemplateRequire } = require('lavamoat-core/src/generateKernel')
 
 module.exports = buildRuntime
 
+async function buildRuntimeCjs() {
+  const runtimeCjsTemplate = await readFile(pathJoin(__dirname, 'runtime-cjs-template.js'), 'utf8')
+  const sst = replaceTemplateRequire(runtimeCjsTemplate, 'strict-scope-terminator', getStrictScopeTerminatorShimSrc())
+  await writeFile(pathJoin(__dirname, 'runtime-cjs.js'), sst)
+}
+
 async function buildRuntime (opts = {}) {
+  await buildRuntimeCjs()
   const runtimeTemplate = await readFile(pathJoin(__dirname, 'runtime-template.js'), 'utf8')
   let output = runtimeTemplate
   // inline kernel

--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -5,10 +5,16 @@ const { getStrictScopeTerminatorShimSrc, replaceTemplateRequire } = require('lav
 
 module.exports = buildRuntimeUMD
 
+function markAsGenerated(output, file) {
+  const runner = __filename.slice(__dirname.length + 1)
+  return `// DO NOT EDIT! THIS FILE IS GENERATED FROM "${file}" BY RUNNING "${runner}"\n\n` + output
+}
+
 async function buildRuntimeCJS () {
   const runtimeCjsTemplate = await readFile(pathJoin(__dirname, 'runtime-cjs-template.js'), 'utf8')
-  const sst = replaceTemplateRequire(runtimeCjsTemplate, 'strict-scope-terminator', getStrictScopeTerminatorShimSrc())
-  await writeFile(pathJoin(__dirname, 'runtime-cjs.js'), sst)
+  let output = replaceTemplateRequire(runtimeCjsTemplate, 'strict-scope-terminator', getStrictScopeTerminatorShimSrc())
+  output = markAsGenerated(output, 'runtime-cjs-template.js')
+  await writeFile(pathJoin(__dirname, 'runtime-cjs.js'), output)
 }
 
 async function buildRuntimeES (opts) {
@@ -20,6 +26,7 @@ async function buildRuntimeES (opts) {
   // inline reportStatsHook
   const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
   output = stringReplace(output, '__reportStatsHook__', statsCode)
+  output = markAsGenerated(output, 'runtime-template.js')
   await writeFile(pathJoin(__dirname, 'runtime.js'), output)
 }
 

--- a/packages/lavapack/src/runtime-cjs-template.js
+++ b/packages/lavapack/src/runtime-cjs-template.js
@@ -1,0 +1,74 @@
+;(function() {
+
+  const {strictScopeTerminator} = templateRequire('strict-scope-terminator')
+
+  // polyfill node/browserify's globalRef
+  globalThis.global = globalThis
+
+  const moduleRegistry = new Map()
+  const moduleCache = new Map()
+
+  // create a lavamoat pulic API for loading modules over multiple files
+  const LavaPack = Object.freeze({
+    loadPolicy: Object.freeze(loadPolicy),
+    loadBundle: Object.freeze(loadBundle),
+    runModule: Object.freeze(runModule),
+  })
+
+  Object.defineProperty(globalThis, 'LavaPack', {value: LavaPack})
+
+  function loadPolicy () {
+    throw new Error('runtime-cjs: unable to enforce policy')
+  }
+
+  // it is called by the modules collection that will be appended to this file
+  function loadBundle (newModules, entryPoints, bundlePolicy) {
+    // ignore bundlePolicy as we wont be enforcing it
+    // verify + load in each module
+    for (const [moduleId, moduleDeps, initFn] of newModules) {
+      // verify that module is new
+      if (moduleRegistry.has(moduleId)) {
+        throw new Error(`LavaMoat - loadBundle encountered redundant module definition for id "${moduleId}"`)
+      }
+      // add the module
+      moduleRegistry.set(moduleId, { deps: moduleDeps, precompiledInitializer: initFn })
+    }
+    // run each of entryPoints
+    const entryExports = Array.prototype.map.call(entryPoints, (entryId) => {
+      return runModule(entryId)
+    })
+    // webpack compat: return the first module's exports
+    return entryExports[0]
+  }
+
+  function runModule (moduleId) {
+    if (!moduleRegistry.has(moduleId)) {
+      throw new Error(`no module registered for "${moduleId}" (${typeof moduleId})`)
+    }
+    if (moduleCache.has(moduleId)) {
+      const moduleObject = moduleCache.get(moduleId)
+      return moduleObject.exports
+    }
+    const moduleObject = { exports: {} }
+    const evalKit = {
+      scopeTerminator: strictScopeTerminator,
+      globalThis,
+    }
+    moduleCache.set(moduleId, moduleObject)
+    const moduleData = moduleRegistry.get(moduleId)
+    const localRequire = requireRelative.bind(null, moduleId, moduleData)
+    const { precompiledInitializer } = moduleData
+    // this invokes the with-proxy wrapper (proxy replace by start compartment global)
+    const moduleInitializerFactory = precompiledInitializer.call(evalKit)
+    // this ensures strict mode
+    const moduleInitializer = moduleInitializerFactory()
+    moduleInitializer.call(moduleObject.exports, localRequire, moduleObject, moduleObject.exports)
+    return moduleObject.exports
+  }
+
+  function requireRelative (parentId, parentData, requestedName) {
+    const resolvedId = (parentData.deps || {})[requestedName] || requestedName
+    return runModule(resolvedId)
+  }
+
+})()

--- a/packages/lavapack/src/runtime-cjs-template.js
+++ b/packages/lavapack/src/runtime-cjs-template.js
@@ -1,9 +1,20 @@
 ;(function() {
 
-  const {strictScopeTerminator} = templateRequire('strict-scope-terminator')
+  // identify the globalRef
+  const globalRef = (typeof globalThis !== 'undefined') ? globalThis : (typeof self !== 'undefined') ? self : (typeof global !== 'undefined') ? global : undefined
+  if (!globalRef) {
+    throw new Error('Lavamoat - unable to identify globalRef')
+  }
+
+  // polyfill globalThis
+  if (globalRef && !globalRef.globalThis) {
+    globalRef.globalThis = globalRef
+  }
 
   // polyfill node/browserify's globalRef
   globalThis.global = globalThis
+
+  const {strictScopeTerminator} = templateRequire('strict-scope-terminator')
 
   const moduleRegistry = new Map()
   const moduleCache = new Map()

--- a/packages/lavapack/src/runtime-cjs.js
+++ b/packages/lavapack/src/runtime-cjs.js
@@ -1,5 +1,19 @@
 ;(function() {
 
+  // identify the globalRef
+  const globalRef = (typeof globalThis !== 'undefined') ? globalThis : (typeof self !== 'undefined') ? self : (typeof global !== 'undefined') ? global : undefined
+  if (!globalRef) {
+    throw new Error('Lavamoat - unable to identify globalRef')
+  }
+
+  // polyfill globalThis
+  if (globalRef && !globalRef.globalThis) {
+    globalRef.globalThis = globalRef
+  }
+
+  // polyfill node/browserify's globalRef
+  globalThis.global = globalThis
+
   const {strictScopeTerminator} = // define strict-scope-terminator
 (function(){
   const global = globalRef
@@ -119,9 +133,6 @@ module.exports = {
   })()
   return module.exports
 })()
-
-  // polyfill node/browserify's globalRef
-  globalThis.global = globalThis
 
   const moduleRegistry = new Map()
   const moduleCache = new Map()

--- a/packages/lavapack/src/runtime-cjs.js
+++ b/packages/lavapack/src/runtime-cjs.js
@@ -1,3 +1,5 @@
+// DO NOT EDIT! THIS FILE IS GENERATED FROM "runtime-cjs-template.js" BY RUNNING "builder-runtime.js"
+
 ;(function() {
 
   // identify the globalRef

--- a/packages/lavapack/src/runtime-cjs.js
+++ b/packages/lavapack/src/runtime-cjs.js
@@ -1,5 +1,125 @@
 ;(function() {
 
+  const {strictScopeTerminator} = // define strict-scope-terminator
+(function(){
+  const global = globalRef
+  const exports = {}
+  const module = { exports }
+  ;(function(){
+// START of injected code from strict-scope-terminator
+// import {
+//   Proxy,
+//   String,
+//   TypeError,
+//   ReferenceError,
+//   create,
+//   freeze,
+//   getOwnPropertyDescriptors,
+//   globalThis,
+//   immutableObject,
+// } from './commons.js';
+const { freeze, create, getOwnPropertyDescriptors } = Object;
+const immutableObject = freeze(create(null));
+
+// import { assert } from './error/assert.js';
+const assert = {
+  fail: (msg) => {
+    throw new Error(msg);
+  }
+}
+
+// const { details: d, quote: q } = assert;
+const d = (strings, args) => strings.join() + args.join();
+const q = (arg) => arg
+
+/**
+ * alwaysThrowHandler
+ * This is an object that throws if any property is called. It's used as
+ * a proxy handler which throws on any trap called.
+ * It's made from a proxy with a get trap that throws. It's safe to
+ * create one and share it between all Proxy handlers.
+ */
+const alwaysThrowHandler = new Proxy(
+  immutableObject,
+  freeze({
+    get(_shadow, prop) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      assert.fail(
+        d`Please report unexpected scope handler trap: ${q(String(prop))}`,
+      );
+    },
+  }),
+);
+
+/*
+ * scopeProxyHandlerProperties
+ * scopeTerminatorHandler manages a strictScopeTerminator Proxy which serves as
+ * the final scope boundary that will always return "undefined" in order
+ * to prevent access to "start compartment globals".
+ */
+const scopeProxyHandlerProperties = {
+  get(_shadow, _prop) {
+    return undefined;
+  },
+
+  set(_shadow, prop, _value) {
+    // We should only hit this if the has() hook returned true matches the v8
+    // ReferenceError message "Uncaught ReferenceError: xyz is not defined"
+    throw new ReferenceError(`${String(prop)} is not defined`);
+  },
+
+  has(_shadow, prop) {
+    // we must at least return true for all properties on the realm globalThis
+    return prop in globalThis;
+  },
+
+  // note: this is likely a bug of safari
+  // https://bugs.webkit.org/show_bug.cgi?id=195534
+  getPrototypeOf() {
+    return null;
+  },
+
+  // Chip has seen this happen single stepping under the Chrome/v8 debugger.
+  // TODO record how to reliably reproduce, and to test if this fix helps.
+  // TODO report as bug to v8 or Chrome, and record issue link here.
+  getOwnPropertyDescriptor(_target, prop) {
+    // Coerce with `String` in case prop is a symbol.
+    const quotedProp = q(String(prop));
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    console.warn(
+      `getOwnPropertyDescriptor trap on scopeTerminatorHandler for ${quotedProp}`,
+      new TypeError().stack,
+    );
+    return undefined;
+  },
+};
+
+// The scope handler's prototype is a proxy that throws if any trap other
+// than get/set/has are run (like getOwnPropertyDescriptors, apply,
+// getPrototypeOf).
+const strictScopeTerminatorHandler = freeze(
+  create(
+    alwaysThrowHandler,
+    getOwnPropertyDescriptors(scopeProxyHandlerProperties),
+  ),
+);
+
+const strictScopeTerminator = new Proxy(
+  immutableObject,
+  strictScopeTerminatorHandler,
+);
+
+module.exports = {
+  alwaysThrowHandler,
+  strictScopeTerminatorHandler,
+  strictScopeTerminator,
+}
+
+// END of injected code from strict-scope-terminator
+  })()
+  return module.exports
+})()
+
   // polyfill node/browserify's globalRef
   globalThis.global = globalThis
 
@@ -48,12 +168,16 @@
       return moduleObject.exports
     }
     const moduleObject = { exports: {} }
+    const evalKit = {
+      scopeTerminator: strictScopeTerminator,
+      globalThis,
+    }
     moduleCache.set(moduleId, moduleObject)
     const moduleData = moduleRegistry.get(moduleId)
     const localRequire = requireRelative.bind(null, moduleId, moduleData)
     const { precompiledInitializer } = moduleData
     // this invokes the with-proxy wrapper (proxy replace by start compartment global)
-    const moduleInitializerFactory = precompiledInitializer.call(globalThis)
+    const moduleInitializerFactory = precompiledInitializer.call(evalKit)
     // this ensures strict mode
     const moduleInitializer = moduleInitializerFactory()
     moduleInitializer.call(moduleObject.exports, localRequire, moduleObject, moduleObject.exports)

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -679,7 +679,7 @@ freeze(bestEffortStringify);
  */
 
 /**
- * @typedef {Object} AssertMakeErrorOptions
+ * @typedef {object} AssertMakeErrorOptions
  * @property {string=} errorName
  */
 
@@ -726,51 +726,65 @@ freeze(bestEffortStringify);
  */
 
 // Type all the overloads of the assertTypeof function.
-// There may eventually be a better way to do this, but they break with
-// Typescript 4.0.
+// There may eventually be a better way to do this, but
+// thems the breaks with Typescript 4.0.
 /**
  * @callback AssertTypeofBigint
  * @param {any} specimen
  * @param {'bigint'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is bigint}
- *
+ */
+
+/**
  * @callback AssertTypeofBoolean
  * @param {any} specimen
  * @param {'boolean'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is boolean}
- *
+ */
+
+/**
  * @callback AssertTypeofFunction
  * @param {any} specimen
  * @param {'function'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Function}
- *
+ */
+
+/**
  * @callback AssertTypeofNumber
  * @param {any} specimen
  * @param {'number'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is number}
- *
+ */
+
+/**
  * @callback AssertTypeofObject
  * @param {any} specimen
  * @param {'object'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Record<any, any> | null}
- *
+ */
+
+/**
  * @callback AssertTypeofString
  * @param {any} specimen
  * @param {'string'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is string}
- *
+ */
+
+/**
  * @callback AssertTypeofSymbol
  * @param {any} specimen
  * @param {'symbol'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is symbol}
- *
+ */
+
+/**
  * @callback AssertTypeofUndefined
  * @param {any} specimen
  * @param {'undefined'} typename
@@ -824,7 +838,7 @@ freeze(bestEffortStringify);
  */
 
 /**
- * @typedef {Object} StringablePayload
+ * @typedef {object} StringablePayload
  * Holds the payload passed to quote so that its printed form is visible.
  * @property {() => string} toString How to print the payload
  */
@@ -2491,10 +2505,8 @@ const        makeSafeEvaluator=  ({
 
 
 const        provideCompartmentEvaluator=  (compartmentFields, options)=>  {
-  const {
-    sloppyGlobalsMode=  false,
-    __moduleShimLexicals__=  undefined}=
-      options;
+  const { sloppyGlobalsMode=  false, __moduleShimLexicals__=  undefined}=
+    options;
 
   let safeEvaluate;
 
@@ -4287,7 +4299,7 @@ $h‍_once.makeAlias(makeAlias);const resolveAll=(imports,resolveHook,fullReferr
   return freeze(resolvedImports);
  };
 
-const loadRecord=  async(
+const loadRecord=  (
   compartmentPrivateFields,
   moduleAliases,
   compartment,
@@ -4408,27 +4420,64 @@ const loadWithoutErrorAnnotation=  async(
       } in compartment ${q(compartment.name)}`;
    }
 
-  if( staticModuleRecord.record!==  undefined) {
-    const {
-      compartment: aliasCompartment=  compartment,
-      specifier: aliasSpecifier=  moduleSpecifier,
-      record: aliasModuleRecord,
-      importMeta}=
-        staticModuleRecord;
+  // check if record is a RedirectStaticModuleInterface
+  if( staticModuleRecord.specifier!==  undefined) {
+    // check if this redirect with an explicit record
+    if( staticModuleRecord.record!==  undefined) {
+      // ensure expected record shape
+      if( staticModuleRecord.compartment!==  undefined) {
+        throw new TypeError(
+          'Cannot redirect to an explicit record with a specified compartment');
 
-    const aliasRecord=  await loadRecord(
-      compartmentPrivateFields,
-      moduleAliases,
-      aliasCompartment,
-      aliasSpecifier,
-      aliasModuleRecord,
-      pendingJobs,
-      moduleLoads,
-      errors,
-      importMeta);
+       }
+      const {
+        compartment: aliasCompartment=  compartment,
+        specifier: aliasSpecifier=  moduleSpecifier,
+        record: aliasModuleRecord,
+        importMeta}=
+          staticModuleRecord;
 
-    mapSet(moduleRecords, moduleSpecifier, aliasRecord);
-    return aliasRecord;
+      const aliasRecord=  loadRecord(
+        compartmentPrivateFields,
+        moduleAliases,
+        aliasCompartment,
+        aliasSpecifier,
+        aliasModuleRecord,
+        pendingJobs,
+        moduleLoads,
+        errors,
+        importMeta);
+
+      mapSet(moduleRecords, moduleSpecifier, aliasRecord);
+      return aliasRecord;
+     }
+
+    // check if this redirect with an explicit compartment
+    if( staticModuleRecord.compartment!==  undefined) {
+      // ensure expected record shape
+      if( staticModuleRecord.importMeta!==  undefined) {
+        throw new TypeError(
+          'Cannot redirect to an implicit record with a specified importMeta');
+
+       }
+      // Behold: recursion.
+      // eslint-disable-next-line no-use-before-define
+      const aliasRecord=  await memoizedLoadWithErrorAnnotation(
+        compartmentPrivateFields,
+        moduleAliases,
+        staticModuleRecord.compartment,
+        staticModuleRecord.specifier,
+        pendingJobs,
+        moduleLoads,
+        errors);
+
+      mapSet(moduleRecords, moduleSpecifier, aliasRecord);
+      return aliasRecord;
+     }
+
+    throw new TypeError(
+      'Unnexpected RedirectStaticModuleInterface record shape');
+
    }
 
   return loadRecord(
@@ -4871,6 +4920,7 @@ $h‍_once.makeThirdPartyModuleInstance(makeThirdPartyModuleInstance);const make
     __syncModuleProgram__: functorSource,
     __fixedExportMap__: fixedExportMap=  {},
     __liveExportMap__: liveExportMap=  {},
+    __reexportMap__: reexportMap=  {},
     __needsImportMeta__: needsImportMeta=  false}=
       staticModuleRecord;
 
@@ -5124,26 +5174,35 @@ $h‍_once.makeThirdPartyModuleInstance(makeThirdPartyModuleInstance);const make
        }
       if( arrayIncludes(exportAlls, specifier)) {
         // Make all these imports candidates.
-        for( const [importName, importNotify]of  entries(importNotifiers)) {
-          if( candidateAll[importName]===  undefined) {
-            candidateAll[importName]=  importNotify;
+        // Note names don't change in reexporting all
+        for( const [importAndExportName, importNotify]of  entries(
+          importNotifiers))
+           {
+          if( candidateAll[importAndExportName]===  undefined) {
+            candidateAll[importAndExportName]=  importNotify;
            }else {
             // Already a candidate: remove ambiguity.
-            candidateAll[importName]=  false;
+            candidateAll[importAndExportName]=  false;
            }
+         }
+       }
+      if( reexportMap[specifier]) {
+        // Make named reexports candidates too.
+        for( const [localName, exportedName]of  reexportMap[specifier]) {
+          candidateAll[exportedName]=  importNotifiers[localName];
          }
        }
      }
 
-    for( const [importName, notify]of  entries(candidateAll)) {
-      if( !notifiers[importName]&&  notify!==  false) {
-        notifiers[importName]=  notify;
+    for( const [exportName, notify]of  entries(candidateAll)) {
+      if( !notifiers[exportName]&&  notify!==  false) {
+        notifiers[exportName]=  notify;
 
         // exported live binding state
         let value;
         const update=  (newValue)=> value=  newValue;
         notify(update);
-        exportsProps[importName]=  {
+        exportsProps[exportName]=  {
           get() {
             return value;
            },
@@ -5335,12 +5394,8 @@ const        instantiate=  (
   moduleAliases,
   moduleRecord)=>
      {
-  const {
-    compartment,
-    moduleSpecifier,
-    resolvedImports,
-    staticModuleRecord}=
-      moduleRecord;
+  const { compartment, moduleSpecifier, resolvedImports, staticModuleRecord}=
+    moduleRecord;
   const { instances}=   weakmapGet(compartmentPrivateFields, compartment);
 
   // Memoize.
@@ -6593,12 +6648,8 @@ freeze(ErrorInfo);
 
 /** @type {MakeCausalConsole} */
 const makeCausalConsole=  (baseConsole, loggedErrorHandler)=>  {
-  const {
-    getStackString,
-    tagError,
-    takeMessageLogArgs,
-    takeNoteLogArgsArray}=
-      loggedErrorHandler;
+  const { getStackString, tagError, takeMessageLogArgs, takeNoteLogArgsArray}=
+    loggedErrorHandler;
 
   /**
    * @param {ReadonlyArray<any>} logArgs
@@ -7712,8 +7763,10 @@ const        getAnonymousIntrinsics=  ()=>  {
 
   // 9.2.4.1 %ThrowTypeError%
 
-  const ThrowTypeError=  getOwnPropertyDescriptor(makeArguments(), 'callee').
-     get;
+  const ThrowTypeError=  getOwnPropertyDescriptor(
+    makeArguments(),
+    'callee').
+    get;
 
   // 21.1.5.2 The %StringIteratorPrototype% Object
 
@@ -8215,7 +8268,8 @@ function        tameDomains(domainTaming=  'safe') {
 })
 ,
 // === functors[36] ===
-(({   imports: $h‍_imports,   liveVar: $h‍_live,   onceVar: $h‍_once,   importMeta: $h‍____meta,  }) => {   let FERAL_FUNCTION,SyntaxError,TypeError,defineProperties,getPrototypeOf,setPrototypeOf;$h‍_imports([["./commons.js", [["FERAL_FUNCTION", [$h‍_a => (FERAL_FUNCTION = $h‍_a)]],["SyntaxError", [$h‍_a => (SyntaxError = $h‍_a)]],["TypeError", [$h‍_a => (TypeError = $h‍_a)]],["defineProperties", [$h‍_a => (defineProperties = $h‍_a)]],["getPrototypeOf", [$h‍_a => (getPrototypeOf = $h‍_a)]],["setPrototypeOf", [$h‍_a => (setPrototypeOf = $h‍_a)]]]]]);   
+(({   imports: $h‍_imports,   liveVar: $h‍_live,   onceVar: $h‍_once,   importMeta: $h‍____meta,  }) => {   let FERAL_FUNCTION,SyntaxError,TypeError,defineProperties,getPrototypeOf,setPrototypeOf,freeze;$h‍_imports([["./commons.js", [["FERAL_FUNCTION", [$h‍_a => (FERAL_FUNCTION = $h‍_a)]],["SyntaxError", [$h‍_a => (SyntaxError = $h‍_a)]],["TypeError", [$h‍_a => (TypeError = $h‍_a)]],["defineProperties", [$h‍_a => (defineProperties = $h‍_a)]],["getPrototypeOf", [$h‍_a => (getPrototypeOf = $h‍_a)]],["setPrototypeOf", [$h‍_a => (setPrototypeOf = $h‍_a)]],["freeze", [$h‍_a => (freeze = $h‍_a)]]]]]);   
+
 
 
 
@@ -8266,7 +8320,7 @@ function                tameFunctionConstructors() {
     FERAL_FUNCTION.prototype.constructor('return 1');
    }catch( ignore) {
     // Throws, no need to patch.
-    return harden({});
+    return freeze({});
    }
 
   const newIntrinsics=  {};
@@ -8299,7 +8353,7 @@ function                tameFunctionConstructors() {
     // Prevents the evaluation of source when calling constructor on the
     // prototype of functions.
     // eslint-disable-next-line func-names
-    const InertConstructor=  function() {
+    const InertConstructor=  function()  {
       throw new TypeError(
         'Function.prototype.constructor is not a valid constructor.');
 
@@ -8505,9 +8559,8 @@ function                tameMathObject(mathTaming=  'safe') {
   const originalMath=  Math;
   const initialMath=  originalMath; // to follow the naming pattern
 
-  const { random: _, ...otherDescriptors}=   getOwnPropertyDescriptors(
-    originalMath);
-
+  const { random: _, ...otherDescriptors}=
+    getOwnPropertyDescriptors(originalMath);
 
   const sharedMath=  create(objectPrototype, otherDescriptors);
 
@@ -9042,10 +9095,8 @@ const        repairIntrinsics=  (options=  {})=>  {
   // [`stackFiltering` options](https://github.com/Agoric/SES-shim/blob/master/packages/ses/lockdown-options.md#stackfiltering-options)
   // for an explanation.
 
-  const {
-    getEnvironmentOption: getenv,
-    getCapturedEnvironmentOptionNames}=
-      makeEnvironmentCaptor(globalThis);
+  const { getEnvironmentOption: getenv, getCapturedEnvironmentOptionNames}=
+    makeEnvironmentCaptor(globalThis);
 
   const {
     errorTaming=  getenv('LOCKDOWN_ERROR_TAMING', 'safe'),
@@ -9151,11 +9202,8 @@ const        repairIntrinsics=  (options=  {})=>  {
 
   tameDomains(domainTaming);
 
-  const {
-    addIntrinsics,
-    completePrototypes,
-    finalIntrinsics}=
-      makeIntrinsicsCollector();
+  const { addIntrinsics, completePrototypes, finalIntrinsics}=
+    makeIntrinsicsCollector();
 
   addIntrinsics({ harden});
 
@@ -9346,23 +9394,25 @@ assign(globalThis, {
 ,
 ]; // functors end
 
-  function cell(name, value = undefined) {
+  const cell = (name, value = undefined) => {
     const observers = [];
-    function set(newValue) {
-      value = newValue;
-      for (const observe of observers) {
+    return Object.freeze({
+      get: Object.freeze(() => {
+        return value;
+      }),
+      set: Object.freeze((newValue) => {
+        value = newValue;
+        for (const observe of observers) {
+          observe(value);
+        }
+      }),
+      observe: Object.freeze((observe) => {
+        observers.push(observe);
         observe(value);
-      }
-    }
-    function get() {
-      return value;
-    }
-    function observe(observe) {
-      observers.push(observe);
-      observe(value);
-    }
-    return { get, set, observe, enumerable: true };
-  }
+      }),
+      enumerable: true,
+    });
+  };
 
   const cells = [
     {
@@ -9667,23 +9717,24 @@ assign(globalThis, {
   ];
 
 
-  const namespaces = cells.map(cells => Object.create(null, cells));
+  const namespaces = cells.map(cells => Object.freeze(Object.create(null, cells)));
 
   for (let index = 0; index < namespaces.length; index += 1) {
     cells[index]['*'] = cell('*', namespaces[index]);
   }
 
-  function observeImports(map, importName, importIndex) {
-    for (const [name, observers] of map.get(importName)) {
-      const cell = cells[importIndex][name];
-      if (cell === undefined) {
-        throw new ReferenceError(`Cannot import name ${name}`);
-      }
-      for (const observer of observers) {
-        cell.observe(observer);
-      }
+function observeImports(map, importName, importIndex) {
+  for (const [name, observers] of map.get(importName)) {
+    const cell = cells[importIndex][name];
+    if (cell === undefined) {
+      throw new ReferenceError(`Cannot import name ${name}`);
+    }
+    for (const observer of observers) {
+      cell.observe(observer);
     }
   }
+}
+
 
   functors[0]({
     imports(entries) {

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -1,3 +1,5 @@
+// DO NOT EDIT! THIS FILE IS GENERATED FROM "runtime-template.js" BY RUNNING "builder-runtime.js"
+
 ;(function() {
   // this runtime template code is destined to wrap LavaMoat entirely,
   // therefore this is our way of capturing access to basic APIs LavaMoat


### PR DESCRIPTION
When quad-flip was introduced in #394 updating the `runtime-cjs.js` file was forgotten.
That file is used specifically to support running MetaMask under development mode, meaning `yarn start` would produce a broken build (reverted in https://github.com/MetaMask/metamask-extension/pull/17043).

This PR fixes `runtime-cjs.js` to correctly support the changes introduced in #394.
To do so, building `runtime-cjs.js` file was crucial so it would include the contents of the new `strict-scope-terminator.js` file which is crucial for the updated SES lib to work.