### PR TITLE
feat(allow-scripts): generate & ship typescript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ temp/
 
 # JetBrains
 .idea
+
+packages/allow-scripts/types

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "checkJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "extends": "@tsconfig/node14/tsconfig.json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
         "@commitlint/config-conventional": "^17.6.7",
+        "@tsconfig/node14": "^14.1.0",
+        "@types/node": "^20.4.1",
+        "@types/yargs": "^17.0.24",
         "ava": "^5.3.1",
         "conventional-changelog-conventionalcommits": "^6.1.0",
         "cross-env": "^7.0.3",
@@ -25,7 +28,8 @@
         "eslint-plugin-react": "^7.33.0",
         "husky": "^8.0.3",
         "lerna": "^7.1.4",
-        "lint-staged": "^13.2.3"
+        "lint-staged": "^13.2.3",
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3099,9 +3103,10 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
+      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
@@ -3311,6 +3316,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/npmcli__promise-spawn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/npmcli__promise-spawn/-/npmcli__promise-spawn-6.0.0.tgz",
+      "integrity": "sha512-UeAlcVTkwHOrjZ4MLG+t/oNTvYa9Zg1qewaWMyG0NmHGpY6OqygGoDjq6uPNDqSiIXFxsDS9sgx8aHNBxGbyMg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "dev": true,
@@ -3425,6 +3439,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "dev": true
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.1",
@@ -18608,6 +18637,12 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
@@ -19870,10 +19905,13 @@
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "4.0.1",
         "npm-normalize-package-bin": "^3.0.0",
-        "yargs": "^16.2.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "allow-scripts": "src/cli.js"
+      },
+      "devDependencies": {
+        "@types/npmcli__promise-spawn": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
     "@commitlint/config-conventional": "^17.6.7",
+    "@tsconfig/node14": "^14.1.0",
+    "@types/node": "^20.4.1",
+    "@types/yargs": "^17.0.24",
     "ava": "^5.3.1",
     "conventional-changelog-conventionalcommits": "^6.1.0",
     "cross-env": "^7.0.3",
@@ -19,6 +22,7 @@
     "eslint-plugin-react": "^7.33.0",
     "husky": "^8.0.3",
     "lerna": "^7.1.4",
+    "typescript": "^5.1.6",
     "lint-staged": "^13.2.3"
   },
   "engines": {
@@ -31,8 +35,12 @@
     "lint:eslint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:deps": "lerna run lint:deps",
-    "build": "npm -w @lavamoat/lavapack -w @lavamoat/viz -w @lavamoat/yarn-plugin-allow-scripts run build",
+    "build": "npm -w @lavamoat/lavapack -w @lavamoat/viz -w @lavamoat/yarn-plugin-allow-scripts run build && npm run build:types",
+    "build:types": "tsc -b",
+    "clean:types": "tsc -b --clean",
+    "watch:types": "tsc -b --watch",
     "rebuild": "npm -w @lavamoat/lavapack -w @lavamoat/viz -w @lavamoat/yarn-plugin-allow-scripts run rebuild",
+    "rebuild:types": "npm run clean:types; npm run build:types",
     "lint:staged": "lint-staged",
     "lint:commit": "commitlint",
     "postinstall": "husky install",

--- a/packages/allow-scripts/.depcheckrc
+++ b/packages/allow-scripts/.depcheckrc
@@ -1,3 +1,7 @@
 ignores:
   # monorepo deps
   - 'ava'
+  - "@types/npmcli__promise-spawn"
+
+  # only types (from @types/npmcli__promise-spawn) are referenced
+  - "@npmcli/promise-spawn"

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -15,7 +15,7 @@
     "@npmcli/run-script": "^6.0.0",
     "bin-links": "4.0.1",
     "npm-normalize-package-bin": "^3.0.0",
-    "yargs": "^16.2.0"
+    "yargs": "^17.7.2"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,9 @@
   "description": "A tool for running only the dependency lifecycle hooks specified in an allowlist.",
   "directories": {
     "test": "test"
+  },
+  "devDependencies": {
+    "@types/npmcli__promise-spawn": "^6.0.0"
   },
   "scripts": {
     "test": "npm run test:run",
@@ -45,5 +48,6 @@
       "test/*.spec.js"
     ],
     "timeout": "30s"
-  }
+  },
+  "types": "./types/index.d.ts"
 }

--- a/packages/allow-scripts/src/cli.js
+++ b/packages/allow-scripts/src/cli.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-const yargs = require('yargs')
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
 const { runAllowedPackages, setDefaultConfiguration, printPackagesList } = require('./index.js')
 const { writeRcFile, editPackageJson } = require('./setup.js')
-const { FEATURE } = require('./toggles') 
+const { FEATURE } = require('./toggles')
 
 start().catch((err) => {
   console.error(err)
@@ -46,7 +47,7 @@ async function start () {
 }
 
 function parseArgs () {
-  const argsParser = yargs
+  const argsParser = yargs(hideBin(process.argv))
     .usage('Usage: $0 <command> [options]')
     .command('$0', 'run the allowed scripts')
     .command('run', 'run the allowed scripts')
@@ -60,7 +61,7 @@ function parseArgs () {
     })
     .help()
 
-  const parsedArgs = argsParser.parse()
+  const parsedArgs = argsParser.parseSync()
   parsedArgs.command = parsedArgs._[0]
 
   return parsedArgs

--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -11,18 +11,22 @@ const setup = require('./setup')
 
 /**
  * @typedef {Object} PkgConfs
- * @property {Object} packageJson
+ * @property {Record<string,any>} packageJson
  * @property {Object} configs
  * @property {ScriptsConfig} configs.lifecycle
  * @property {BinsConfig} configs.bin
  * @property {boolean} somePoliciesAreMissing
- *
+ */
+
+/**
  * Individual package info
  * @typedef {Object} PkgInfo
  * @property {string} canonicalName
  * @property {string} path
  * @property {Object} scripts
- *
+ */
+
+/**
  * Individual bin link info
  * @typedef {Object} BinInfo
  * @property {string} canonicalName
@@ -31,25 +35,31 @@ const setup = require('./setup')
  * @property {string} path
  * @property {string} link
  * @property {string} fullLinkPath
- *
+**/
+
+/**
  * Configuration for a type of scripts policies
  * @typedef {Object} ScriptsConfig
- * @property {Object} allowConfig
+ * @property {Record<string,any>} allowConfig
  * @property {Map<string,[PkgInfo]>} packagesWithScripts
- * @property {Array} allowedPatterns
- * @property {Array} disallowedPatterns
- * @property {Array} missingPolicies
- * @property {Array} excessPolicies
- *
+ * @property {Array<string>} allowedPatterns
+ * @property {Array<string>} disallowedPatterns
+ * @property {Array<string>} missingPolicies
+ * @property {Array<string>} excessPolicies
+ */
+
+/**
  * @typedef {Map<string,[BinInfo]>} BinCandidates
- *
+ */
+
+/**
  * Configuration for a type of bins policies
  * @typedef {Object} BinsConfig
- * @property {Object} allowConfig
+ * @property {Record<string,any>} allowConfig
  * @property {BinCandidates} binCandidates
  * @property {Array<BinInfo>} allowedBins
  * @property {Array<BinInfo>} firewalledBins
- * @property {Array} excessPolicies
+ * @property {Array<string>} excessPolicies
  * @property {boolean} somePoliciesAreMissing
  */
 
@@ -61,6 +71,10 @@ module.exports = {
   setup,
 }
 
+/**
+ *
+ * @param {GetOptionsForBinOpts} param0
+ */
 async function getOptionsForBin({ rootDir, name }) {
   const {
     configs: {
@@ -74,6 +88,10 @@ async function getOptionsForBin({ rootDir, name }) {
 }
 
 
+/**
+ * @param {RunAllowedPackagesOpts} param0
+ * @returns {Promise<void>}
+ */
 async function runAllowedPackages({ rootDir }) {
   const {
     configs: {
@@ -131,6 +149,9 @@ async function runAllowedPackages({ rootDir }) {
   await runScript({ event: 'prepare', path: rootDir })
 }
 
+/**
+ * @param {SetDefaultConfigurationOpts} param0
+ */
 async function setDefaultConfiguration({ rootDir }) {
   const conf = await loadAllPackageConfigurations({ rootDir })
   const {
@@ -167,6 +188,10 @@ async function setDefaultConfiguration({ rootDir }) {
   })
 }
 
+/**
+ * @param {PrintPackagesListOpts} param0
+ * @returns {Promise<void>}
+ */
 async function printPackagesList({ rootDir }) {
   const {
     configs: {
@@ -180,6 +205,10 @@ async function printPackagesList({ rootDir }) {
 }
 
 
+/**
+ *
+ * @param {PrintMissingPoliciesIfAnyOpts} param0
+ */
 function printMissingPoliciesIfAny({ missingPolicies = [], packagesWithScripts = new Map() }) {
   if(missingPolicies.length) {
     console.log('packages missing configuration:')
@@ -208,6 +237,7 @@ async function runAllScriptsForEvent({ event, packages }) {
 }
 /**
  * @param {Array<BinInfo>} allowedBins
+ * @returns {Promise<void>}
  */
 async function installBinScripts(allowedBins) {
   for (const { bin, path, link, canonicalName } of allowedBins) {
@@ -219,6 +249,7 @@ async function installBinScripts(allowedBins) {
  * Points all bins on the list to whichbin.js cli app from allow-scripts
  * @param {Array<BinInfo>} firewalledBins
  * @param {string} link - absolute path to the whichbin.js script
+ * @returns {Promise<void>}
  */
 async function installBinFirewall(firewalledBins, link) {
   // Note how we take the path of the original package so that the bin is added at the appropriate level of node_modules nesting
@@ -227,6 +258,10 @@ async function installBinFirewall(firewalledBins, link) {
   }
 }
 
+/**
+ * @param {RunScriptOpts} param0
+ * @returns {Promise<void>}
+ */
 async function runScript({ path, event }) {
   await npmRunScript({
     // required, the script to run
@@ -253,6 +288,7 @@ const bannedBins = new Set(['node', 'npm', 'yarn', 'pnpm'])
  * @param {BinCandidates} binCandidates
  */
 function prepareBinScriptsPolicy(binCandidates) {
+  /** @type {Record<string,string>} */
   const policy = {}
   // pick direct dependencies without conflicts and enable them by default unless colliding with bannedBins
   for ( const [bin, infos] of binCandidates.entries()) {
@@ -341,10 +377,8 @@ function printPackagesByScriptConfiguration({
 
 /**
  *
- * @param {Object} args
- * @param {string} args.rootDir
- * @param {PkgConfs} args.conf
- * @returns {Promise}
+ * @param {SavePackageConfigurationsOpts} param0
+ * @returns {Promise<void>}
  */
 async function savePackageConfigurations({ rootDir, conf: {
   packageJson,
@@ -483,6 +517,11 @@ function indexBinsConfiguration(config) {
   return config
 }
 
+/**
+ *
+ * @param {(value: any) => any} getterFn
+ * @returns {(a: any, b: any) => 1|-1|0}
+ */
 function sortBy(getterFn) {
   return (a, b) => {
     const aVal = getterFn(a)
@@ -496,3 +535,44 @@ function sortBy(getterFn) {
     }
   }
 }
+
+/**
+ * @typedef RunScriptOpts
+ * @property {string} event
+ * @property {string} path
+ */
+
+
+/**
+ * @typedef SavePackageConfigurationsOpts
+ * @property {string} rootDir
+ * @property {PkgConfs} conf
+ */
+
+/**
+ * @typedef GetOptionsForBinOpts
+ * @property {string} rootDir
+ * @property {string} name
+ *
+ */
+
+/**
+ * @typedef RunAllowedPackagesOpts
+ * @property {string} rootDir
+ */
+
+/**
+ * @typedef PrintPackagesListOpts
+ * @property {string} rootDir
+ */
+
+/**
+ * @typedef SetDefaultConfigurationOpts
+ * @property {string} rootDir
+ */
+
+/**
+ * @typedef PrintMissingPoliciesIfAnyOpts
+ * @property {string[]} [missingPolicies]
+ * @property {Map<string,unknown[]>} [packagesWithScripts]
+ */

--- a/packages/allow-scripts/src/linker.js
+++ b/packages/allow-scripts/src/linker.js
@@ -1,5 +1,6 @@
 // @ts-check
 // All of this is derived from the main functionality of bin-links that unfortunately would not allow for absolute path links
+
 const binTarget = require('bin-links/lib/bin-target.js')
 const isWindows = require('bin-links/lib/is-windows.js')
 const linkBin = isWindows ? require('bin-links/lib/shim-bin.js') : require('bin-links/lib/link-bin.js')
@@ -7,6 +8,9 @@ const linkBin = isWindows ? require('bin-links/lib/shim-bin.js') : require('bin-
 
 const { dirname, resolve, relative } = require('path')
 
+/**
+ * @param {LinkBinOpts} opts
+ */
 const linkBinRelative = ({ path, bin, link, top = undefined, force = true }) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
@@ -15,6 +19,9 @@ const linkBinRelative = ({ path, bin, link, top = undefined, force = true }) => 
   return linkBin({ path, from, to, absFrom, force })
 }
 
+/**
+ * @param {LinkBinOpts} opts
+ */
 const linkBinAbsolute = ({ path, bin, link, top = undefined, force = true }) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
@@ -27,3 +34,12 @@ module.exports = {
   linkBinRelative,
   linkBinAbsolute,
 }
+
+/**
+ * @typedef LinkBinOpts
+ * @property {string} path
+ * @property {string} bin
+ * @property {string} link
+ * @property {string} [top]
+ * @property {boolean} [force]
+ */

--- a/packages/allow-scripts/src/setup.js
+++ b/packages/allow-scripts/src/setup.js
@@ -35,11 +35,22 @@ module.exports = {
   editPackageJson,
 }
 
+/**
+ *
+ * @param {string} filename
+ * @returns {string}
+ */
 function addInstallParentDir(filename) {
   const rootDir = process.env.INIT_CWD || process.cwd()
   return path.join(rootDir, filename)
 }
 
+/**
+ *
+ * @param {string} entry
+ * @param {string} file
+ * @returns {boolean}
+ */
 function isEntryPresent(entry, file) {
   const rcPath = addInstallParentDir(file)
   if (!existsSync(rcPath)) {
@@ -49,6 +60,10 @@ function isEntryPresent(entry, file) {
   return rcFileContents.includes(entry)
 }
 
+/**
+ *
+ * @param {WriteRcFileContentOpts} param0
+ */
 function writeRcFileContent({file, entry}) {
   const rcPath = addInstallParentDir(file)
 
@@ -60,11 +75,14 @@ function writeRcFileContent({file, entry}) {
   }
 }
 
+/**
+ * @type {boolean}
+ */
 let binsBlockedMemo
+
 /**
  *
- * @param {Object} args
- * @param {boolean} noMemoization - turn off memoization, make a fresh lookup
+ * @param {AreBinsBlockedOpts} args
  * @returns {boolean}
  */
 function areBinsBlocked({ noMemoization = false } = {}) {
@@ -156,3 +174,14 @@ function editPackageJson () {
     writeFileSync(addInstallParentDir('package.json'), JSON.stringify(packageJson, null, 2))
   }
 }
+
+/**
+ * @typedef WriteRcFileContentOpts
+ * @property {string} file
+ * @property {string} entry
+ */
+
+/**
+ * @typedef AreBinsBlockedOpts
+ * @property {boolean} [noMemoization] turn off memoization, make a fresh lookup
+ */

--- a/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
@@ -1,0 +1,12 @@
+declare module "bin-links/lib/bin-target.js" {
+  namespace binTarget {
+    interface BinTargetOptions {
+      top?: string;
+      path: string;
+    }
+  }
+
+  function binTarget(opts: binTarget.BinTargetOptions): string;
+
+  export = binTarget;
+}

--- a/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
@@ -1,0 +1,4 @@
+declare module "bin-links/lib/is-windows.js" {
+  var isWindows: boolean;
+  export = isWindows;
+}

--- a/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
@@ -1,0 +1,15 @@
+declare module "bin-links/lib/link-bin.js" {
+  namespace linkBin {
+    interface LinkBinOptions {
+      path: string;
+      from: string;
+      to: string;
+      absFrom: string;
+      force: boolean;
+    }
+  }
+
+  function linkBin(opts: linkBin.LinkBinOptions): Promise<boolean>;
+
+  export = linkBin;
+}

--- a/packages/allow-scripts/src/types/bin-links/shim-bin..d.ts
+++ b/packages/allow-scripts/src/types/bin-links/shim-bin..d.ts
@@ -1,0 +1,15 @@
+declare module "bin-links/lib/shim-bin.js" {
+  namespace shimBin {
+    interface ShimBinOptions {
+      path: string;
+      from: string;
+      to: string;
+      absFrom: string;
+      force: boolean;
+    }
+  }
+
+  function shimBin(opts: shimBin.ShimBinOptions): Promise<boolean>;
+
+  export = shimBin;
+}

--- a/packages/allow-scripts/src/types/lavamoat__aa.d.ts
+++ b/packages/allow-scripts/src/types/lavamoat__aa.d.ts
@@ -1,0 +1,15 @@
+// XXX: temporary while `@lavamoat/aa` exports no types
+
+declare module "@lavamoat/aa" {
+  export interface Resolver {
+    sync(path: string, opts: { basedir: string }): string;
+  }
+  export interface LoadCanonicalNameMapOpts {
+    rootDir: string;
+    includeDevDeps?: boolean;
+    resolve?: Resolver;
+  }
+  export function loadCanonicalNameMap(
+    opts: LoadCanonicalNameMapOpts
+  ): Promise<Map<string, string>>;
+}

--- a/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
+++ b/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
@@ -1,0 +1,19 @@
+declare module "npm-normalize-package-bin" {
+  namespace normalizePackageBin {
+    interface PackageBin {
+      name: string;
+      bin?: string | Record<string, string>;
+    }
+
+    interface NormalizedPackageBin {
+      name: string;
+      bin?: Record<string, string>;
+    }
+  }
+
+  function normalizePackageBin(
+    pkg: normalizePackageBin.PackageBin
+  ): normalizePackageBin.NormalizedPackageBin;
+
+  export = normalizePackageBin;
+}

--- a/packages/allow-scripts/src/types/npmcli__run-script.d.ts
+++ b/packages/allow-scripts/src/types/npmcli__run-script.d.ts
@@ -1,0 +1,22 @@
+declare module "@npmcli/run-script" {
+  import { StdioOptions } from "node:child_process";
+  import type PromiseSpawn from "@npmcli/promise-spawn";
+
+  namespace npmRunScript {
+    interface RunScriptOptions {
+      event: string;
+      path: string;
+      scriptShell?: string;
+      env?: Record<string, string>;
+      stdio?: StdioOptions;
+      stdioString?: boolean;
+      banner?: boolean;
+    }
+  }
+
+  function npmRunScript(
+    opts: npmRunScript.RunScriptOptions
+  ): ReturnType<typeof PromiseSpawn>;
+
+  export = npmRunScript;
+}

--- a/packages/allow-scripts/tsconfig.json
+++ b/packages/allow-scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "types",
+    "rootDir": "src",
+    "skipLibCheck": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "packages/allow-scripts"
+    }
+  ]
+}


### PR DESCRIPTION
This is a PoC for creating (and shipping) declaration files for LavaMoat packages.

Right now, I've fully typed the sources (not the tests) of `@lavamoat/allow-scripts`, which now validates the types in "strict" mode.  TypeScript is configured for incremental builds (preferable for monorepos), but only builds one module as a PoC.

To generate types, execute `npm run build:types` in the `@lavamoat/allow-scripts` workspace.  They will be output into `packages/allow-scripts/types` (which is not under VCS).

I added available type declarations (from DefinitelyTyped), but I had to write a handful of my own for external modules. These do not appear to be re-exported.  AFAICT (but I haven't tested it!) there aren't any type declarations that are needed as production dependencies (in `@lavamoat/allow-scripts`, anyway).

I took some liberties tweaking existing types (narrowing where appropriate, separating `@typedef`s so that descriptions would be picked up, etc.).  I'd prefer if we used the `T[]` syntax for arrays instead of `Array<T>`, but that's just my personal preference and I stuck to the current convention.

I note that these `.d.ts` files I created have _semicolons_ which is a byproduct of my IDE's default formatting.  If we intend to keep any of these around, I'd recommend pulling in `@typescript-eslint/plugin` and its ilk.
