### PR TITLE
lavapack/version - 5.0.0

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.16.7",
     "@lavamoat/aa": "^3.1.0",
-    "@lavamoat/lavapack": "^4.0.0",
+    "@lavamoat/lavapack": "^5.0.0",
     "browser-resolve": "^2.0.0",
     "concat-stream": "^2.0.0",
     "convert-source-map": "^1.8.0",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/lavapack",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "LavaMoat packer",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- Scuttle writables too in addition to configurables (#453)

Major version bump due to breaking change #453

bumped internal dependents to @lavamoat/lavapack@^5.0.0
- browserify