### PR TITLE
core: fix globalThis polyfill

### DIFF
--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -25,13 +25,15 @@
     // identify the globalRef
     let globalRef = globalThis
 
-    if (!globalRef) {
-      globalRef = self || global
-      if (!globalRef) {
-        throw new Error('Lavamoat - globalThis not defined')
-      }
+    if (typeof globalRef === 'undefined') {
+      globalRef = typeof self !== 'undefined' ? self : global
 
-      console.error('LavaMoat - Deprecation Warning: global reference is expected as `globalThis`')
+      if (typeof globalRef !== 'undefined') {
+        console.error('LavaMoat - Deprecation Warning: global reference is expected as `globalThis`')
+      }
+    }
+    if (!globalRef) {
+      throw new Error('Lavamoat - globalThis not defined')
     }
 
     // polyfill globalThis

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -26,7 +26,7 @@
     let globalRef = globalThis
 
     if (typeof globalRef === 'undefined') {
-      globalRef = typeof self !== 'undefined' ? self : global
+      globalRef = typeof self !== 'undefined' ? self : (typeof global !== 'undefined' ? global : undefined) 
 
       if (typeof globalRef !== 'undefined') {
         console.error('LavaMoat - Deprecation Warning: global reference is expected as `globalThis`')


### PR DESCRIPTION
Motivation: https://github.com/LavaMoat/LavaMoat/pull/459#issuecomment-1457347132

> we are now uttering possibly undefined vars without a typeof operator. this would throw in strict mode. 

This reverts to using `typeof` 