### PR TITLE
chore(deps): remove @metamask/eslint-config-nodejs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,18 +23,17 @@ module.exports = {
     // https://eslint.org/docs/latest/use/configure/language-options#specifying-environments
     ecmaVersion: 12,
   },
-  env: { es2020: true }, // this should be synced with the version of V8 used by the min supported node version
-  extends: ['@metamask/eslint-config-nodejs'],
+  env: { es2020: true, node: true }, // this should be synced with the version of V8 used by the min supported node version
+  extends: ['eslint:recommended', 'plugin:n/recommended'],
   rules: {
-    // base rules. should probably use eslint/recommended instead.
+    // base rules; none of these are in eslint/recommended
     'arrow-spacing': ['error', { before: true, after: true }],
     'brace-style': ['error', '1tbs'],
     'comma-dangle': ['error', 'always-multiline'],
     curly: ['error', 'all'],
     'eol-last': ['error', 'always'],
     indent: ['error', 2, { SwitchCase: 1, ObjectExpression: 'first' }],
-    'no-restricted-globals': 0,
-    'no-unexpected-multiline': 'error',
+    'no-empty': ['error', { allowEmptyCatch: true }],
     quotes: ['error', 'single'],
     semi: ['error', 'never'],
     'space-before-blocks': ['error', 'always'],
@@ -47,19 +46,31 @@ module.exports = {
       },
     ],
 
-    // plugin rules
+    // additional errors not in n/recommended
+    'n/callback-return': 'error',
+    'n/handle-callback-err': 'error',
+    'n/no-callback-literal': 'error',
+    'n/no-mixed-requires': 'error',
+    'n/no-new-require': 'error',
+    'n/no-restricted-import': 'error',
+    'n/no-restricted-require': 'error',
+    'n/prefer-global/buffer': 'error',
+    'n/prefer-global/console': 'error',
+    'n/prefer-global/process': 'error',
+    'n/prefer-global/text-decoder': 'error',
+    'n/prefer-global/text-encoder': 'error',
+    'n/prefer-global/url-search-params': 'error',
+    'n/prefer-global/url': 'error',
+    'n/prefer-promises/dns': 'error',
+    'n/prefer-promises/fs': 'error',
 
-    // all of these override stuff set in @metamask/eslint-config-nodejs.
-    'n/no-extraneous-require': 0,
-    'n/global-require': 0,
-    'n/exports-style': 0,
-    'n/no-process-env': 0,
-    // this rule seems broken
-    'n/no-unpublished-require': 0,
-    // we should probably actually fix these three and disable this override.
-    'n/no-sync': 0,
-    'n/no-process-exit': 0,
-    'n/no-path-concat': 0,
+    // these rules seem broken in a monorepo
+    'n/no-extraneous-require': 'off',
+    'n/no-unpublished-require': 'off',
+
+    // we should probably actually fix these three and turn these back on
+    'n/no-sync': 'off', // very few reasons to actually use this; "CLI tool" is not one of them
+    'n/no-process-exit': 'off', // should not be used with async code
   },
   // these are plugin-specific settings.
   settings: {
@@ -78,7 +89,7 @@ module.exports = {
       files: ['packages/*/test/**/*.js', 'packages/*/src/**/*.test.js'],
       extends: ['plugin:ava/recommended'],
       rules: {
-        'ava/no-import-test-files': 0,
+        'ava/no-import-test-files': 'off',
       },
     },
     {
@@ -87,6 +98,49 @@ module.exports = {
         Compartment: 'readonly',
         templateRequire: 'readonly',
         lockdown: 'readonly',
+      },
+    },
+    {
+      files: ['packages/*/test/**/*.js'],
+      env: {
+        browser: true,
+      },
+      rules: {
+        'no-unused-vars': 'off',
+        'no-undef': 'off',
+        'n/no-path-concat': 'off', // this should be removed and the issues fixed
+        'n/no-missing-require': 'off',
+      },
+    },
+    {
+      files: ['packages/core/lib/**/*.js'],
+      rules: {
+        'no-unused-vars': 'off',
+      },
+    },
+    {
+      files: ['packages/lavapack/src/*-template.js'],
+      globals: {
+        templateRequire: 'readonly',
+        self: 'readonly',
+        __reportStatsHook__: 'readonly',
+        __createKernel__: 'readonly',
+      },
+    },
+    {
+      files: ['packages/core/src/*Template.js'],
+      globals: {
+        __lavamoatDebugOptions__: 'readonly',
+        __lavamoatSecurityOptions__: 'readonly',
+        self: 'readonly',
+        __createKernelCore__: 'readonly',
+      },
+    },
+    {
+      files: ['packages/perf/**/*.js'],
+      globals: {
+        lockdown: 'readonly',
+        Compartment: 'readonly',
       },
     },
     {
@@ -105,11 +159,18 @@ module.exports = {
       extends: ['plugin:react/recommended'],
       plugins: ['react', 'import'],
       rules: {
-        'no-negated-condition': 0,
+        'no-negated-condition': 'off',
         'import/extensions': ['error', 'always', { ignorePackages: true }],
-        'import/no-unassigned-import': 0,
-        'import/unambiguous': 0,
-        'react/prop-types': 0,
+        'import/no-unassigned-import': 'off',
+        'import/unambiguous': 'off',
+        'react/prop-types': 'off',
+        'n/no-missing-import': 'off',
+      },
+    },
+    {
+      files: ['packages/viz/src/App.test.js'],
+      env: {
+        mocha: true,
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
         "@commitlint/config-conventional": "^17.6.7",
-        "@metamask/eslint-config-nodejs": "^12.0.0",
         "ava": "^5.2.0",
         "conventional-changelog-conventionalcommits": "^6.1.0",
         "cross-env": "^7.0.3",
@@ -2192,21 +2191,6 @@
       "version": "0.2.31",
       "license": "Apache-2.0"
     },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz",
-      "integrity": "sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "comment-parser": "1.3.1",
-        "esquery": "^1.5.0",
-        "jsdoc-type-pratt-parser": "~4.0.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19 || ^20"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "dev": true,
@@ -2547,39 +2531,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@metamask/eslint-config": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eslint-config/-/eslint-config-12.1.0.tgz",
-      "integrity": "sha512-kNzuAgRu/L8nQi5bW7nfLS78ylmW9gcTH81+zGEq9KNiOgNfg8pxCNjatYRbnOoLA57/NYKLLxbTeBMjXRscfg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.27.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-jsdoc": "^39.6.2 || ^41",
-        "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-promise": "^6.1.1",
-        "prettier": "^2.7.1"
-      }
-    },
-    "node_modules/@metamask/eslint-config-nodejs": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eslint-config-nodejs/-/eslint-config-nodejs-12.1.0.tgz",
-      "integrity": "sha512-qYg6TESACJokSD8pnbgJ6JtQDvx2jCM/hWEeHbGsNDDUvMl0f8MlHz1H5bDutiUgWDJMI3oMWm6OYMmUWZhXPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@metamask/eslint-config": "^12.0.0",
-        "eslint": "^8.27.0",
-        "eslint-plugin-n": "^15.7.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4577,16 +4528,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/are-docs-informative": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
-      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "license": "ISC",
@@ -6518,16 +6459,6 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -8702,19 +8633,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-config-prettier": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
-      "integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.7",
       "dev": true,
@@ -8877,42 +8795,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-jsdoc": {
-      "version": "41.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-41.1.2.tgz",
-      "integrity": "sha512-MePJXdGiPW7AG06CU5GbKzYtKpoHwTq1lKijjq+RwL/cQkZtBZ59Zbv5Ep0RVxSMnq6242249/n+w4XrTZ1Afg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.37.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.3.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.5.0",
-        "semver": "^7.3.8",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint-plugin-n": {
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
@@ -8936,41 +8818,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
-      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -11786,16 +11633,6 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -15844,35 +15681,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
     "@commitlint/config-conventional": "^17.6.7",
-    "@metamask/eslint-config-nodejs": "^12.0.0",
     "ava": "^5.2.0",
     "conventional-changelog-conventionalcommits": "^6.1.0",
     "cross-env": "^7.0.3",

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -1,4 +1,4 @@
-const { readFileSync, statSync } = require('fs')
+const { readFileSync } = require('fs')
 const path = require('path')
 const nodeResolve = require('resolve')
 
@@ -31,7 +31,7 @@ function createPerformantResolve () {
         readPackageSync: readPackageWithout(path),
       }),
   }
-};
+}
 
 /**
  * @param {object} options
@@ -39,7 +39,7 @@ function createPerformantResolve () {
  */
 async function loadCanonicalNameMap({ rootDir, includeDevDeps, resolve } = {}) {
   const canonicalNameMap = new Map()
-  // performant resolve avoids loading package.jsons if their path is what's being resolved, 
+  // performant resolve avoids loading package.jsons if their path is what's being resolved,
   // offering 2x performance improvement compared to using original resolve
   resolve = resolve || createPerformantResolve()
   // resolve = resolve || nodeResolve
@@ -87,7 +87,8 @@ let nextLevelTodos
  * @param {object} options
  * @returns {Map<{packageDir: string, logicalPathParts: string[]}>}
  */
-function walkDependencyTreeForBestLogicalPaths({ packageDir, logicalPath = [], includeDevDeps = false, visited = new Set(), resolve = performantResolve }) {
+function walkDependencyTreeForBestLogicalPaths({ packageDir, logicalPath = [], includeDevDeps = false, visited = new Set(), resolve }) {
+  resolve = resolve ?? createPerformantResolve()
   const preferredPackageLogicalPathMap = new Map()
   // add the entry package as the first work unit
   currentLevelTodos = [{ packageDir, logicalPath, includeDevDeps, visited, resolve }]

--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -17,13 +17,13 @@ const setup = require('./setup')
  * @property {BinsConfig} configs.bin
  * @property {boolean} somePoliciesAreMissing
  *
- * Individual package info 
+ * Individual package info
  * @typedef {Object} PkgInfo
  * @property {string} canonicalName
  * @property {string} path
  * @property {Object} scripts
  *
- * Individual bin link info 
+ * Individual bin link info
  * @typedef {Object} BinInfo
  * @property {string} canonicalName
  * @property {boolean} isDirect
@@ -41,7 +41,7 @@ const setup = require('./setup')
  * @property {Array} missingPolicies
  * @property {Array} excessPolicies
  *
- * @typedef {Map<string,[BinInfo]>} BinCandidates 
+ * @typedef {Map<string,[BinInfo]>} BinCandidates
  *
  * Configuration for a type of bins policies
  * @typedef {Object} BinsConfig
@@ -193,8 +193,8 @@ function printMissingPoliciesIfAny({ missingPolicies = [], packagesWithScripts =
 // internals
 
 /**
- * 
- * @param {Object} arg 
+ *
+ * @param {Object} arg
  * @param {string} arg.event
  * @param {Array<PkgInfo>} arg.packages
  */
@@ -207,7 +207,7 @@ async function runAllScriptsForEvent({ event, packages }) {
   }
 }
 /**
- * @param {Array<BinInfo>} allowedBins 
+ * @param {Array<BinInfo>} allowedBins
  */
 async function installBinScripts(allowedBins) {
   for (const { bin, path, link, canonicalName } of allowedBins) {
@@ -217,7 +217,7 @@ async function installBinScripts(allowedBins) {
 }
 /**
  * Points all bins on the list to whichbin.js cli app from allow-scripts
- * @param {Array<BinInfo>} firewalledBins 
+ * @param {Array<BinInfo>} firewalledBins
  * @param {string} link - absolute path to the whichbin.js script
  */
 async function installBinFirewall(firewalledBins, link) {
@@ -250,7 +250,7 @@ async function runScript({ path, event }) {
 const bannedBins = new Set(['node', 'npm', 'yarn', 'pnpm'])
 
 /**
- * @param {BinCandidates} binCandidates 
+ * @param {BinCandidates} binCandidates
  */
 function prepareBinScriptsPolicy(binCandidates) {
   const policy = {}
@@ -267,7 +267,7 @@ function prepareBinScriptsPolicy(binCandidates) {
 
 
 /**
- * @param {BinsConfig} param0 
+ * @param {BinsConfig} param0
  */
 function printPackagesByBins({
   allowedBins,
@@ -292,7 +292,7 @@ function printPackagesByBins({
 }
 
 /**
- * @param {ScriptsConfig} param0 
+ * @param {ScriptsConfig} param0
  */
 function printPackagesByScriptConfiguration({
   packagesWithScripts,
@@ -340,8 +340,8 @@ function printPackagesByScriptConfiguration({
 }
 
 /**
- * 
- * @param {Object} args 
+ *
+ * @param {Object} args
  * @param {string} args.rootDir
  * @param {PkgConfs} args.conf
  * @returns {Promise}
@@ -362,8 +362,8 @@ async function savePackageConfigurations({ rootDir, conf: {
 }
 
 /**
- * 
- * @param {Object} args 
+ *
+ * @param {Object} args
  * @param {string} args.rootDir
  * @returns {Promise<PkgConfs>}
  */
@@ -372,13 +372,14 @@ async function loadAllPackageConfigurations({ rootDir }) {
   const binCandidates = new Map()
 
   const dependencyMap = await loadCanonicalNameMap({ rootDir, includeDevDeps: true })
-  const sortedDepEntries = Array.from(dependencyMap.entries()).sort(sortBy(([filePath, canonicalName]) => canonicalName))
+  const sortedDepEntries = Array.from(dependencyMap.entries()).sort(sortBy(([, canonicalName]) => canonicalName))
   const packageJson = JSON.parse(await fs.readFile(path.join(rootDir, 'package.json'), 'utf8'))
   const directDeps = new Set([...Object.keys(packageJson.devDependencies||{}),...Object.keys(packageJson.dependencies||{})])
 
   for (const [filePath, canonicalName] of sortedDepEntries) {
     // const canonicalName = getCanonicalNameForPath({ rootDir, filePath: filePath })
     let depPackageJson
+    // eslint-disable-next-line no-useless-catch
     try {
       depPackageJson = JSON.parse(await fs.readFile(path.join(filePath, 'package.json'), 'utf-8'))
     } catch (err) {
@@ -412,7 +413,7 @@ async function loadAllPackageConfigurations({ rootDir }) {
         }
         collection.push({
           // canonical name for a direct dependency is just dependency name
-          isDirect: directDeps.has(canonicalName), 
+          isDirect: directDeps.has(canonicalName),
           bin: name,
           path: filePath,
           link,
@@ -455,9 +456,9 @@ function indexLifecycleConfiguration(config) {
   // packages with config
   const configuredPatterns = Object.keys(config.allowConfig)
   // select allowed + disallowed
-  config.allowedPatterns = Object.entries(config.allowConfig).filter(([pattern, packageData]) => !!packageData).map(([pattern]) => pattern)
+  config.allowedPatterns = Object.entries(config.allowConfig).filter(([, packageData]) => !!packageData).map(([pattern]) => pattern)
 
-  config.disallowedPatterns = Object.entries(config.allowConfig).filter(([pattern, packageData]) => !packageData).map(([pattern]) => pattern)
+  config.disallowedPatterns = Object.entries(config.allowConfig).filter(([, packageData]) => !packageData).map(([pattern]) => pattern)
 
   config.missingPolicies = Array.from(config.packagesWithScripts.keys())
     .filter(pattern => !configuredPatterns.includes(pattern))

--- a/packages/allow-scripts/src/linker.js
+++ b/packages/allow-scripts/src/linker.js
@@ -1,6 +1,5 @@
 // @ts-check
 // All of this is derived from the main functionality of bin-links that unfortunately would not allow for absolute path links
-const { promises: fs } = require('fs')
 const binTarget = require('bin-links/lib/bin-target.js')
 const isWindows = require('bin-links/lib/is-windows.js')
 const linkBin = isWindows ? require('bin-links/lib/shim-bin.js') : require('bin-links/lib/link-bin.js')

--- a/packages/allow-scripts/test/index.js
+++ b/packages/allow-scripts/test/index.js
@@ -89,10 +89,10 @@ test('cli - run command - good dep at the root', (t) => {
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
-    'running lifecycle scripts for event \"preinstall\"',
+    'running lifecycle scripts for event "preinstall"',
     '- good_dep',
-    'running lifecycle scripts for event \"install\"',
-    'running lifecycle scripts for event \"postinstall\"',
+    'running lifecycle scripts for event "install"',
+    'running lifecycle scripts for event "postinstall"',
     'running lifecycle scripts for top level package',
     '',
   ])
@@ -124,10 +124,10 @@ test('cli - run command - good dep at the root with experimental bins', (t) => {
   t.deepEqual(result.stdout.toString().split('\n'), [
     'installing bin scripts',
     '- good - from package: good_dep',
-    'running lifecycle scripts for event \"preinstall\"',
+    'running lifecycle scripts for event "preinstall"',
     '- good_dep',
-    'running lifecycle scripts for event \"install\"',
-    'running lifecycle scripts for event \"postinstall\"',
+    'running lifecycle scripts for event "install"',
+    'running lifecycle scripts for event "postinstall"',
     'running lifecycle scripts for top level package',
     '',
   ])
@@ -166,10 +166,10 @@ test('cli - run command - good dep as a sub dep', (t) => {
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
-    'running lifecycle scripts for event \"preinstall\"',
+    'running lifecycle scripts for event "preinstall"',
     '- bbb>good_dep',
-    'running lifecycle scripts for event \"install\"',
-    'running lifecycle scripts for event \"postinstall\"',
+    'running lifecycle scripts for event "install"',
+    'running lifecycle scripts for event "postinstall"',
     '- bbb',
     'running lifecycle scripts for top level package',
     '',
@@ -205,10 +205,10 @@ test('cli - run command - good dep as a sub dep with experimental bins', (t) => 
   t.deepEqual(result.stdout.toString().split('\n'), [
     'installing bin scripts',
     '- good - from package: aaa',
-    'running lifecycle scripts for event \"preinstall\"',
+    'running lifecycle scripts for event "preinstall"',
     '- bbb>good_dep',
-    'running lifecycle scripts for event \"install\"',
-    'running lifecycle scripts for event \"postinstall\"',
+    'running lifecycle scripts for event "install"',
+    'running lifecycle scripts for event "postinstall"',
     '- bbb',
     '',
   ])

--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -277,7 +277,7 @@ function validatePolicy (policy) {
     throw new Error('LavaMoat - Expected label \'resources\' for configuration key')
   }
 
-  Object.entries(policy.resources).forEach(([packageName, packageOpts], index) => {
+  Object.entries(policy.resources).forEach(([, packageOpts]) => {
     const packageOptions = Object.keys(packageOpts)
     const packageEntries = Object.values(packageOpts)
     const optionsWhitelist = ['globals', 'packages']

--- a/packages/browserify/test/basic.js
+++ b/packages/browserify/test/basic.js
@@ -47,7 +47,7 @@ test('basic - lavamoat policy and bundle', async (t) => {
   })
   await autoConfigForScenario({ scenario })
   const { bundleForScenario } = await createBundleForScenario({ scenario })
-  
+
   t.true(bundleForScenario.includes('"location.href":true'), 'prelude includes href policy')
 
   const testHref = 'https://funky.town.gov/yolo?snake=yes'
@@ -74,7 +74,7 @@ test('basic - lavamoat bundle without prelude', async (t) => {
   let didCallLoadBundle = false
   const testGlobal = {
     LavaPack: { loadBundle: () => {
-      didCallLoadBundle = true 
+      didCallLoadBundle = true
     } },
   }
   evalBundle(bundleForScenario, testGlobal)

--- a/packages/browserify/test/generatePolicy.js
+++ b/packages/browserify/test/generatePolicy.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 const test = require('ava')
 
 const {
@@ -19,7 +20,7 @@ test('generatePolicy - empty policy', async (t) => {
 test('generatePolicy - basic policy', async (t) => {
   const scenario = createScenarioFromScaffold({
     defineOne: () => {
-      module.exports = global.two 
+      module.exports = global.two
     },
     defaultPolicy: false,
   })
@@ -83,6 +84,8 @@ test('generatePolicy - policy ignores global refs', async (t) => {
 test('generatePolicy - policy ignores global refs when properties are not accessed', async (t) => {
   const scenario = createScenarioFromScaffold({
     defineOne: () => {
+      // XXX: this is probably wrong.  either use `typeof window === 'undefined'` or `window === undefined`
+      // eslint-disable-next-line valid-typeof
       typeof window !== undefined
     },
     defaultPolicy: false,

--- a/packages/core/lib/strict-scope-terminator.js
+++ b/packages/core/lib/strict-scope-terminator.js
@@ -41,11 +41,11 @@ const alwaysThrowHandler = new Proxy(
   }),
 )
 
-/*
- * scopeProxyHandlerProperties
+/**
  * scopeTerminatorHandler manages a strictScopeTerminator Proxy which serves as
  * the final scope boundary that will always return "undefined" in order
  * to prevent access to "start compartment globals".
+ * @type {ProxyHandler}
  */
 const scopeProxyHandlerProperties = {
   get(_shadow, _prop) {

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -39,6 +39,7 @@ function generateKernel (_opts = {}) {
   output = replaceTemplateRequire(output, 'ses', sesSrc)
   output = stringReplace(output, '__createKernelCore__', kernelCode)
   output = stringReplace(output, '__lavamoatDebugOptions__', JSON.stringify({debugMode: !!opts.debugMode}))
+  // eslint-disable-next-line no-prototype-builtins
   if (opts?.hasOwnProperty('scuttleGlobalThis')) {
     // scuttleGlobalThis config placeholder should be set only if ordered so explicitly.
     // if not, should be left as is to be replaced by a later processor (e.g. LavaPack).

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -59,6 +59,7 @@ function createModuleInspector (opts = {}) {
     }
   }
 
+  // eslint-disable-next-line no-unused-vars
   function inspectBuiltinModule (moduleRecord) {
     // builtins themselves do not require any configuration
     // packages that import builtins need to add that to their configuration
@@ -189,7 +190,7 @@ function createModuleInspector (opts = {}) {
   function inspectForImports (ast, moduleRecord, packageName, isBuiltin, includeDebugInfo) {
     // get all requested names that resolve to isBuiltin
     const namesForBuiltins = Object.entries(moduleRecord.importMap)
-      .filter(([_, resolvedName]) => isBuiltin(resolvedName))
+      .filter(([, resolvedName]) => isBuiltin(resolvedName))
       .map(([requestedName]) => requestedName)
     const { cjsImports: moduleBuiltins } = inspectImports(ast, namesForBuiltins)
     if (!moduleBuiltins.length) {

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -146,12 +146,14 @@
 
       const obj = Object.create(null)
       for (const prop of props) {
+        // eslint-disable-next-line no-inner-declarations
         function set() {
           console.warn(
             `LavaMoat - property "${prop}" of globalThis cannot be set under scuttling mode. ` +
             'To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.',
           )
         }
+        // eslint-disable-next-line no-inner-declarations
         function get() {
           throw new Error(
             `LavaMoat - property "${prop}" of globalThis is inaccessible under scuttling mode. ` +
@@ -230,6 +232,7 @@
         // this is passed to the module initializer
         // it adds the context of the parent module
         // this could be replaced via "Function.prototype.bind" if its more performant
+        // eslint-disable-next-line no-inner-declarations
         function requireRelativeWithContext (requestedName) {
           const parentModuleExports = moduleObj.exports
           const parentModuleData = moduleData
@@ -248,7 +251,8 @@
       const parentModulePackageName = parentModuleData.package
       const parentPackagesWhitelist = parentPackagePolicy.packages
       const parentBuiltinsWhitelist = Object.entries(parentPackagePolicy.builtin)
-        .filter(([_, allowed]) => allowed === true)
+        .filter(([, allowed]) => allowed === true)
+        // eslint-disable-next-line no-unused-vars
         .map(([packagePath, allowed]) => packagePath.split('.')[0])
 
       // resolve the moduleId from the requestedName
@@ -298,6 +302,7 @@
           // grab all allowed builtin paths that match this package
             .filter(([packagePath, allowed]) => allowed === true && moduleId === packagePath.split('.')[0])
           // only include the paths after the packageName
+            // eslint-disable-next-line no-unused-vars
             .map(([packagePath, allowed]) => packagePath.split('.').slice(1).join('.'))
             .sort()
         )
@@ -475,7 +480,7 @@
       // transform functions, getters & setters on prop descs. Solves SES scope proxy bug
       Object.entries(Object.getOwnPropertyDescriptors(endowments))
         // ignore non-configurable properties because we are modifying endowments in place
-        .filter(([key, propDesc]) => propDesc.configurable)
+        .filter(([, propDesc]) => propDesc.configurable)
         .forEach(([key, propDesc]) => {
           const wrappedPropDesc = applyEndowmentPropDescTransforms(propDesc, packageCompartment, rootPackageCompartment.globalThis)
           Reflect.defineProperty(endowments, key, wrappedPropDesc)

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -48,6 +48,7 @@
     // create the SES rootRealm
     // "templateRequire" calls are inlined in "generateKernel"
     // load-bearing semi-colon, do not remove
+    // eslint-disable-next-line no-extra-semi
     ;templateRequire('ses')
 
     const lockdownOptions = {

--- a/packages/core/src/makeGetEndowmentsForConfig.js
+++ b/packages/core/src/makeGetEndowmentsForConfig.js
@@ -43,7 +43,7 @@ function makeGetEndowmentsForConfig ({ createFunctionWrapper }) {
       // false means no access. It's necessary so that overrides can also be used to tighten the policy
       if (configValue === false) {
         explicitlyBanned.push(path)
-        return 
+        return
       }
       // write access handled elsewhere
       if (configValue === 'write') {
@@ -238,6 +238,7 @@ function makeGetEndowmentsForConfig ({ createFunctionWrapper }) {
 
 function getPropertyDescriptorDeep (target, key) {
   let receiver = target
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     // abort if this is the end of the prototype chain.
     if (!receiver) {

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -234,7 +234,7 @@ function createHookedConsole () {
   let hasResolved = false
   let resolve
   const firstLogEventPromise = new Promise(_resolve => {
-    resolve = _resolve 
+    resolve = _resolve
   })
   const hookedLog = (message) => {
     if (hasResolved) {
@@ -359,7 +359,6 @@ function fillInFileDetails (files) {
     if (path.extname(file) === '.js') {
       // parse as LavamoatModuleRecord
       fileObj.specifier = fileObj.file || file
-      fileObj.packageName = fileObj.packageName
       fileObj.type = fileObj.type || 'js'
       fileObj.entry = Boolean(fileObj.entry)
     }
@@ -374,7 +373,7 @@ function moduleDataForBuiltin (builtinObj, name) {
     package: name,
     type: 'builtin',
     moduleInitializer: (_, _2, module) => {
-      module.exports = builtinObj[name] 
+      module.exports = builtinObj[name]
     },
   }
 }

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -53,6 +53,8 @@ function createPacker({
   policy = {},
   // prune policy to only include packages used in the bundle
   prunePolicy = false,
+  // XXX: what is this?
+  // eslint-disable-next-line no-unused-vars
   externalRequireName,
   sourceRoot,
   sourceMapPrefix,
@@ -232,7 +234,7 @@ function createPacker({
   }
 
   function serializeModule (moduleData, sourceMeta) {
-    const { id, packageName, source, deps, file } = moduleData
+    const { id, packageName, deps, file } = moduleData
     const relativeFilePath = file && path.relative(basedir, file)
     // for now, ignore new sourcemap and just append original filename
     // serialize final module entry

--- a/packages/lavapack/src/runtime-cjs-template.js
+++ b/packages/lavapack/src/runtime-cjs-template.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-extra-semi
 ;(function() {
   function getGlobalRef () {
     if (typeof globalThis !== 'undefined') {
@@ -43,6 +44,7 @@
   }
 
   // it is called by the modules collection that will be appended to this file
+  // eslint-disable-next-line no-unused-vars
   function loadBundle (newModules, entryPoints, bundlePolicy) {
     // ignore bundlePolicy as we wont be enforcing it
     // verify + load in each module

--- a/packages/lavapack/src/runtime-template.js
+++ b/packages/lavapack/src/runtime-template.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+// eslint-disable-next-line no-extra-semi
 ;(function() {
   // this runtime template code is destined to wrap LavaMoat entirely,
   // therefore this is our way of capturing access to basic APIs LavaMoat

--- a/packages/perf/build.js
+++ b/packages/perf/build.js
@@ -32,6 +32,7 @@ const bundler = browserify(['./entry.js'], {
 
 // build
 
+// eslint-disable-next-line no-unused-vars
 async function main () {
   fs.mkdirSync('./bundle', { recursive: true })
   await performBundle()

--- a/packages/perf/endo.js
+++ b/packages/perf/endo.js
@@ -59,7 +59,7 @@ async function main () {
     path: await addToCompartment('path', require('path')),
     fs: await addToCompartment('fs', require('fs')),
   }
-  
+
 
   const readPowers = makeReadPowers({ fs, url, crypto })
   const moduleLocation = url.pathToFileURL(process.cwd() + '/entry.js')
@@ -81,7 +81,7 @@ async function main () {
   )
 
   function makeSesModuleTransform (language) {
-    return function sesModuleTransform (sourceBytes, _speciefier, _location) {
+    return function sesModuleTransform (sourceBytes) {
       const transformedSource = _applySesEvasions(sourceBytes.toString())
       const bytes = Buffer.from(transformedSource, 'utf8')
       return { bytes, parser: language }
@@ -99,13 +99,13 @@ async function main () {
     return result
   }
 
-  
+
   function applySesEvasions (source) {
     return applyTransforms(source, [
       evadeHtmlCommentTest,
       evadeImportExpressionTest,
       (src) => {
-        const someDirectEvalPattern = /(^|[^.])\beval(\s*\()/g      
+        const someDirectEvalPattern = /(^|[^.])\beval(\s*\()/g
         return src.replaceAll(someDirectEvalPattern, '$1(0,eval)(')
       },
     ])

--- a/packages/survey/src/downloadPackage.js
+++ b/packages/survey/src/downloadPackage.js
@@ -1,7 +1,7 @@
 const util = require('util')
 const execFile = util.promisify(require('child_process').execFile)
 const { promises: fs } = require('fs')
-const { resolve } = require('path')
+const { resolve, join } = require('path')
 
 module.exports = {
   downloadPackage,
@@ -9,10 +9,8 @@ module.exports = {
 
 
 async function downloadPackage (packageName) {
-  const downloadDir = resolve(__dirname + '/../downloads')
+  const downloadDir = resolve(join(__dirname, '..', 'downloads'))
   const packageDir = `${downloadDir}/${packageName}`
   await fs.rmdir(packageDir, { recursive: true })
-  const { stdout, stderr } = await execFile(__dirname + '/download.sh', [packageName, packageDir])
-  // console.log(stdout)
-  // console.info(stderr)
+  await execFile(join(__dirname, 'download.sh'), [packageName, packageDir])
 }

--- a/packages/survey/src/execTest.js
+++ b/packages/survey/src/execTest.js
@@ -7,7 +7,7 @@ const { spawn, exec: execCb } = require('child_process')
 
 const exec = promisify(execCb)
 const makeTempDir = async () => {
-  return await fs.mkdtemp(path.join(os.tmpdir(), 'lavamoat-survey-')) 
+  return await fs.mkdtemp(path.join(os.tmpdir(), 'lavamoat-survey-'))
 }
 const mitmPath = new URL('../mitm', `file://${__filename}`).pathname
 
@@ -42,12 +42,12 @@ async function prepareRepo ({ projectDir, gitRepo, gitRef }) {
 }
 
 async function installDependencies ({ projectDir }) {
-  const { stdout, stderr } = await exec('yarn install', { cwd: projectDir })
+  await exec('yarn install', { cwd: projectDir })
   console.log('deps installed')
 }
 
 async function runPlainTests ({ projectDir }) {
-  const { stdout, stderr } = await exec('yarn run test', { cwd: projectDir })
+  await exec('yarn run test', { cwd: projectDir })
   console.log('tests passed directly')
 }
 

--- a/packages/survey/src/getTopPackages.js
+++ b/packages/survey/src/getTopPackages.js
@@ -10,6 +10,8 @@ module.exports = {
   getTopPackages,
 }
 
+// XXX: remove if unneeded
+// eslint-disable-next-line no-unused-vars
 const npmDependentsScraper = createScraper({
   buildUrl: ({ offset }) => `https://www.npmjs.com/browse/depended?offset=${offset}`,
   entrySelector: '.flex-row.pr3',
@@ -43,7 +45,7 @@ const librariesIoRankScraper = createScraper({
 })
 
 async function getTopPackages () {
-  const indexPath = path.resolve(__dirname + '/../downloads/index.json')
+  const indexPath = path.resolve(__dirname, '..', 'downloads', 'index.json')
   try {
     const indexContent = await fs.readFile(indexPath, 'utf8')
     return JSON.parse(indexContent)
@@ -77,7 +79,7 @@ function createScraper ({ buildUrl, entrySelector, packagesPerPage, maxResults }
     }), { concurrency: 8 })
     return pageResults.flat().slice(0, count)
   }
-  
+
   async function downloadPage (page) {
     const offset = page * packagesPerPage
     const url = buildUrl({ page, offset })

--- a/packages/survey/src/index.js
+++ b/packages/survey/src/index.js
@@ -80,18 +80,18 @@ async function generateConfigFile (packageName) {
 }
 
 async function generatePolicy (packageName) {
-  const { package, packageDir } = await loadPackage(packageName)
+  const { package: pkg, packageDir } = await loadPackage(packageName)
   // if main is explicitly empty, skip (@types/node, etc)
-  if (package.main === '') {
+  if (pkg.main === '') {
     console.warn(`skipped "${packageName}" - explicitly no entry`)
     return { resources: {} }
   }
   // normalize the id as a relative path
-  const entryId = './' + path.relative('./', package.main || 'index.js')
+  const entryId = './' + path.relative('./', pkg.main || 'index.js')
   const resolveHook = makeResolveHook({ cwd: packageDir })
-  let entryFull
+
   try {
-    entryFull = resolveHook(entryId, `${packageDir}/package.json`)
+    resolveHook(entryId, `${packageDir}/package.json`)
   } catch (err) {
     if (err.code === 'MODULE_NOT_FOUND') {
       console.warn(`skipped "${packageName}" - no entry`)
@@ -117,7 +117,6 @@ async function generatePolicy (packageName) {
 async function writeConfig (packageName, config) {
   const configContent = JSON.stringify(config, null, 2)
   const policyPath = getPolicyPath(packageName)
-  const policyDir = path.dirname(policyPath)
   // ensure dir exists (this includes the package scope)
   await fs.mkdir(path.dirname(policyPath), { recursive: true })
   await fs.writeFile(policyPath, configContent)

--- a/packages/survey/src/load.js
+++ b/packages/survey/src/load.js
@@ -1,5 +1,3 @@
-const util = require('util')
-const { promises: fs } = require('fs')
 const { resolve } = require('path')
 const { downloadPackage } = require('./downloadPackage.js')
 const { fileExists } = require('./util.js')
@@ -10,7 +8,7 @@ module.exports = {
 
 
 async function loadPackage (packageName) {
-  const downloadDir = resolve(__dirname + '/../downloads')
+  const downloadDir = resolve(__dirname, '..', 'downloads')
   const packageDir = `${downloadDir}/${packageName}`
   const packageJsonPath = `${packageDir}/package.json`
   const exists = await fileExists(packageJsonPath)
@@ -18,7 +16,7 @@ async function loadPackage (packageName) {
     console.info(`downloading ${packageName}`)
     await downloadPackage(packageName)
   }
-  const package = require(packageJsonPath)
-  return { package, packageDir }
+  const pkg = require(packageJsonPath)
+  return { package: pkg, packageDir }
 }
 

--- a/packages/survey/src/parseForPolicy.js
+++ b/packages/survey/src/parseForPolicy.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { parseForPolicy: nodeParseForConfig, makeResolveHook, makeImportHook } = require('lavamoat/src/parseForPolicy')
+const { makeResolveHook, makeImportHook } = require('lavamoat/src/parseForPolicy')
 const { builtinModules: builtinPackages } = require('module')
 const { inspectSesCompat, codeSampleFromAstNode } = require('lavamoat-tofu')
 const { walk } = require('lavamoat-core/src/walk')

--- a/packages/survey/src/prepareHook.js
+++ b/packages/survey/src/prepareHook.js
@@ -10,6 +10,7 @@ const path = require('path')
 const node = process.env.NVM_BIN ? `${process.env.NVM_BIN}/node` : process.argv[0]
 const npxPath = path.resolve(node, '../npx')
 const lavamoat = require.resolve('lavamoat/src/index.js')
+// eslint-disable-next-line no-unused-vars
 const lockdown = new URL('../src/lockdown.cjs', `file://${__filename}`).pathname
 const mitm = new URL('../mitm/node', `file://${__filename}`).pathname
 

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -107,7 +107,7 @@ function inspectGlobals (source, {
   }
 }
 
-function inspectEsmImports (ast, packagesToInspect) {
+function inspectEsmImports (ast) {
   const esmImports = []
   traverse(ast, {
     ImportDeclaration: (path) => {

--- a/packages/tofu/test/inspectEsmImports.js
+++ b/packages/tofu/test/inspectEsmImports.js
@@ -52,6 +52,7 @@ function testInspect (label, opts, fn, expectedResultObj) {
       label, opts, ast, source
       console.log(resultSorted)
       console.log(expectedSorted)
+      // eslint-disable-next-line no-debugger
       debugger
     }
 

--- a/packages/tofu/test/inspectGlobals.js
+++ b/packages/tofu/test/inspectGlobals.js
@@ -132,6 +132,8 @@ testInspect('not picking up js language features', {
 testInspect('ignore globalRef without property lookup', {
   globalRefs: ['window'],
 }, () => {
+  // XXX: this is probably wrong.  either use `typeof window === 'undefined'` or `window === undefined`
+  // eslint-disable-next-line valid-typeof
   typeof window === undefined
 }, {})
 
@@ -274,6 +276,7 @@ function testInspect (label, opts, fn, expectedResultObj) {
     // for debugging
     if (!deepEqual(resultSorted, expectedSorted)) {
       label, opts
+      // eslint-disable-next-line no-debugger
       debugger
     }
 

--- a/packages/tofu/test/inspectImports.js
+++ b/packages/tofu/test/inspectImports.js
@@ -94,6 +94,7 @@ function testInspect (label, opts, fn, expectedResultObj) {
       label, opts
       console.log(resultSorted)
       console.log(expectedSorted)
+      // eslint-disable-next-line no-debugger
       debugger
     }
 

--- a/packages/viz/bin/index.js
+++ b/packages/viz/bin/index.js
@@ -91,7 +91,6 @@ async function main () {
       console.info('serving a pre-built dashboard. to generate new dashboard and serve use "lavamoat-viz --serve"')
       console.info('this is equivalent to "npx serve ./viz"')
       console.info('\n')
-      const fullDest = path.resolve(dest)
       return await serveViz(dest)
     }
     default: {

--- a/packages/viz/src/App.js
+++ b/packages/viz/src/App.js
@@ -11,7 +11,7 @@ const { DepGraph } = require('./graphs/DepGraph.js')
 const { LavamoatPolicies } = globalThis
 
 // merge all configs into final
-for (const [policyName, policyData] of Object.entries(LavamoatPolicies)) {
+for (const [, policyData] of Object.entries(LavamoatPolicies)) {
   if (!policyData.final) {
     if (policyData.override) {
       policyData.final = mergePolicy(policyData.primary, policyData.override)
@@ -27,7 +27,7 @@ const defaultPolicyName = policyNames[0]
 class App extends Component {
 
   selectPolicy (target) {
-    this.setState(state => ({ policyName: target }))
+    this.setState(() => ({ policyName: target }))
   }
 
   render () {

--- a/packages/viz/src/graphs/DepGraph.js
+++ b/packages/viz/src/graphs/DepGraph.js
@@ -327,7 +327,9 @@ class DepGraph extends React.Component {
       onHoverStart: ({ object: { name: nodeId } }, controller) => {
         setControllerText(controller, `${nodeId}`)
       },
-      onSelectStart: ({ object: { name: nodeId } }, controller) => {
+      onSelectStart: ({ object: { name: nodeId } }) => {
+        // FIXME: this is most certainly broken
+        // eslint-disable-next-line no-undef
         actions.selectPackage(nodeId)
       },
       controller1,

--- a/packages/viz/src/graphs/buffer-geometry-controller.js
+++ b/packages/viz/src/graphs/buffer-geometry-controller.js
@@ -45,7 +45,7 @@ export class BufferGeometryController {
     }
     // update draw range. check position attribute size to see if
     // we are counting indices or vertices
-    const [_, count] = this.attributeSizes.position
+    const [, count] = this.attributeSizes.position
     this.geometry.setDrawRange(0, (itemCount + 1) * count)
     return index
   }
@@ -130,7 +130,7 @@ export class InstancedBufferGeometryController {
     }
     // update draw range. check position attribute size to see if
     // we are counting indices or vertices
-    const [_, count] = this.attributeSizes.position
+    const [, count] = this.attributeSizes.position
     this.geometry.setDrawRange(0, (itemCount + 1) * count)
     return index
   }

--- a/packages/viz/src/graphs/points-controller.js
+++ b/packages/viz/src/graphs/points-controller.js
@@ -1,4 +1,4 @@
-import { Mesh, CircleGeometry, Points, PointsMaterial, ShaderMaterial, RawShaderMaterial, TextureLoader } from 'three'
+import { Mesh, CircleGeometry, RawShaderMaterial, TextureLoader } from 'three'
 import { InstancedBufferGeometryController } from './buffer-geometry-controller.js'
 
 const vertexShader2 = `
@@ -27,7 +27,7 @@ void main() {
 
   mvPosition.xyz += position * scale * size;
   gl_Position = projectionMatrix * mvPosition;
-  
+
   vUv = uv;
   vColor = color;
 }

--- a/packages/viz/src/graphs/utils/utils.js
+++ b/packages/viz/src/graphs/utils/utils.js
@@ -43,7 +43,7 @@ function parseConfigDebugForPackages (policyName, policyDebugData, policyFinal) 
   const { debugInfo } = policyDebugData
   const { resources } = policyFinal
   // aggregate info under package name
-  Object.entries(debugInfo).forEach(([_, moduleDebugInfo]) => {
+  Object.entries(debugInfo).forEach(([, moduleDebugInfo]) => {
     const { moduleRecord } = moduleDebugInfo
     const packageId = moduleRecord.packageName
     let packageData = packages[packageId]
@@ -79,7 +79,7 @@ function parseConfigDebugForPackages (policyName, policyDebugData, policyFinal) 
     })
   })
   // modify danger rank
-  Object.entries(packages).forEach(([_, packageData]) => {
+  Object.entries(packages).forEach(([, packageData]) => {
     const dangerRank = getDangerRankForPackage(packageData, envConfig)
     packageData.dangerRank = dangerRank
   })
@@ -97,7 +97,7 @@ function createGraph (packages, policyFinal, {
   const nodes = []
   const links = []
   // for each module, create node and links
-  Object.entries(packages).forEach(([_, packageData]) => {
+  Object.entries(packages).forEach(([, packageData]) => {
     const { importMap } = packageData
     const packageId = packageData.id
     // skip hidden packages
@@ -332,7 +332,7 @@ function sortByKey (key, reverse = false) {
     return aVal > bVal ? reverseVal : -reverseVal
   }
 }
-  
+
 
 export {
   parseConfigDebugForPackages,

--- a/packages/viz/src/graphs/vr-viz/forcegraph.js
+++ b/packages/viz/src/graphs/vr-viz/forcegraph.js
@@ -34,7 +34,7 @@ export class FastThreeForceGraph extends Group {
         collisionObject.visible = false
         return collisionObject
       })
-      .linkThreeObject((link) => {
+      .linkThreeObject(() => {
         // create dummy object, only used to statisy ThreeForceGraph
         const dummyObject = new Object3D()
         dummyObject.visible = false
@@ -47,7 +47,7 @@ export class FastThreeForceGraph extends Group {
         // override link position update
         return true
       })
-    
+
     this.graph.visible = false
     this.collisionObjects = this.graph.children
 

--- a/packages/viz/src/index.js
+++ b/packages/viz/src/index.js
@@ -5,7 +5,7 @@ import 'codemirror/lib/codemirror.css'
 import './css/index.css'
 import App from './App.js'
 import * as serviceWorker from './serviceWorker.js'
-import ScratchPad from './scene.js'
+import './scene.js'
 
 ReactDOM.render(<App />, document.getElementById('root'))
 // ReactDOM.render(<ScratchPad />, document.getElementById('root'))

--- a/packages/viz/src/merge-deep.js
+++ b/packages/viz/src/merge-deep.js
@@ -13,7 +13,7 @@ var union = require('arr-union')
 var clone = require('clone-deep')
 var typeOf = require('kind-of')
 
-module.exports = function mergeDeep(orig, objects) {
+module.exports = function mergeDeep(orig) {
   if (!isObject(orig) && !Array.isArray(orig)) {
     orig = {}
   }

--- a/packages/viz/src/scene.js
+++ b/packages/viz/src/scene.js
@@ -78,7 +78,7 @@ export default class ScratchPad extends ThreeComponent {
     const graph = new FastThreeForceGraph({ graphData: packageData })
     this.graph = graph
     const scale = 0.1
-    graph.scale.set(scale, scale, scale)   
+    graph.scale.set(scale, scale, scale)
     this.scene.add(graph)
 
     this.animateListeners = []

--- a/packages/viz/src/three-component.js
+++ b/packages/viz/src/three-component.js
@@ -30,7 +30,7 @@ export default class ThreeComponent extends React.Component {
     // // scene.add(floor);
 
     // this.scene.add(new THREE.HemisphereLight(0x808080, 0x606060))
-    
+
     // this.renderer = new THREE.WebGLRenderer({
     //     canvas: this.canvas,
     //     antialias: false,
@@ -78,8 +78,8 @@ export default class ThreeComponent extends React.Component {
     window.addEventListener('resize', this.onWindowResize)
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    // Pass updated props to 
+  componentDidUpdate() {
+    // Pass updated props to
     const newValue = this.props.whateverProperty
     this.updateValue(newValue)
   }
@@ -100,7 +100,7 @@ export default class ThreeComponent extends React.Component {
     this.renderer.setSize(innerWidth, innerHeight)
   }
 
-  updateValue (value) {
+  updateValue () {
     // Whatever you need to do with React props
   }
 


### PR DESCRIPTION
Closes #637

This removes the dep on `@metamask/eslint-config-nodejs` which has a peer dep on `@metamask/eslint-config`.  `npm` will automatically install that module, and that module _itself_ has peer deps which may also conflict with our deps currently or in the future.

Given `@metamask/eslint-config-nodejs` is _intended_ to be used with `@metamask/eslint-config`, we then must drop it.

The ESLint config has been modified to extend both `eslint/recommended` and `eslint-plugin-n/recommended` configs.  Extra rules were copied from `@metamask/eslint-config-nodejs`, but many (such as restrictions on browser-only globals) were not, since these can be trivially addressed by ESLint's `env` configuration (unsure what they are doing where this is a problem).  Since this surfaced a whole lot of new issues--especially in test code and templates--additional overrides were necessary.  Any rules which were removed from the main `rules` prop were likely already enabled in `eslint/recommended`.
