### PR TITLE
Scuttle writables too in addition to configurables

### DIFF
--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -120,33 +120,29 @@
       const avoidForLavaMoatCompatibility = ['Compartment', 'Error', 'globalThis']
       const propsToAvoid = new Set([...avoidForLavaMoatCompatibility, ...extraPropsToAvoid])
 
+      const obj = Object.create(null)
       for (const prop of props) {
+        function set() {
+          console.warn(
+            `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
+            'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+          )
+        }
+        function get() {
+          throw new Error(
+            `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
+            'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+          )
+        }
         if (shouldAvoidProp(propsToAvoid, prop)) {
           continue
         }
         let desc = Object.getOwnPropertyDescriptor(globalRef, prop)
         if (desc?.configurable === true) {
-          desc = {
-            configurable: false,
-            set: () => {
-              console.warn(
-                `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
-                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-              )
-            },
-            get: () => {
-              throw new Error(
-                `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
-                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-              )
-            },
-          }
+          desc = { configurable: false, set, get }
         } else if (desc?.writable === true) {
-          desc = {
-            configurable: false,
-            writable: false,
-            value: undefined,
-          }
+          const p = new Proxy(obj, { getPrototypeOf: get, get, set } )
+          desc = { configurable: false, writable: false, value: p }
         } else {
           continue
         }

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -124,23 +124,31 @@
         if (shouldAvoidProp(propsToAvoid, prop)) {
           continue
         }
-        if (Object.getOwnPropertyDescriptor(globalRef, prop)?.configurable === false) {
+        let desc = Object.getOwnPropertyDescriptor(globalRef, prop)
+        if (desc?.configurable === true) {
+          desc = {
+            configurable: false,
+            set: () => {
+              console.warn(
+                `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
+                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+              )
+            },
+            get: () => {
+              throw new Error(
+                `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
+                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+              )
+            },
+          }
+        } else if (desc?.writable === true) {
+          desc = {
+            configurable: false,
+            writable: false,
+            value: undefined,
+          }
+        } else {
           continue
-        }
-        const desc = {
-          set: () => {
-            console.warn(
-              `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
-              'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-            )
-          },
-          get: () => {
-            throw new Error(
-              `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
-              'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-            )
-          },
-          configurable: false,
         }
         Object.defineProperty(globalRef, prop, desc)
       }

--- a/packages/lavapack/src/runtime-template.js
+++ b/packages/lavapack/src/runtime-template.js
@@ -5,6 +5,7 @@
   const {
     RegExp,
     Reflect,
+    Proxy,
     Object,
     Error,
     Array,

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11191,23 +11191,31 @@ module.exports = {
         if (shouldAvoidProp(propsToAvoid, prop)) {
           continue
         }
-        if (Object.getOwnPropertyDescriptor(globalRef, prop)?.configurable === false) {
+        let desc = Object.getOwnPropertyDescriptor(globalRef, prop)
+        if (desc?.configurable === true) {
+          desc = {
+            configurable: false,
+            set: () => {
+              console.warn(
+                `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
+                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+              )
+            },
+            get: () => {
+              throw new Error(
+                `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
+                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+              )
+            },
+          }
+        } else if (desc?.writable === true) {
+          desc = {
+            configurable: false,
+            writable: false,
+            value: undefined,
+          }
+        } else {
           continue
-        }
-        const desc = {
-          set: () => {
-            console.warn(
-              `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
-              'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-            )
-          },
-          get: () => {
-            throw new Error(
-              `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
-              'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-            )
-          },
-          configurable: false,
         }
         Object.defineProperty(globalRef, prop, desc)
       }

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -7,6 +7,7 @@
   const {
     RegExp,
     Reflect,
+    Proxy,
     Object,
     Error,
     Array,
@@ -11187,33 +11188,29 @@ module.exports = {
       const avoidForLavaMoatCompatibility = ['Compartment', 'Error', 'globalThis']
       const propsToAvoid = new Set([...avoidForLavaMoatCompatibility, ...extraPropsToAvoid])
 
+      const obj = Object.create(null)
       for (const prop of props) {
+        function set() {
+          console.warn(
+            `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
+            'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+          )
+        }
+        function get() {
+          throw new Error(
+            `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
+            'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
+          )
+        }
         if (shouldAvoidProp(propsToAvoid, prop)) {
           continue
         }
         let desc = Object.getOwnPropertyDescriptor(globalRef, prop)
         if (desc?.configurable === true) {
-          desc = {
-            configurable: false,
-            set: () => {
-              console.warn(
-                `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
-                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-              )
-            },
-            get: () => {
-              throw new Error(
-                `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
-                'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
-              )
-            },
-          }
+          desc = { configurable: false, set, get }
         } else if (desc?.writable === true) {
-          desc = {
-            configurable: false,
-            writable: false,
-            value: undefined,
-          }
+          const p = new Proxy(obj, { getPrototypeOf: get, get, set } )
+          desc = { configurable: false, writable: false, value: p }
         } else {
           continue
         }


### PR DESCRIPTION
Apparently there are properties on the global object that are `configurable:false` but `writable:true`.
We can scuttle those with a value instead of a getter and by that enhance our scuttling capabilities beyond current state.
For example, this PR will successfully scuttle `window.chrome`. 