### PR TITLE
node/version - 7.0.0

### DIFF
--- a/packages/node/examples/eval-server/package.json
+++ b/packages/node/examples/eval-server/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "bad-idea-eval-server": "^1.0.0",
-    "lavamoat": "^1.0.5"
+    "lavamoat": "^7.0.0"
   },
   "scripts": {
     "setup": "yarn install",

--- a/packages/node/examples/express/package.json
+++ b/packages/node/examples/express/package.json
@@ -9,7 +9,7 @@
     "express": "^4.17.3"
   },
   "devDependencies": {
-    "lavamoat": "^1.0.10",
+    "lavamoat": "^7.0.0",
     "patch-package": "^6.2.1",
     "postinstall-postinstall": "^2.1.0"
   },

--- a/packages/node/examples/todo-cli/package.json
+++ b/packages/node/examples/todo-cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.0.0",
-    "lavamoat": "^2.0.1",
+    "lavamoat": "^7.0.0",
     "minimist": "^1.2.6",
     "readline": "^1.3.0"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
     "lavamoat": "src/cli.js",
     "lavamoat-run-command": "src/run-command.js"
   },
-  "version": "6.4.0",
+  "version": "7.0.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "lavamoat-browserify": "^15.5.0",
-    "lavamoat": "^6.4.0",
+    "lavamoat": "^7.0.0",
     "readable-stream": "^3.6.0",
     "@endo/compartment-mapper": "^0.8.4",
     "ses": "^0.18.4"

--- a/packages/survey/package.json
+++ b/packages/survey/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "lavamoat": "^6.4.0",
+    "lavamoat": "^7.0.0",
     "lavamoat-tofu": "^6.0.2",
     "node-fetch": "^2.6.9",
     "p-limit": "^3.1.0"


### PR DESCRIPTION
- fix: Node.js 18 compatibility (https://github.com/LavaMoat/LavaMoat/pull/551)
- deps: lavamoat-core@^12.3.0->^14.1.1
- deps: bump https://github.com/babel packages to latest (https://github.com/LavaMoat/LavaMoat/pull/587)
- deps: bump json-stable-stringify, node-gyp-build, resolve, yargs (https://github.com/LavaMoat/LavaMoat/pull/556)
- deps: remove object.fromentries (https://github.com/LavaMoat/LavaMoat/pull/555)
- change: BREAKING: Minimum Node.js version 14 (https://github.com/LavaMoat/LavaMoat/pull/398)
- fix: Properly add scuttling functionality (https://github.com/LavaMoat/LavaMoat/pull/382, https://github.com/LavaMoat/LavaMoat/pull/391)
- change: update examples