### PR TITLE
core/version - 14.0.0

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -19,7 +19,7 @@
     "convert-source-map": "^1.8.0",
     "duplexify": "^4.1.1",
     "json-stable-stringify": "^1.0.1",
-    "lavamoat-core": "^13.0.0",
+    "lavamoat-core": "^14.0.0",
     "pify": "^4.0.1",
     "readable-stream": "^3.6.0",
     "source-map": "^0.7.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-core",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "LavaMoat kernel and utils",
   "main": "src/index.js",
   "directories": {

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -14,7 +14,7 @@
     "combine-source-map": "^0.8.0",
     "convert-source-map": "^1.7.0",
     "json-stable-stringify": "^1.0.1",
-    "lavamoat-core": "^13.0.0",
+    "lavamoat-core": "^14.0.0",
     "readable-stream": "^3.6.0",
     "through2": "^4.0.2",
     "umd": "^3.0.3"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,7 +23,7 @@
     "bindings": "^1.5.0",
     "htmlescape": "^1.1.1",
     "json-stable-stringify": "^1.0.1",
-    "lavamoat-core": "^13.0.0",
+    "lavamoat-core": "^14.0.0",
     "lavamoat-tofu": "^6.0.2",
     "node-gyp-build": "^4.2.3",
     "object.fromentries": "^2.0.2",


### PR DESCRIPTION
- Scuttle writables too in addition to configurables (#453)

Major version bump due to breaking change #453

bumped internal dependents to lavamoat-core@^14.0.0
- node
- lavapack
- browserify