### PR TITLE
Release browserify-lavapack v4.0.0

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.16.7",
     "@lavamoat/aa": "^3.1.0",
-    "@lavamoat/lavapack": "^3.3.0",
+    "@lavamoat/lavapack": "^4.0.0",
     "browser-resolve": "^2.0.0",
     "concat-stream": "^2.0.0",
     "convert-source-map": "^1.8.0",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/lavapack",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "LavaMoat packer",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- generate runtime (https://github.com/LavaMoat/LavaMoat/pull/437)
- Preliminary support for SES quad-flip update in runtime cjs generation to adjust with (https://github.com/LavaMoat/LavaMoat/pull/436)
- code quality improvement in scuttle regexes (https://github.com/LavaMoat/LavaMoat/pull/443)

Major version bump due to nodejs v12 deprecation in https://github.com/LavaMoat/LavaMoat/commit/cee9caf3fd39bb943c9b0437f5bfe1a0982bdaa8