### PR TITLE
node: yarn test:prep: force NODE_ENV=development for test projects setup

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "test": "yarn test:prep && yarn test:run",
-    "test:prep": "for d in ./test/projects/*/ ; do (cd \"$d\" && yarn setup && ../../../src/cli.js -a index.js); done",
+    "test:prep": "for d in ./test/projects/*/ ; do (cd \"$d\" && NODE_ENV=development yarn setup && ../../../src/cli.js -a index.js); done",
     "test:run": "ava --timeout=30s test/index.js",
     "lint": "yarn lint:eslint && yarn lint:deps",
     "lint:eslint": "eslint .",


### PR DESCRIPTION
Without this, lavamoat-node tests will fail if `test:prep` has been run with `NODE_ENV=production`.