### PR TITLE
Wrap getters calling with try catch to avoid unhandled errors

### DIFF
--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -374,7 +374,10 @@
         const descriptors = Object.getOwnPropertyDescriptors(source)
         Object.values(descriptors).forEach(desc => {
           if ('get' in desc) {
-            Reflect.apply(desc.get, globalRef, [])
+            try {
+              // calling getters can potentially throw (e.g. localStorage inside a sandboxed iframe)
+              Reflect.apply(desc.get, globalRef, [])
+            } catch {}
           }
         })
       })

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11448,7 +11448,10 @@ module.exports = {
         const descriptors = Object.getOwnPropertyDescriptors(source)
         Object.values(descriptors).forEach(desc => {
           if ('get' in desc) {
-            Reflect.apply(desc.get, globalRef, [])
+            try {
+              // calling getters can potentially throw (e.g. localStorage inside a sandboxed iframe)
+              Reflect.apply(desc.get, globalRef, [])
+            } catch {}
           }
         })
       })


### PR DESCRIPTION
Calling getters might throw and we need to catch there errors so the program will continue to execute ([ctx](https://github.com/LavaMoat/LavaMoat/pull/464#issue-1612466023))