### PR TITLE
core: remove Object.fromEntries polyfill

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -796,7 +796,6 @@
       },
       "packages": {
         "json-stable-stringify": true,
-        "lavamoat-core>fromentries": true,
         "lavamoat-core>lavamoat-tofu": true,
         "lavamoat-core>merge-deep": true
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,6 @@
     "node": ">=14.0.0 <19.0.0"
   },
   "dependencies": {
-    "fromentries": "^1.2.0",
     "json-stable-stringify": "^1.0.1",
     "lavamoat-tofu": "^6.0.2",
     "merge-deep": "^3.0.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,6 @@
     "ses": "^0.17.0",
     "eslint-plugin-ava": "^11.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "object.fromentries": "^2.0.2",
     "tmp-promise": "^3.0.2"
   },
   "scripts": {

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -1,6 +1,5 @@
 const EventEmitter = require('events')
 const path = require('path')
-const fromEntries = require('fromentries')
 const jsonStringify = require('json-stable-stringify')
 const {
   parse,
@@ -212,7 +211,7 @@ function createModuleInspector (opts = {}) {
       // get dependencies, ignoring builtins
       const packageDeps = aggregateDeps({ packageModules, moduleIdToModuleRecord })
       if (packageDeps.length) {
-        packages = fromEntries(packageDeps.map(depPackageName => [depPackageName, true]))
+        packages = Object.fromEntries(packageDeps.map(depPackageName => [depPackageName, true]))
       }
       // get globals
       if (packageToGlobals[packageName]) {

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -2,7 +2,6 @@ const { parseForPolicy, LavamoatModuleRecord, generateKernel, getDefaultPaths } 
 const mergeDeep = require('merge-deep')
 const { runInContext, createContext } = require('vm')
 const path = require('path')
-const fromEntries = require('object.fromentries')
 const { promises: fs } = require('fs')
 var tmp = require('tmp-promise')
 const stringify = require('json-stable-stringify')


### PR DESCRIPTION
These were added for node v10 compatibility in https://github.com/LavaMoat/LavaMoat/commit/78aa255024cc3cac611bd02598e785dff8453aa4.
Minimum supported nodejs version is v14 where the polyfilled function is available natively, so these are no longer needed.