### PR TITLE
viz/deps: bump lavamoat-core to current

### DIFF
--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "version": "6.0.9",
   "dependencies": {
-    "lavamoat-core": "^10.0.1",
+    "lavamoat-core": "^14.1.0",
     "ncp": "^2.0.0",
     "open": "^7.0.3",
     "pify": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8825,17 +8825,6 @@ launch-editor@^2.6.0:
     picocolors "^1.0.0"
     shell-quote "^1.7.3"
 
-lavamoat-core@^10.0.1:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/lavamoat-core/-/lavamoat-core-10.1.2.tgz#13ebef3cd42ed04f31c504b4046cc00299c595a9"
-  integrity sha512-VG95sqsowWrtbZthlOiznUhYnqNfhJxhiry26FEbDd8hQeZY5QY1vmT5mydyvJGDmoBPVKHbz5xMwjeBjC5xnw==
-  dependencies:
-    fromentries "^1.2.0"
-    json-stable-stringify "^1.0.1"
-    lavamoat-tofu "^6.0.0"
-    merge-deep "^3.0.2"
-    resolve "^1.15.1"
-
 lavamoat-core@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/lavamoat-core/-/lavamoat-core-7.0.0.tgz#61231b1454d3978d9a9bc0cfbc7c827c1ccd3314"


### PR DESCRIPTION
`viz` is still on `lavamoat-core` v10. This bumps it to current for next release.