### PR TITLE
allow-scripts/version - 2.3.1

### DIFF
--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/allow-scripts",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "src/index.js",
   "bin": {
     "allow-scripts": "src/cli.js"


### PR DESCRIPTION
- Release `@lavamoat/allow-scripts` v2.3.1

### Changes since v2.3.0

- fix: Bump @npmcli/run-script to 6.0.0 to fix dependency issues (#479)
- fix: avoid failure if preinstall-always-fail already installed (#423)