### PR TITLE
Avoid calling crashing descriptors in sandboxed frames

### DIFF
--- a/packages/browserify/examples/01-simple-js/build.js
+++ b/packages/browserify/examples/01-simple-js/build.js
@@ -4,6 +4,7 @@ const browserify = require('browserify')
 // configure LavaMoat
 const lavamoatOpts = {
   writeAutoPolicy: false,
+  sandboxedIframeMode: false,
   scuttleGlobalThis: true,
   scuttleGlobalThisExceptions: ['print', /HTML[a-zA-Z]*Element/, 'prompt'],
 }

--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -119,6 +119,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
   }
 
   const nonAliasedOptions = [
+    'sandboxedIframeMode',
     'scuttleGlobalThis',
     'scuttleGlobalThisExceptions',
     'bundleWithPrecompiledModules',
@@ -158,6 +159,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
     pruneConfig: Boolean(pluginOpts.prunePolicy),
     debugMode: Boolean(pluginOpts.debugMode),
     statsMode: Boolean(pluginOpts.statsMode),
+    sandboxedIframeMode: Boolean(pluginOpts.sandboxedIframeMode),
     scuttleGlobalThis: pluginOpts.scuttleGlobalThis,
     scuttleGlobalThisExceptions: pluginOpts.scuttleGlobalThisExceptions,
     writeAutoPolicy: Boolean(pluginOpts.writeAutoPolicy || pluginOpts.writeAutoPolicyDebug),

--- a/packages/browserify/test/runScenarios.js
+++ b/packages/browserify/test/runScenarios.js
@@ -6,8 +6,8 @@ const { runAndTestScenario } = require('lavamoat-core/test/util')
 test('Run scenarios with precompiled modules', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Browserify Scenario: ${scenario.name}`)
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
-    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
+    const {sandboxedIframeMode, scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
+    const additionalOpts = {sandboxedIframeMode, scuttleGlobalThis, scuttleGlobalThisExceptions}
     await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
   }
 })

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -41,7 +41,7 @@ function generateKernel (opts = {}) {
   if (opts.hasOwnProperty('scuttleGlobalThis')) {
     // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
+    const {sandboxedIframeMode, scuttleGlobalThis, scuttleGlobalThisExceptions} = opts
     if (scuttleGlobalThisExceptions) {
       // toString regexps if there's any
       for (let i = 0; i < scuttleGlobalThisExceptions.length; i++) {
@@ -49,6 +49,7 @@ function generateKernel (opts = {}) {
       }
     }
     output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
+      sandboxedIframeMode,
       scuttleGlobalThis,
       scuttleGlobalThisExceptions,
     }))

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -459,6 +459,14 @@
 
       // sets up read/write access as configured
       const globalsConfig = packagePolicy.globals
+      for (const desc in globalsConfig) {
+        if (skipDescCallIgnoreList.includes(desc)) {
+          if (globalsConfig.hasOwnProperty(desc)) {
+            globalsConfig[desc] = false
+          }
+        }
+      }
+
       prepareCompartmentGlobalFromConfig(packageCompartment, globalsConfig, endowments, globalStore, globalThisRefs)
 
       // save the compartment for use by other modules in the package

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -378,9 +378,7 @@
       // call on contents of endowmentsSources directly instead of in new array instances. If there is a lazy getter it only changes the original prop desc.
       endowmentSources.forEach(source => {
         const descriptors = Object.getOwnPropertyDescriptors(source)
-        Object.entries(descriptors)
-          .filter(([name]) => !sandboxedIframeMode || !sandboxedIframeForbiddenDescs.includes(name))
-          .forEach(([_, desc]) => {
+        Object.entries(descriptors).filter(([name]) => !sandboxedIframeMode || !sandboxedIframeForbiddenDescs.includes(name)).forEach(([_, desc]) => {
           if ('get' in desc) {
             Reflect.apply(desc.get, globalRef, [])
           }

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -18,6 +18,7 @@
     } = __lavamoatDebugOptions__
     // security options are hard-coded at build time
     const {
+      sandboxedIframeMode,
       scuttleGlobalThis,
       scuttleGlobalThisExceptions,
     } = __lavamoatSecurityOptions__
@@ -69,6 +70,7 @@
       getExternalCompartment,
       globalRef,
       globalThisRefs,
+      sandboxedIframeMode,
       scuttleGlobalThis,
       scuttleGlobalThisExceptions,
       debugMode,

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -57,6 +57,7 @@ function createPacker({
   sourceRoot,
   sourceMapPrefix,
   bundleWithPrecompiledModules = true,
+  sandboxedIframeMode = false,
   scuttleGlobalThis = false,
   scuttleGlobalThisExceptions = [],
 } = {}) {
@@ -64,10 +65,10 @@ function createPacker({
   const parser = raw ? through.obj() : JSONStream.parse([true])
   const stream = through.obj(
     function (buf, _, next) {
-      parser.write(buf); next() 
+      parser.write(buf); next()
     },
     function () {
-      parser.end() 
+      parser.end()
     },
   )
 
@@ -92,6 +93,7 @@ function createPacker({
   }
 
   prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({
+    sandboxedIframeMode,
     scuttleGlobalThis,
     scuttleGlobalThisExceptions,
   }))
@@ -164,7 +166,7 @@ function createPacker({
       stream.push(generateBundleLoaderInitial())
     }
     entryFiles = entryFiles.filter(function (x) {
-      return x !== undefined 
+      return x !== undefined
     })
 
     // filter the policy removing packages that arent included
@@ -197,7 +199,7 @@ function createPacker({
       if (sourceMapPrefix) {
         comment = comment.replace(
           /^\/\/#/, function () {
-            return sourceMapPrefix 
+            return sourceMapPrefix
           },
         )
       }

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11533,6 +11533,14 @@ module.exports = {
 
       // sets up read/write access as configured
       const globalsConfig = packagePolicy.globals
+      for (const desc in globalsConfig) {
+        if (skipDescCallIgnoreList.includes(desc)) {
+          if (globalsConfig.hasOwnProperty(desc)) {
+            globalsConfig[desc] = false
+          }
+        }
+      }
+
       prepareCompartmentGlobalFromConfig(packageCompartment, globalsConfig, endowments, globalStore, globalThisRefs)
 
       // save the compartment for use by other modules in the package

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11453,9 +11453,7 @@ module.exports = {
       // call on contents of endowmentsSources directly instead of in new array instances. If there is a lazy getter it only changes the original prop desc.
       endowmentSources.forEach(source => {
         const descriptors = Object.getOwnPropertyDescriptors(source)
-        Object.entries(descriptors)
-          .filter(([name]) => !sandboxedIframeMode || !sandboxedIframeForbiddenDescs.includes(name))
-          .forEach(([_, desc]) => {
+        Object.entries(descriptors).filter(([name]) => !sandboxedIframeMode || !sandboxedIframeForbiddenDescs.includes(name)).forEach(([_, desc]) => {
           if ('get' in desc) {
             Reflect.apply(desc.get, globalRef, [])
           }

--- a/packages/node/src/kernel.js
+++ b/packages/node/src/kernel.js
@@ -18,7 +18,7 @@ function createKernel ({ projectRoot, lavamoatPolicy, canonicalNameMap, debugMod
   const { resolutions } = lavamoatPolicy
   const getRelativeModuleId = createModuleResolver({ projectRoot, resolutions, canonicalNameMap })
   const loadModuleData = createModuleLoader({ canonicalNameMap })
-  const kernelSrc = generateKernel({ debugMode, scuttleGlobalThis, scuttleGlobalThisExceptions })
+  const kernelSrc = generateKernel({ debugMode, sandboxedIframeMode: false, scuttleGlobalThis, scuttleGlobalThisExceptions })
   const createKernel = evaluateWithSourceUrl('LavaMoat/node/kernel', kernelSrc)
   const reportStatsHook = statsMode ? makeInitStatsHook({ onStatsReady }) : noop
   const kernel = createKernel({


### PR DESCRIPTION
Discovered by @FrederikBolding , LavaMoat runtime causes an exception when is executed on a realm of a frame with a "sandbox" attribute. That's because LavaMoat tries to call all descriptors getters it can find of the global object, and that crashes for shared storage APIs in sandboxed frames due to security.

For those specific descriptors, we don't need that - this PR ignores those props.