### PR TITLE
lavapack/version - 5.1.0

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@lavamoat/aa": "^3.1.0",
-    "@lavamoat/lavapack": "^5.0.0",
+    "@lavamoat/lavapack": "^5.1.0",
     "browser-resolve": "^2.0.0",
     "concat-stream": "^2.0.0",
     "convert-source-map": "^1.9.0",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/lavapack",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "LavaMoat packer",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- deps: lavamoat-core@14.0.0->14.1.0 (https://github.com/LavaMoat/LavaMoat/pull/576)
  - change: Policy generation now looks at .cjs, .mjs, .ts and .js files as opposed to only .js files (https://github.com/LavaMoat/LavaMoat/pull/474)
  - change: Deprecate `global`,`self` as aliases for `globalThis` (https://github.com/LavaMoat/LavaMoat/pull/461)
  - fix: Restrict `engines.node` to < 19.0.0 (https://github.com/LavaMoat/LavaMoat/pull/552)                                                - fix: Add `WebAssembly` to scuttle globalThis exceptions. This is necessary as of Node.js 18 (https://github.com/LavaMoat/LavaMoat/pull/551)
  - fix: Remove console taming so that errors are logged to the console correctly (https://github.com/LavaMoat/LavaMoat/pull/493)
  - fix: Fix globalThis polyfill (https://github.com/LavaMoat/LavaMoat/pull/567)                                                            - fix: Handle error when receiver is null in getPropertyDescriptorDeep (https://github.com/LavaMoat/LavaMoat/pull/463)
  - fix: Drop unnecessary additionalOpts arg and migrate back into using scenario object (https://github.com/LavaMoat/LavaMoat/pull/471)
  - fix: Catch errors thrown when calling property getters (https://github.com/LavaMoat/LavaMoat/pull/468)
- deps: dependency maintenance bumps
  - json-stable-stringify@^1.0.1->^1.0.2
  - convert-source-map@^1.9.0->^2.0.0
  - espree@^7.3.0->^9.5.2

Depends on:
- #570 
- #576 