### PR TITLE
core/fix - remove console taming to that errors are logged to the console correctly

### DIFF
--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -60,8 +60,6 @@
       errorTaming: 'unsafe',
       // shows the full call stack
       stackFiltering: 'verbose',
-      // deep stacks
-      consoleTaming: 'unsafe',
     }
 
     lockdown(lockdownOptions)

--- a/packages/lavapack/src/runtime.js
+++ b/packages/lavapack/src/runtime.js
@@ -10537,8 +10537,6 @@ function observeImports(map, importName, importIndex) {
       errorTaming: 'unsafe',
       // shows the full call stack
       stackFiltering: 'verbose',
-      // deep stacks
-      consoleTaming: 'unsafe',
     }
 
     lockdown(lockdownOptions)


### PR DESCRIPTION
I noticed errors were not being logged to the node console correctly, changing this option fixes that