### PR TITLE
deps: bump core deps and devDeps

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -795,9 +795,14 @@
         "define": true
       },
       "packages": {
-        "json-stable-stringify": true,
+        "lavamoat-core>json-stable-stringify": true,
         "lavamoat-core>lavamoat-tofu": true,
         "lavamoat-core>merge-deep": true
+      }
+    },
+    "lavamoat-core>json-stable-stringify": {
+      "packages": {
+        "lavamoat-core>json-stable-stringify>jsonify": true
       }
     },
     "lavamoat-core>lavamoat-tofu": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "json-stable-stringify": "^1.0.2",
     "lavamoat-tofu": "^6.0.2",
-    "merge-deep": "^3.0.2"
+    "merge-deep": "^3.0.3"
   },
   "devDependencies": {
     "@metamask/eslint-config-nodejs": "^10.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "node": ">=14.0.0 <19.0.0"
   },
   "dependencies": {
-    "json-stable-stringify": "^1.0.1",
+    "json-stable-stringify": "^1.0.2",
     "lavamoat-tofu": "^6.0.2",
     "merge-deep": "^3.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@metamask/eslint-config-nodejs": "^10.0.0",
-    "ses": "^0.17.0",
+    "ses": "^0.18.4",
     "eslint-plugin-ava": "^11.0.0",
     "eslint-plugin-node": "^11.1.0",
     "tmp-promise": "^3.0.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "ses": "^0.18.4",
     "eslint-plugin-ava": "^11.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "tmp-promise": "^3.0.2"
+    "tmp-promise": "^3.0.3"
   },
   "scripts": {
     "lint": "yarn lint:eslint && yarn lint:deps",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12699,11 +12699,6 @@ serve@^13.0.4:
     serve-handler "6.1.3"
     update-check "1.5.2"
 
-ses@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.17.0.tgz#4e37cd1c4003e4448df2e84983900ccc5e2f095a"
-  integrity sha512-ObQ4DF4OgkmuPVRZLSmB1E+8jWh6lnlSpN9JHnphAUb/5J6k7da+7kj63cXrz53NDPd69rUV3DsfRBNBx8xcPQ==
-
 ses@^0.18.4:
   version "0.18.4"
   resolved "https://registry.yarnpkg.com/ses/-/ses-0.18.4.tgz#28781719870262afc6928b7d6d94dc16318dbd86"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13670,7 +13670,7 @@ tinylogic@^1.0.3:
   dependencies:
     chevrotain "^9.1.0"
 
-tmp-promise@^3.0.2, tmp-promise@^3.0.3:
+tmp-promise@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
   integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9742,7 +9742,7 @@ meow@^8.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
-merge-deep@^3.0.2:
+merge-deep@^3.0.2, merge-deep@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.3.tgz#1a2b2ae926da8b2ae93a0ac15d90cd1922766003"
   integrity sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==


### PR DESCRIPTION
- `core/deps`: `merge-deep`@`^3.0.2`->`^3.0.3`
- `core/deps`: `json-stable-stringify`@`^1.0.1`->`^1.0.2`
- `core/devDeps`: `ses`@`^0.17.0`->`^0.18.4`
  - Note: Prior to this change, users respecting thelockfile actually end upwith two different versions of `ses`, where `core` was on the older `0.17.0`.
- `core/devDeps`: `tmp-promise`@`^3.0.2`->`^3.0.3`

