### PR TITLE
browserify/deps: move @babel/code-frame to devDeps

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -11,7 +11,6 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@babel/code-frame": "^7.16.7",
     "@lavamoat/aa": "^3.1.0",
     "@lavamoat/lavapack": "^5.0.0",
     "browser-resolve": "^2.0.0",
@@ -26,6 +25,7 @@
     "through2": "^3.0.0"
   },
   "devDependencies": {
+    "@babel/code-frame": "^7.16.7",
     "@metamask/eslint-config-nodejs": "^10.0.0",
     "bify-package-factor": "^1.0.7",
     "browserify": "^17.0.0",


### PR DESCRIPTION
This package is only used in tests.