### PR TITLE
chore(ci): add a release-please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+# this workflow automatically creates release PRs when something gets merged into the main branch.
+# we're using the strategy documented here https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # v3
+        with:
+          release-type: node
+          command: manifest
+          # see https://github.com/google-github-actions/release-please-action#github-credentials
+          # in case we want to run more workflows

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json",
+  "packages/aa": "3.1.2",
+  "packages/allow-scripts": "2.3.1",
+  "packages/browserify": "15.7.0",
+  "packages/core": "14.2.0",
+  "packages/lavapack": "5.2.0",
+  "packages/node": "7.1.0",
+  "packages/preinstall-always-fail": "1.0.0",
+  "packages/tofu": "6.0.2",
+  "packages/viz": "6.0.9"
+}

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,10 @@
   "changelogPreset": "conventional-changelog-conventionalcommits",
   "command": {
     "publish": {
-      "message": "chore: publish"
+      "message": "chore: publish",
+      "fromPackage": true,
+      "push": false,
+      "gitTagVersion": false
     },
     "version": {
       "allowBranch": "main",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    "packages/aa": {},
+    "packages/allow-scripts": {},
+    "packages/browserify": {},
+    "packages/core": {},
+    "packages/lavapack": {},
+    "packages/node": {},
+    "packages/preinstall-always-fail": {},
+    "packages/tofu": {},
+    "packages/viz": {}
+  },
+  "separate-pull-requests": true
+}


### PR DESCRIPTION
This adds configuration for releasing with the [release-please action](https://github.com/google-github-actions/release-please-action).

The way it works, in a nutshell:

- a commit with a [conventional commits](https://conventionalcommits.org)-valid message gets merged into `main`
- the action runs and creates _one PR per package_, with a new release ready to go, including updates to various CHANGELOGs, etc.
- another commit is merged
- the action either updates its existing PRs or creates new ones
- once a release PR is merged, the github release happens automatically
- the `npm publish` must be run manually by a human
