### PR TITLE
Better scuttle regexes preparation

### DIFF
--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -86,6 +86,17 @@
       if (!Array.isArray(scuttleGlobalThisExceptions)) {
         throw new Error(`LavaMoat - scuttleGlobalThisExceptions must be an array, got "${typeof scuttleGlobalThisExceptions}"`)
       }
+      // turn scuttleGlobalThisExceptions regexes strings to actual regexes
+      for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
+        const prop = scuttleGlobalThisExceptions[i]
+        if (!prop.startsWith('/')) {
+          continue
+        }
+        const parts = prop.split('/')
+        const pattern = parts.slice(1, -1).join('/')
+        const flags = parts[parts.length - 1]
+        scuttleGlobalThisExceptions[i] = new RegExp(pattern, flags)
+      }
       performScuttleGlobalThis(globalRef, scuttleGlobalThisExceptions)
     }
 
@@ -104,17 +115,6 @@
       getPrototypeChain(globalRef)
         .forEach(proto =>
           props.push(...Object.getOwnPropertyNames(proto)))
-
-      for (let i = 0; i < extraPropsToAvoid.length; i++) {
-        const prop = extraPropsToAvoid[i]
-        if (!prop.startsWith('/')) {
-          continue
-        }
-        const parts = prop.split('/')
-        const pattern = parts.slice(1, -1).join('/')
-        const flags = parts[parts.length - 1]
-        extraPropsToAvoid[i] = new RegExp(pattern, flags)
-      }
 
       // support LM,SES exported APIs and polyfills
       const avoidForLavaMoatCompatibility = ['Compartment', 'Error', 'globalThis']

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11153,6 +11153,17 @@ module.exports = {
       if (!Array.isArray(scuttleGlobalThisExceptions)) {
         throw new Error(`LavaMoat - scuttleGlobalThisExceptions must be an array, got "${typeof scuttleGlobalThisExceptions}"`)
       }
+      // turn scuttleGlobalThisExceptions regexes strings to actual regexes
+      for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
+        const prop = scuttleGlobalThisExceptions[i]
+        if (!prop.startsWith('/')) {
+          continue
+        }
+        const parts = prop.split('/')
+        const pattern = parts.slice(1, -1).join('/')
+        const flags = parts[parts.length - 1]
+        scuttleGlobalThisExceptions[i] = new RegExp(pattern, flags)
+      }
       performScuttleGlobalThis(globalRef, scuttleGlobalThisExceptions)
     }
 
@@ -11171,17 +11182,6 @@ module.exports = {
       getPrototypeChain(globalRef)
         .forEach(proto =>
           props.push(...Object.getOwnPropertyNames(proto)))
-
-      for (let i = 0; i < extraPropsToAvoid.length; i++) {
-        const prop = extraPropsToAvoid[i]
-        if (!prop.startsWith('/')) {
-          continue
-        }
-        const parts = prop.split('/')
-        const pattern = parts.slice(1, -1).join('/')
-        const flags = parts[parts.length - 1]
-        extraPropsToAvoid[i] = new RegExp(pattern, flags)
-      }
 
       // support LM,SES exported APIs and polyfills
       const avoidForLavaMoatCompatibility = ['Compartment', 'Error', 'globalThis']


### PR DESCRIPTION
Soon we'd want to pass the scuttling function to Snow to scuttle all realms.
The preparation of the exceptions array should only happen once, but with Snow it happens multiple times.
To fix this, we take the preparation part out of the scuttling function so it would only happen once.
Later, we'll pass the scuttling function to Snow, now that it doesn't do preparation anymore.