### PR TITLE
browserify: add back prunepolicy option alias for prunePolicy

### DIFF
--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -111,6 +111,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
     pr: 'includePrelude',
     prelude: 'includePrelude',
     pp: 'prunePolicy',
+    prunepolicy: 'prunePolicy',
     d: 'debugMode',
     debug: 'debugMode',
     stats: 'statsMode',


### PR DESCRIPTION
The `prunepolicy` alias for the `prunePolicy` option was removed in #440. This reverts it in order to be able to ship a non-breaking #602 from a clean `main`.