### PR TITLE
browserify/test: use yarn link to force workspace deps

### DIFF
--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -34,7 +34,7 @@ module.exports = {
 }
 
 async function copyFolder(from, to, opts = {skip: []}) {
-  await fs.mkdir(to)
+  await fs.mkdir(to, { recursive: true })
   const elements = await fs.readdir(from)
   for (const element of elements) {
     if (opts.skip.includes(element)) {


### PR DESCRIPTION
This fixes a bug where tests will fail if `lavamoat-browserify` specifies a dependency of an unpublished version of a LavaMoat workspace package.

Current behavior:
```
yarn add --network-concurrency 1 -D browserify@^17 ${WORKSPACE_ROOT}/packages/browserify
for pkg in $localDeps; do
  rm -rf ./node_modules/$pkg
  cp -r ${WORKSPACE_ROOT}/packages/$pkg ./node_modules/
done
```

New behavior:
```
for pkg in $localDeps; do
  yarn unlink $pkg.name
  cd ${WORKSPACE_ROOT}/packages/$pkg.dir && yarn link
done
yarn link $localDeps
yarn add --network-concurrency 1 --prefer-offline -D browserify@^17 lavamoat-browserify
```

Example of CI run failing due to this: https://github.com/LavaMoat/LavaMoat/actions/runs/3750080609/jobs/6369329103#step:5:332
