### PR TITLE
browserify/version - 15.6.0

### DIFF
--- a/packages/browserify/examples/00-simple-cli/package.json
+++ b/packages/browserify/examples/00-simple-cli/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "browserify": "^17.0.0",
-    "lavamoat-browserify": "^15.5.0",
+    "lavamoat-browserify": "^15.6.0",
     "serve": "^14.2.0"
   },
   "scripts": {

--- a/packages/browserify/examples/01-simple-js/package.json
+++ b/packages/browserify/examples/01-simple-js/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "browserify": "^17.0.0",
-    "lavamoat-browserify": "^15.5.0",
+    "lavamoat-browserify": "^15.6.0",
     "serve": "^14.2.0"
   },
   "scripts": {

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-browserify",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "description": "browserify plugin for sandboxing dependencies with LavaMoat",
   "main": "src/index.js",
   "directories": {

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "browserify": "^17.0.0",
-    "lavamoat-browserify": "^15.5.0",
+    "lavamoat-browserify": "^15.6.0",
     "lavamoat": "^7.0.0",
     "readable-stream": "^3.6.0",
     "@endo/compartment-mapper": "^0.8.4",


### PR DESCRIPTION
- fix: Node.js 18 compatibility (https://github.com/LavaMoat/LavaMoat/pull/551)
- deps: update lavamoat-core@^12.4.0->^14.1.1
- deps: @lavamoat/lavapack@^3.3.0->^5.1.2
- doc: update examples and docs (https://github.com/LavaMoat/LavaMoat/pull/476)
- change: Add back policyDebug option (https://github.com/LavaMoat/LavaMoat/pull/440)