### PR TITLE
Core bug cant read with write perm

### DIFF
--- a/packages/core/src/makeGetEndowmentsForConfig.js
+++ b/packages/core/src/makeGetEndowmentsForConfig.js
@@ -45,11 +45,8 @@ function makeGetEndowmentsForConfig ({ createFunctionWrapper }) {
         explicitlyBanned.push(path)
         return 
       }
-      // write access handled elsewhere
-      if (configValue === 'write') {
-        return
-      }
-      if (configValue !== true) {
+      // to allow read access, the value must be true or "write"
+      if (configValue !== true && configValue !== 'write') {
         throw new Error(`LavaMoat - unrecognizable policy value (${typeof configValue}) for path "${path}"`)
       }
       whitelistedReads.push(path)

--- a/packages/core/src/makePrepareRealmGlobalFromConfig.js
+++ b/packages/core/src/makePrepareRealmGlobalFromConfig.js
@@ -62,7 +62,7 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
           if (globalStore.has(key)) {
             return globalStore.get(key)
           } else {
-            return endowments[key]
+            return Reflect.get(endowments, key, this)
           }
         },
         set (value) {

--- a/packages/core/test/scenarios/globalWrites.js
+++ b/packages/core/test/scenarios/globalWrites.js
@@ -45,26 +45,22 @@ module.exports = [
       name: 'globalWrites - and reads',
       defineOne: () => {
         module.exports = {
-          type: typeof globalThis.xyz,
-          value: globalThis.xyz
+          type: typeof globalThis.setTimeout,
         }
       },
       config: {
         resources: {
           one: {
             globals: {
-              xyz: 'write'
+              // using "setTimeout" as an example of an endowment available
+              // in all testing environments
+              setTimeout: 'write'
             }
           },
         }
       },
-      // populate evaluation realm global
-      beforeCreateKernel: (scenario) => {
-        scenario.globalThis.xyz = 123
-      },
       expectedResult: {
-        type: 'number',
-        value: 123,
+        type: 'function',
       },
     })
     return scenario

--- a/packages/core/test/scenarios/globalWrites.js
+++ b/packages/core/test/scenarios/globalWrites.js
@@ -39,5 +39,34 @@ module.exports = [
       expectedResult: true
     })
     return scenario
-  }
+  },
+  async () => {
+    const scenario = createScenarioFromScaffold({
+      name: 'globalWrites - and reads',
+      defineOne: () => {
+        module.exports = {
+          type: typeof globalThis.xyz,
+          value: globalThis.xyz
+        }
+      },
+      config: {
+        resources: {
+          one: {
+            globals: {
+              xyz: 'write'
+            }
+          },
+        }
+      },
+      // populate evaluation realm global
+      beforeCreateKernel: (scenario) => {
+        scenario.globalThis.xyz = 123
+      },
+      expectedResult: {
+        type: 'number',
+        value: 123,
+      },
+    })
+    return scenario
+  },
 ]

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -390,7 +390,12 @@ function prepareModuleInitializerArgs (requireRelativeWithContext, moduleObj, mo
 
 function evaluateWithSourceUrl (filename, content, context) {
 
-  const vmContext = createContext()
+  const vmContext = createContext({
+    // vm does not have setTimeout
+    // we check for presence of "setTimeout" in a test
+    // bc its an example of an endowment available in all environments
+    setTimeout: () => { throw new Error('setTimeout not available in vm context') },
+  })
   const vmGlobalThis = runInContext('this', vmContext)
   const vmFeralFunction = vmGlobalThis.Function
 


### PR DESCRIPTION
`write` is supposed imply `read`, but the read getter reads from the endowments which we were incorrectly not populating

df81c47602ca1ea16196b7e44415d8816f021715 is an unrelated driveby fix