### PR TITLE
core/version - 14.1.0

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -18,7 +18,7 @@
     "convert-source-map": "^1.9.0",
     "duplexify": "^4.1.1",
     "json-stable-stringify": "^1.0.1",
-    "lavamoat-core": "^14.0.0",
+    "lavamoat-core": "^14.1.0",
     "pify": "^4.0.1",
     "readable-stream": "^3.6.0",
     "source-map": "^0.7.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-core",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "description": "LavaMoat kernel and utils",
   "main": "src/index.js",
   "directories": {

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -14,7 +14,7 @@
     "combine-source-map": "^0.8.0",
     "convert-source-map": "^1.9.0",
     "json-stable-stringify": "^1.0.1",
-    "lavamoat-core": "^14.0.0",
+    "lavamoat-core": "^14.1.0",
     "readable-stream": "^3.6.0",
     "through2": "^4.0.2",
     "umd": "^3.0.3"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,7 +23,7 @@
     "bindings": "^1.5.0",
     "htmlescape": "^1.1.1",
     "json-stable-stringify": "^1.0.2",
-    "lavamoat-core": "^14.0.0",
+    "lavamoat-core": "^14.1.0",
     "lavamoat-tofu": "^6.0.2",
     "node-gyp-build": "^4.6.0",
     "resolve": "^1.22.3",


### PR DESCRIPTION
- change: Policy generation now looks at .cjs, .mjs, .ts and .js files as opposed to only .js files (https://github.com/LavaMoat/LavaMoat/pull/474)
 - change: Deprecate `global`,`self` as aliases for `globalThis` (https://github.com/LavaMoat/LavaMoat/pull/461)
 - fix: Restrict `engines.node` to < 19.0.0 (https://github.com/LavaMoat/LavaMoat/pull/552)
 - fix: Add `WebAssembly` to scuttle globalThis exceptions. This is necessary as of Node.js 18 (https://github.com/LavaMoat/LavaMoat/pull/551)
 - fix: Remove console taming so that errors are logged to the console correctly (https://github.com/LavaMoat/LavaMoat/pull/493)
 - fix: Fix globalThis polyfill (https://github.com/LavaMoat/LavaMoat/pull/567)
 - fix: Handle error when receiver is null in getPropertyDescriptorDeep (https://github.com/LavaMoat/LavaMoat/pull/463)
 - fix: Drop unnecessary additionalOpts arg and migrate back into using scenario object (https://github.com/LavaMoat/LavaMoat/pull/471)
 - fix: Catch errors thrown when calling property getters (https://github.com/LavaMoat/LavaMoat/pull/468)