### PR TITLE
browserify/chore: add tooling config,tests,examples to npmignore

### DIFF
--- a/packages/browserify/.npmignore
+++ b/packages/browserify/.npmignore
@@ -1,0 +1,7 @@
+test/
+examples/
+.depcheckrc
+.eslintignore
+.eslintrc.json
+ava.config.cjs
+yarn-error.log


### PR DESCRIPTION
Excludes redundant files from published tarballs.

In particular, the `examples` lockfiles will always lag one version behind due to containing a reference to the package itself: 

https://github.com/LavaMoat/LavaMoat/blob/a2d83bdc0a9a069ca495eba14079b6658081b265/packages/browserify/examples/01-simple-js/yarn.lock#L1273

Excluding these directories from the release makes this less of an issue.


### Related:
- #607 
- #602 