### PR TITLE
internal refactor scuttling options handling

### DIFF
--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -31,36 +31,30 @@ function getStrictScopeTerminatorShimSrc () {
 }
 
 // takes the kernelTemplate and populates it with the libraries
-function generateKernel (_opts = {}) {
-  const opts = Object.assign({}, _opts)
+function generateKernel (opts = {}) {
   const kernelCode = generateKernelCore()
 
   let output = kernelTemplate
   output = replaceTemplateRequire(output, 'ses', sesSrc)
   output = stringReplace(output, '__createKernelCore__', kernelCode)
   output = stringReplace(output, '__lavamoatDebugOptions__', JSON.stringify({debugMode: !!opts.debugMode}))
-  if (opts?.hasOwnProperty('scuttleGlobalThis')) {
-    // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
-    // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).
-    let scuttleGlobalThis = opts.scuttleGlobalThis
-    if (opts.scuttleGlobalThisExceptions) {
-      console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
-      if (scuttleGlobalThis === true) {
-        scuttleGlobalThis = {enabled: true}
-      }
-    }
-    const exceptions = scuttleGlobalThis?.exceptions || opts.scuttleGlobalThisExceptions
-    scuttleGlobalThis.exceptions = exceptions
-    if (exceptions) {
-      // toString regexps if there's any
-      for (let i = 0; i < exceptions.length; i++) {
-        exceptions[i] = String(exceptions[i])
-      }
-    }
-    output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
-      scuttleGlobalThis,
-    }))
+
+
+  if (opts.scuttleGlobalThisExceptions) {
+    console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
   }
+  const scuttleGlobalThis = opts.hasOwnProperty('scuttleGlobalThis') ? {
+    enabled: opts.scuttleGlobalThis === true || (typeof opts.scuttleGlobalThis === 'object' && opts.scuttleGlobalThis.enabled),
+    exceptions: (typeof opts.scuttleGlobalThis === 'object' && opts.scuttleGlobalThis.exceptions || opts.scuttleGlobalThisExceptions || [])
+      .map(e => String(e)), // cast any regexes into strings
+  } : {
+    enabled: false,
+  }
+
+
+  output = stringReplace(output, '__lavamoatSecurityOptions__', JSON.stringify({
+    scuttleGlobalThis,
+  }))
 
   return output
 }

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -53,7 +53,6 @@ function createPacker({
   policy = {},
   // prune policy to only include packages used in the bundle
   prunePolicy = false,
-  externalRequireName,
   sourceRoot,
   sourceMapPrefix,
   bundleWithPrecompiledModules = true,

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -56,7 +56,7 @@ function createPacker({
   sourceRoot,
   sourceMapPrefix,
   bundleWithPrecompiledModules = true,
-  scuttleGlobalThis = {},
+  scuttleGlobalThis,
   scuttleGlobalThisExceptions,
 } = {}) {
   // stream/parser wrapping incase raw: false
@@ -87,22 +87,17 @@ function createPacker({
 
   if (scuttleGlobalThisExceptions) {
     console.warn('Lavamoat - "scuttleGlobalThisExceptions" is deprecated. Use "scuttleGlobalThis.exceptions" instead.')
-    if (scuttleGlobalThis === true) {
-      scuttleGlobalThis = {enabled: true}
-    }
   }
-  const exceptions = scuttleGlobalThis?.exceptions || scuttleGlobalThisExceptions
-  scuttleGlobalThis.exceptions = exceptions
-
-  // toString regexps if there's any
-  if (exceptions) {
-    for (let i = 0; i < exceptions.length; i++) {
-      exceptions[i] = String(exceptions[i])
-    }
+  const _scuttleGlobalThis = !!scuttleGlobalThis ? {
+    enabled: scuttleGlobalThis === true || (scuttleGlobalThis === 'object' && scuttleGlobalThis.enabled),
+    exceptions: (typeof scuttleGlobalThis === 'object' && scuttleGlobalThis.exceptions || scuttleGlobalThisExceptions || [])
+      .map(e => String(e)), // cast any regexes into strings
+  } : {
+    enabled: false,
   }
 
   prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({
-    scuttleGlobalThis,
+    scuttleGlobalThis: _scuttleGlobalThis,
   }))
 
   // note: pack stream cant started emitting data until its received its first module


### PR DESCRIPTION
Intention is to make the parsing less complex (even more so once the legacy configuration API can be dropped)