### PR TITLE
ci/nodejs: lint before test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: yarn --frozen-lockfile --ignore-scripts
-      - name: Test
-        run: yarn test
       - name: Lint
         run: yarn lint
+      - name: Test
+        run: yarn test


### PR DESCRIPTION
Linting is a lot faster; this should tighten the feedback loop on average.