### PR TITLE
Skip JSON files only for policy generation

### DIFF
--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -97,7 +97,7 @@ function createModuleInspector (opts = {}) {
     // skip json files
     const filename = moduleRecord.file || 'unknown'
     const fileExtension = path.extname(filename)
-    if (fileExtension === '.json') {
+    if (!fileExtension.match(/^\.([cm]?js|ts)$/)) {
       return
     }
     // get ast (parse or use cached)

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -97,7 +97,7 @@ function createModuleInspector (opts = {}) {
     // skip json files
     const filename = moduleRecord.file || 'unknown'
     const fileExtension = path.extname(filename)
-    if (fileExtension !== '.js') {
+    if (fileExtension === '.json') {
       return
     }
     // get ast (parse or use cached)


### PR DESCRIPTION
Inverts the JSON file extension check to only check for `.json`. This allows for parsing of `.cjs`, `.ts` etc.