### PR TITLE
Fix uncaught error when receiver is null in `getPropertyDescriptorDeep`

### DIFF
--- a/packages/core/src/makeGetEndowmentsForConfig.js
+++ b/packages/core/src/makeGetEndowmentsForConfig.js
@@ -239,6 +239,10 @@ function makeGetEndowmentsForConfig ({ createFunctionWrapper }) {
 function getPropertyDescriptorDeep (target, key) {
   let receiver = target
   while (true) {
+    // abort if this is the end of the prototype chain.
+    if (!receiver) {
+      return { prop: null, receiver: null }
+    }
     // support lookup on objects and primitives
     const typeofReceiver = typeof receiver
     if (typeofReceiver === 'object' || typeofReceiver === 'function') {
@@ -252,10 +256,6 @@ function getPropertyDescriptorDeep (target, key) {
       // prototype lookup for primitives
       // eslint-disable-next-line no-proto
       receiver = receiver.__proto__
-    }
-    // abort if this is the end of the prototype chain.
-    if (!receiver) {
-      return { prop: null, receiver: null }
     }
   }
 }


### PR DESCRIPTION
Fixes an uncaught error when `receiver` is null in `getPropertyDescriptorDeep`, by simply validating that `receiver` is a truthy value before trying to call `getOwnPropertyDescriptor`.