### PR TITLE
Fix test scenario creation

### DIFF
--- a/packages/browserify/test/runScenarios.js
+++ b/packages/browserify/test/runScenarios.js
@@ -6,9 +6,7 @@ const { runAndTestScenario } = require('lavamoat-core/test/util')
 test('Run scenarios with precompiled modules', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Browserify Scenario: ${scenario.name}`)
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
-    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario }))
   }
 })
 

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -135,12 +135,11 @@ function evalBundle (bundle, context) {
 async function runBrowserify ({
   scenario,
   bundleWithPrecompiledModules = true,
-  ...additionalOpts
 }) {
-  if (additionalOpts?.scuttleGlobalThisExceptions) {
+  if (scenario?.opts?.scuttleGlobalThisExceptions) {
     // toString regexps if there's any
-    for (let i = 0; i < additionalOpts.scuttleGlobalThisExceptions.length; i++) {
-      additionalOpts.scuttleGlobalThisExceptions[i] = String(additionalOpts.scuttleGlobalThisExceptions[i])
+    for (let i = 0; i < scenario.opts.scuttleGlobalThisExceptions.length; i++) {
+      scenario.opts.scuttleGlobalThisExceptions[i] = String(scenario.opts.scuttleGlobalThisExceptions[i])
     }
   }
   const lavamoatParams = {
@@ -148,7 +147,6 @@ async function runBrowserify ({
     opts: {
       bundleWithPrecompiledModules,
       ...scenario.opts,
-      ...additionalOpts,
     },
     policy: scenario.config,
     policyOverride: scenario.configOverride,
@@ -208,7 +206,6 @@ async function prepareBrowserifyScenarioOnDisk ({ scenario }) {
 async function createBundleForScenario ({
   scenario,
   bundleWithPrecompiledModules = true,
-  ...additonalOpts
 }) {
   let policy
   if (!scenario.dir) {
@@ -219,7 +216,7 @@ async function createBundleForScenario ({
     policy = path.join(scenario.dir, `/lavamoat/browserify/`)
   }
 
-  const { output: { stdout: bundle, stderr } } = await runBrowserify({ scenario, bundleWithPrecompiledModules, ...additonalOpts })
+  const { output: { stdout: bundle, stderr } } = await runBrowserify({ scenario, bundleWithPrecompiledModules })
   if (stderr.length) {
     console.warn(stderr)
   }
@@ -230,13 +227,11 @@ async function runScenario ({
   scenario,
   bundle,
   runWithPrecompiledModules = true,
-  ...additonalOpts
 }) {
   if (!bundle) {
     const { bundleForScenario } = await createBundleForScenario({
       scenario,
       bundleWithPrecompiledModules: runWithPrecompiledModules,
-      ...additonalOpts
     })
     bundle = bundleForScenario
     await fs.writeFile(path.join(scenario.dir, 'bundle.js'), bundle)

--- a/packages/core/test/runScenarios.js
+++ b/packages/core/test/runScenarios.js
@@ -5,17 +5,13 @@ const { runScenario, runAndTestScenario } = require('./util')
 test('Run scenarios', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Core Scenario: ${scenario.name}`)
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
-    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario }))
   }
 })
 
 test('Run scenarios with precompiled intializer', async (t) => {
   for await (const scenario of loadScenarios()) {
     console.log(`Running Core Scenario: ${scenario.name}`)
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
-    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions, runWithPrecompiledModules: true}
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, ...additionalOpts }))
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, runWithPrecompiledModules: true }))
   }
 })

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -17,8 +17,10 @@ module.exports = [
       name: 'scuttle - host env global object is scuttled to work',
       defineOne: one,
       expectedResult: Math.PI,
-      scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', /[0-9]+/, 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
+      opts: {
+        scuttleGlobalThis: true,
+        scuttleGlobalThisExceptions: ['process', /[0-9]+/, 'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'],
+      },
     })
     await autoConfigForScenario({ scenario })
     return scenario
@@ -27,8 +29,10 @@ module.exports = [
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is too scuttled to work',
       defineOne: one,
-      scuttleGlobalThis: true,
-      scuttleGlobalThisExceptions: ['process', '/[0-9]+/', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
+      opts: {
+        scuttleGlobalThis: true,
+        scuttleGlobalThisExceptions: ['process', '/[0-9]+/', /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/],
+      },
       expectedFailure: true,
       expectedFailureMessageRegex: /SES_UNHANDLED_REJECTION|inaccessible under scuttling mode./,
     })

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -75,8 +75,6 @@ function createScenarioFromScaffold ({
   },
   expectedFailure = false,
   expectedFailureMessageRegex = /[\s\S]*/,
-  scuttleGlobalThis = false,
-  scuttleGlobalThisExceptions = [],
   files = [],
   builtin = {},
   context = {},
@@ -223,8 +221,6 @@ function createScenarioFromScaffold ({
     expectedResult,
     expectedFailure,
     expectedFailureMessageRegex,
-    scuttleGlobalThis,
-    scuttleGlobalThisExceptions,
     entries: ['entry.js'],
     files: _files,
     config: _config,
@@ -265,8 +261,6 @@ function createHookedConsole () {
 async function runScenario ({
   scenario,
   runWithPrecompiledModules = false,
-  scuttleGlobalThis = false,
-  scuttleGlobalThisExceptions = [],
 }) {
   const {
     entries,
@@ -275,9 +269,11 @@ async function runScenario ({
     configOverride,
     builtin,
     kernelArgs = {},
+    opts = {},
     beforeCreateKernel = () => {}
 } = scenario
   const lavamoatConfig = mergeDeep(config, configOverride)
+  const { scuttleGlobalThis, scuttleGlobalThisExceptions } = opts
   const kernelSrc = generateKernel({ scuttleGlobalThis, scuttleGlobalThisExceptions })
   const { hookedConsole, firstLogEventPromise } = createHookedConsole()
   Object.assign(scenario.context, { console: hookedConsole })

--- a/packages/node/test/runScenarios.js
+++ b/packages/node/test/runScenarios.js
@@ -7,8 +7,6 @@ test('Run scenarios', async (t) => {
   for await (const scenario of loadScenarios()) {
     if (!(Object.keys(scenario.context).length === 0 && scenario.context.constructor === Object)) continue
     console.log(`Running Node Scenario: ${scenario.name}`)
-    const {scuttleGlobalThis, scuttleGlobalThisExceptions} = scenario
-    const additionalOpts = {scuttleGlobalThis, scuttleGlobalThisExceptions}
-    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario, additionalOpts }))
+    await runAndTestScenario(t, scenario, ({ scenario }) => runScenario({ scenario }))
   }
 })

--- a/packages/node/test/util.js
+++ b/packages/node/test/util.js
@@ -20,13 +20,13 @@ function setOptToArgs(args, key, value) {
   }
 }
 
-function convertOptsToArgs ({ scenario, additionalOpts = {} }) {
+function convertOptsToArgs ({ scenario }) {
   const { entries, opts } = scenario
   if (entries.length !== 1) throw new Error('LavaMoat - invalid entries')
   const firstEntry = entries[0]
   const args = [firstEntry]
   Object
-    .entries({ ...opts, ...additionalOpts })
+    .entries(opts)
     .forEach(([key, value]) => setOptToArgs(args, key, value))
   return args
 }
@@ -37,9 +37,9 @@ async function runLavamoat ({ args = [], cwd = process.cwd() } = {}) {
   return { output }
 }
 
-async function runScenario ({ scenario, additionalOpts }) {
+async function runScenario ({ scenario }) {
   const { projectDir } = await prepareScenarioOnDisk({ scenario, policyName: 'node' })
-  const args = convertOptsToArgs({ scenario, additionalOpts })
+  const args = convertOptsToArgs({ scenario })
   const { output: { stdout, stderr } } = await runLavamoat({ args, cwd: projectDir })
   let result
   if (stderr) {


### PR DESCRIPTION
A long time ago I added `additionalOpts` to move across arguments such as scuttling related stuff.
It was a mistake, these arguments can (and should) be integrated into the `scenario` object.
This PR fixes this (which will also help with #462)