### PR TITLE
Deprecate `global`,`self` as aliases for `globalThis`

### DIFF
--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -23,13 +23,19 @@
     } = __lavamoatSecurityOptions__
 
     // identify the globalRef
-    const globalRef = (typeof globalThis !== 'undefined') ? globalThis : (typeof self !== 'undefined') ? self : (typeof global !== 'undefined') ? global : undefined
+    let globalRef = globalThis
+
     if (!globalRef) {
-      throw new Error('Lavamoat - unable to identify globalRef')
+      globalRef = self || global
+      if (!globalRef) {
+        throw new Error('Lavamoat - globalThis not defined')
+      }
+
+      console.error('LavaMoat - Deprecation Warning: global reference is expected as `globalThis`')
     }
 
     // polyfill globalThis
-    if (globalRef && !globalRef.globalThis) {
+    if (!globalRef.globalThis) {
       globalRef.globalThis = globalRef
     }
 


### PR DESCRIPTION
Context: https://github.com/LavaMoat/LavaMoat/pull/458#discussion_r1105144911

> `globalThis` was not common early in lavamoat's history. it may be prevalent enough to remove

This logs a deprecation warning if the fallbacks are being used, with intention for full removal likely in the next release.