### PR TITLE
lift <19 nodejs restriction for pkgs not depending on core

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lerna": "^6.6.2"
   },
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "test": "lerna run --concurrency 1 test",

--- a/packages/aa/package.json
+++ b/packages/aa/package.json
@@ -32,6 +32,6 @@
   },
   "author": "kumavis",
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -47,6 +47,6 @@
   "author": "",
   "homepage": "https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts",
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -19,6 +19,6 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -31,6 +31,6 @@
   },
   "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/tofu/README.md",
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/packages/yarn-plugin-allow-scripts/package.json
+++ b/packages/yarn-plugin-allow-scripts/package.json
@@ -25,6 +25,6 @@
   },
   "packageManager": "yarn@3.1.1",
   "engines": {
-    "node": ">=14.0.0 <19.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
~`@lavamoat/aa` is~ Several packages are not actually affected by the issue prompting the restriction in #552, so should be lifted prior to next release of this package.