### PR TITLE
Snow scuttling integration updates (#462)

### DIFF
--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -120,6 +120,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
 
   const nonAliasedOptions = [
     'scuttleGlobalThis',
+    'scuttleGlobalThisExceptions',
     'bundleWithPrecompiledModules',
     'policyDebug',
     'projectRoot',
@@ -149,6 +150,13 @@ function getConfigurationFromPluginOpts (pluginOpts) {
 
   if (!pluginOpts.projectRoot) {
     pluginOpts.projectRoot = process.cwd()
+  }
+
+  if (pluginOpts.scuttleGlobalThisExceptions) {
+    console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
+    if (!pluginOpts.scuttleGlobalThis || !pluginOpts.scuttleGlobalThis.length) {
+      pluginOpts.scuttleGlobalThis.exceptions = pluginOpts.scuttleGlobalThisExceptions
+    }
   }
 
   const configuration = {

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -38,11 +38,15 @@ function generateKernel (opts = {}) {
   output = replaceTemplateRequire(output, 'ses', sesSrc)
   output = stringReplace(output, '__createKernelCore__', kernelCode)
   output = stringReplace(output, '__lavamoatDebugOptions__', JSON.stringify({debugMode: !!opts.debugMode}))
-  if (opts.hasOwnProperty('scuttleGlobalThis')) {
+  if (opts && opts.hasOwnProperty('scuttleGlobalThis')) {
     // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
-    const scuttleGlobalThis = opts?.scuttleGlobalThis
-    const exceptions = scuttleGlobalThis?.exceptions
+    const scuttleGlobalThis = opts.scuttleGlobalThis
+    if (opts.scuttleGlobalThisExceptions) {
+      console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
+    }
+    const exceptions = scuttleGlobalThis?.exceptions || opts.scuttleGlobalThisExceptions
+    scuttleGlobalThis.exceptions = exceptions
     if (exceptions) {
       // toString regexps if there's any
       for (let i = 0; i < exceptions.length; i++) {

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -79,19 +79,17 @@
     const {
       enabled: scuttleGlobalThisEnabled,
       exceptions: scuttleGlobalThisExceptions,
-      recursive: scuttleGlobalThisRecursive,
+      onLoad: onLoadHandle,
     } = scuttleGlobalThis === true ? scuttleGlobalThisDefaults : scuttleGlobalThis
 
-    let snow = (cb, win) => cb(win)
-    if (scuttleGlobalThisRecursive) {
-      if (!globalRef.SNOW) {
+    let onLoad = (cb, global) => cb(global)
+    if (onLoadHandle) {
+      if (typeof globalRef[onLoadHandle] !== 'function') {
         throw new Error(
-          'LavaMoat - scuttleGlobalThis is configured to be enabled recursively. ' +
-          'For that, Snow-JS must be included before LavaMoat executes. ' +
-          'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/462.',
+          'LavaMoat - `onLoad` function "${onLoadHandle}" expected on globalRef.',
         )
       }
-      snow = globalRef.SNOW
+      onLoad = globalRef[onLoadHandle]
     }
 
     const moduleCache = new Map()
@@ -117,7 +115,7 @@
         const flags = parts[parts.length - 1]
         scuttleGlobalThisExceptions[i] = new RegExp(pattern, flags)
       }
-      snow(realm => performScuttleGlobalThis(realm, scuttleGlobalThisExceptions), globalRef)
+      onLoad(realm => performScuttleGlobalThis(realm, scuttleGlobalThisExceptions), globalRef)
     }
 
     const kernel = {

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -58,6 +58,7 @@ function createPacker({
   sourceMapPrefix,
   bundleWithPrecompiledModules = true,
   scuttleGlobalThis = {},
+  scuttleGlobalThisExceptions,
 } = {}) {
   // stream/parser wrapping incase raw: false
   const parser = raw ? through.obj() : JSONStream.parse([true])
@@ -86,7 +87,12 @@ function createPacker({
   assert(policy, 'must specify a policy')
 
   // toString regexps if there's any
-  const exceptions = scuttleGlobalThis?.exceptions
+  if (scuttleGlobalThisExceptions) {
+    console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
+  }
+  const exceptions = scuttleGlobalThis.exceptions || scuttleGlobalThisExceptions
+  scuttleGlobalThis.exceptions = exceptions
+
   if (exceptions) {
     for (let i = 0; i < exceptions.length; i++) {
       exceptions[i] = String(exceptions[i])

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11156,7 +11156,7 @@ module.exports = {
     } = scuttleGlobalThis === true ? scuttleGlobalThisDefaults : scuttleGlobalThis
 
     let onLoad = (cb, global) => cb(global)
-    if (onLoadHandle) {
+    if (onLoadHandle !== undefined) {
       if (typeof globalRef[onLoadHandle] !== 'function') {
         throw new Error(
           'LavaMoat - `onLoad` function "${onLoadHandle}" expected on globalRef.'

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -11152,19 +11152,17 @@ module.exports = {
     const {
       enabled: scuttleGlobalThisEnabled,
       exceptions: scuttleGlobalThisExceptions,
-      recursive: scuttleGlobalThisRecursive,
+      onLoad: onLoadHandle,
     } = scuttleGlobalThis === true ? scuttleGlobalThisDefaults : scuttleGlobalThis
 
-    let snow = (cb, win) => cb(win)
-    if (scuttleGlobalThisRecursive) {
-      if (!globalRef.SNOW) {
+    let onLoad = (cb, global) => cb(global)
+    if (onLoadHandle) {
+      if (typeof globalRef[onLoadHandle] !== 'function') {
         throw new Error(
-          'LavaMoat - scuttleGlobalThis is configured to be enabled recursively. ' +
-          'For that, Snow-JS must be included before LavaMoat executes. ' +
-          'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/462.',
+          'LavaMoat - `onLoad` function "${onLoadHandle}" expected on globalRef.'
         )
       }
-      snow = globalRef.SNOW
+      onLoad = globalRef[onLoadHandle]
     }
 
     const moduleCache = new Map()
@@ -11190,7 +11188,7 @@ module.exports = {
         const flags = parts[parts.length - 1]
         scuttleGlobalThisExceptions[i] = new RegExp(pattern, flags)
       }
-      snow(realm => performScuttleGlobalThis(realm, scuttleGlobalThisExceptions), globalRef)
+      onLoad(realm => performScuttleGlobalThis(realm, scuttleGlobalThisExceptions), globalRef)
     }
 
     const kernel = {

--- a/packages/node/src/kernel.js
+++ b/packages/node/src/kernel.js
@@ -14,10 +14,16 @@ const nativeRequire = require
 
 module.exports = { createKernel }
 
-function createKernel ({ projectRoot, lavamoatPolicy, canonicalNameMap, debugMode, statsMode, scuttleGlobalThis }) {
+function createKernel ({ projectRoot, lavamoatPolicy, canonicalNameMap, debugMode, statsMode, scuttleGlobalThis, scuttleGlobalThisExceptions }) {
   const { resolutions } = lavamoatPolicy
   const getRelativeModuleId = createModuleResolver({ projectRoot, resolutions, canonicalNameMap })
   const loadModuleData = createModuleLoader({ canonicalNameMap })
+  if (scuttleGlobalThisExceptions) {
+    console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
+    if (!scuttleGlobalThis.exceptions || !scuttleGlobalThis.exceptions.length) {
+      scuttleGlobalThis.exceptions = scuttleGlobalThisExceptions
+    }
+  }
   const kernelSrc = generateKernel({ debugMode, scuttleGlobalThis })
   const createKernel = evaluateWithSourceUrl('LavaMoat/node/kernel', kernelSrc)
   const reportStatsHook = statsMode ? makeInitStatsHook({ onStatsReady }) : noop

--- a/packages/node/src/yargsFlags.js
+++ b/packages/node/src/yargsFlags.js
@@ -69,12 +69,16 @@ module.exports = (yargs, defaults) => {
     default: defaults.scuttleGlobalThis,
   })
   // format scuttle global this config value
-  yargs.coerce('scuttleGlobalThis', arg => {
-    try {
-      // node tests pass this as a stringified object
-      return JSON.parse(arg)
-    } catch {
-      return arg
-    }
+  yargs.coerce('scuttleGlobalThis', arg => typeof arg === 'string'
+    ? JSON.parse(arg)
+    : arg,
+  )
+  // scuttle global this exceptions array
+  yargs.option('scuttleGlobalThisExceptions', {
+    deprecated: true,
+    alias: ['scuttleGlobalThisExceptions'],
+    describe: 'scuttle global this except for the properties provided in this array',
+    type: 'array',
+    default: defaults.scuttleGlobalThisExceptions,
   })
 }


### PR DESCRIPTION
Targeting #462 

- backwards compatibility (https://github.com/LavaMoat/LavaMoat/pull/462#discussion_r1143108260)
- make "preloader" (e.g. SNOW) pluggable
  - choice of `onLoad` for new field is tentative and up for alternatives