### PR TITLE
fix(allow-scripts): update types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ packages/perf/trials/**/*
 packages/survey/mitm/**/*
 packages/viz/dist/**/*
 packages/viz/src/example-policies/**/*
+packages/yarn-plugin-allow-scripts/bundles

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
     // messing with this, so we need to set it manually.
     // https://eslint.org/docs/latest/use/configure/language-options#specifying-environments
     ecmaVersion: 12,
+
+    // for @typescript-eslint/parser, wherever it's used
+    tsconfigRootDir: __dirname,
   },
   // this should be synced with the version of V8 used by the min supported node version
   env: { es2020: true, node: true },
@@ -53,8 +56,39 @@ module.exports = {
     },
   },
   overrides: [
+    /**
+     * All `.ts` files should be checked via `@typescript-eslint/parser`
+     */
     {
-      files: ['packages/*/test/**/*.js', 'packages/*/src/**/*.test.js'],
+      files: ['packages/**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      extends: ['plugin:@typescript-eslint/recommended-type-checked'],
+      parserOptions: {
+        project: ['./packages/*/tsconfig.json'],
+      },
+      rules: {
+        'n/no-missing-import': 'off',
+      },
+    },
+    /**
+     *
+     */
+    {
+      files: ['packages/allow-scripts/src/**/*.js'],
+      parser: '@typescript-eslint/parser',
+      extends: ['plugin:@typescript-eslint/recommended'],
+      parserOptions: {
+        project: ['./packages/allow-scripts/tsconfig.json'],
+      },
+    },
+    {
+      files: ['packages/*/src/**/*.js'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    {
+      files: ['packages/*/test/**/*.js', 'packages/*/src/**/*.spec.js'],
       extends: ['plugin:ava/recommended'],
       rules: {
         'ava/no-import-test-files': 'off',

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,30 @@ jobs:
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts
-      - name: Lint
-        run: npm run lint
       - name: Test
         run: npm test
+
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Upgrade npm # for workspace support
+        run: npm i -g npm@9 # npm@9 supports our supported Node.js versions
+      - name: Install Dependencies
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        with:
+          useRollingCache: true
+          install-command: npm ci --foreground-scripts
+      - name: Lint
+        run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@tsconfig/node16": "^16.1.1",
         "@types/node": "^20.5.9",
         "@types/yargs": "^17.0.24",
+        "@typescript-eslint/eslint-plugin": "^6.7.3",
+        "@typescript-eslint/parser": "^6.7.3",
         "ava": "^5.3.1",
         "conventional-changelog-conventionalcommits": "^6.1.0",
         "depcheck": "^1.4.0",
@@ -2779,9 +2781,10 @@
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2895,8 +2898,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.3.9",
-      "license": "MIT"
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -2968,6 +2972,195 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.3.tgz",
+      "integrity": "sha512-vntq452UHNltxsaaN+L9WyuMch8bMd9CqJ3zhzTPXXidwbf5mqqKCVXEuvRZUqLJSTLeWE65lQwyXsRGnXkCTA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/type-utils": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.3.tgz",
+      "integrity": "sha512-TlutE+iep2o7R8Lf+yoer3zU6/0EAUc8QIBB3GYBc1KGz4c4TRm83xwXUZVPlZ6YCLss4r77jbu6j3sendJoiQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.3.tgz",
+      "integrity": "sha512-wOlo0QnEou9cHO2TdkJmzF7DFGvAKEnB82PuPNHpT8ZKKaZu6Bm63ugOTn9fXNJtvuDPanBc78lGUGGytJoVzQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.3.tgz",
+      "integrity": "sha512-Fc68K0aTDrKIBvLnKTZ5Pf3MXK495YErrbHb1R6aTpfK5OdSFj0rVN7ib6Tx6ePrZ2gsjLqr0s98NG7l96KSQw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.3.tgz",
+      "integrity": "sha512-4g+de6roB2NFcfkZb439tigpAMnvEIg3rIjWQ+EM7IBaYt/CdJt6em9BJ4h4UpdgaBWdmx2iWsafHTrqmgIPNw==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.3.tgz",
+      "integrity": "sha512-YLQ3tJoS4VxLFYHTw21oe1/vIZPRqAO91z6Uv0Ss2BKm/Ag7/RVQBcXTGcXhgJMdA4U+HrKuY5gWlJlvoaKZ5g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.3.tgz",
+      "integrity": "sha512-vzLkVder21GpWRrmSR9JxGZ5+ibIUSudXlW52qeKpzUEQhRSmyZiVDDj3crAth7+5tmN1ulvgKaCU2f/bPRCzg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.3.tgz",
+      "integrity": "sha512-HEVXkU9IB+nk9o63CeICMHxFWbHWr3E1mpilIQBe9+7L/lH97rleFLVtYsfnWB+JVMaiFnEaxvknvmIzX+CqVg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.3",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.1",
@@ -15806,6 +15999,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "lint-staged": "^13.2.3",
         "memfs": "^4.3.0",
         "prettier": "^3.0.2",
+        "type-fest": "^2.19.0",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -16138,6 +16139,8 @@
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint-staged": "^13.2.3",
     "memfs": "^4.3.0",
     "prettier": "^3.0.2",
+    "type-fest": "^2.19.0",
     "typescript": "^5.2.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@tsconfig/node16": "^16.1.1",
     "@types/node": "^20.5.9",
     "@types/yargs": "^17.0.24",
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "@typescript-eslint/parser": "^6.7.3",
     "ava": "^5.3.1",
     "conventional-changelog-conventionalcommits": "^6.1.0",
     "depcheck": "^1.4.0",

--- a/packages/allow-scripts/src/cli.js
+++ b/packages/allow-scripts/src/cli.js
@@ -2,7 +2,11 @@
 
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
-const { runAllowedPackages, setDefaultConfiguration, printPackagesList } = require('./index.js')
+const {
+  runAllowedPackages,
+  setDefaultConfiguration,
+  printPackagesList,
+} = require('./index.js')
 const { writeRcFile, editPackageJson } = require('./setup.js')
 const { FEATURE } = require('./toggles')
 
@@ -11,11 +15,11 @@ start().catch((err) => {
   process.exit(1)
 })
 
-async function start () {
+async function start() {
   const rootDir = process.cwd()
 
   const parsedArgs = parseArgs()
-  const command = parsedArgs.command || 'run'
+  const command = String(parsedArgs.command || 'run')
   FEATURE.bins = parsedArgs.experimentalBins
 
   switch (command) {
@@ -41,12 +45,12 @@ async function start () {
     }
     // (error) unrecognized
     default: {
-      throw new Error(`@lavamoat/allow-scripts - unknown command "${parsedArgs.command}"`)
+      throw new Error(`@lavamoat/allow-scripts - unknown command "${command}"`)
     }
   }
 }
 
-function parseArgs () {
+function parseArgs() {
   const argsParser = yargs(hideBin(process.argv))
     .usage('Usage: $0 <command> [options]')
     .command('$0', 'run the allowed scripts')
@@ -55,7 +59,8 @@ function parseArgs () {
     .command('setup', 'configure local repository to use allow-scripts')
     .option('experimental-bins', {
       alias: 'bin',
-      describe: 'opt-in to set up experimental protection against bin script confusion',
+      describe:
+        'opt-in to set up experimental protection against bin script confusion',
       type: 'boolean',
       default: false,
     })

--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-// @ts-ignore: Object is possibly 'undefined'.
+
 const { promises: fs } = require('fs')
 const path = require('path')
 const npmRunScript = require('@npmcli/run-script')
@@ -11,7 +11,7 @@ const setup = require('./setup')
 
 /**
  * @typedef {Object} PkgConfs
- * @property {Record<string,any>} packageJson
+ * @property {LavamoatPackageJson} packageJson
  * @property {Object} configs
  * @property {ScriptsConfig} configs.lifecycle
  * @property {BinsConfig} configs.bin
@@ -35,7 +35,7 @@ const setup = require('./setup')
  * @property {string} path
  * @property {string} link
  * @property {string} fullLinkPath
-**/
+ **/
 
 /**
  * Configuration for a type of scripts policies
@@ -49,7 +49,7 @@ const setup = require('./setup')
  */
 
 /**
- * @typedef {Map<string,[BinInfo]>} BinCandidates
+ * @typedef {Map<string,BinInfo[]>} BinCandidates
  */
 
 /**
@@ -78,15 +78,12 @@ module.exports = {
 async function getOptionsForBin({ rootDir, name }) {
   const {
     configs: {
-      bin: {
-        binCandidates,
-      },
+      bin: { binCandidates },
     },
   } = await loadAllPackageConfigurations({ rootDir })
 
   return binCandidates.get(name)
 }
-
 
 /**
  * @param {RunAllowedPackagesOpts} param0
@@ -94,16 +91,17 @@ async function getOptionsForBin({ rootDir, name }) {
  */
 async function runAllowedPackages({ rootDir }) {
   const {
-    configs: {
-      lifecycle,
-      bin,
-    },
+    configs: { lifecycle, bin },
     somePoliciesAreMissing,
   } = await loadAllPackageConfigurations({ rootDir })
 
   if (somePoliciesAreMissing) {
-    console.log('\n@lavamoat/allow-scripts has detected dependencies without configuration. explicit configuration required.')
-    console.log('run "allow-scripts auto" to automatically populate the configuration.\n')
+    console.log(
+      '\n@lavamoat/allow-scripts has detected dependencies without configuration. explicit configuration required.'
+    )
+    console.log(
+      'run "allow-scripts auto" to automatically populate the configuration.\n'
+    )
 
     printMissingPoliciesIfAny(lifecycle)
 
@@ -117,7 +115,10 @@ async function runAllowedPackages({ rootDir }) {
     if (bin.binCandidates.size > 0) {
       console.log('installing bin scripts')
       await installBinScripts(bin.allowedBins)
-      await installBinFirewall(bin.firewalledBins, path.join(__dirname, './whichbin.js'))
+      await installBinFirewall(
+        bin.firewalledBins,
+        path.join(__dirname, './whichbin.js')
+      )
     } else {
       console.log('no bin scripts found in dependencies')
     }
@@ -125,17 +126,27 @@ async function runAllowedPackages({ rootDir }) {
 
   // run scripts in dependencies
   if (lifecycle.allowedPatterns.length) {
-    const allowedPackagesWithScriptsLifecycleScripts = Array.from(lifecycle.packagesWithScripts.entries())
+    const allowedPackagesWithScriptsLifecycleScripts = Array.from(
+      lifecycle.packagesWithScripts.entries()
+    )
       .filter(([pattern]) => lifecycle.allowedPatterns.includes(pattern))
       .flatMap(([, packages]) => packages)
 
-
     console.log('running lifecycle scripts for event "preinstall"')
-    await runAllScriptsForEvent({ event: 'preinstall', packages: allowedPackagesWithScriptsLifecycleScripts })
+    await runAllScriptsForEvent({
+      event: 'preinstall',
+      packages: allowedPackagesWithScriptsLifecycleScripts,
+    })
     console.log('running lifecycle scripts for event "install"')
-    await runAllScriptsForEvent({ event: 'install', packages: allowedPackagesWithScriptsLifecycleScripts })
+    await runAllScriptsForEvent({
+      event: 'install',
+      packages: allowedPackagesWithScriptsLifecycleScripts,
+    })
     console.log('running lifecycle scripts for event "postinstall"')
-    await runAllScriptsForEvent({ event: 'postinstall', packages: allowedPackagesWithScriptsLifecycleScripts })
+    await runAllScriptsForEvent({
+      event: 'postinstall',
+      packages: allowedPackagesWithScriptsLifecycleScripts,
+    })
   } else {
     console.log('no allowed lifecycle scripts found in configuration')
   }
@@ -155,10 +166,7 @@ async function runAllowedPackages({ rootDir }) {
 async function setDefaultConfiguration({ rootDir }) {
   const conf = await loadAllPackageConfigurations({ rootDir })
   const {
-    configs: {
-      lifecycle,
-      bin,
-    },
+    configs: { lifecycle, bin },
     somePoliciesAreMissing,
   } = conf
 
@@ -171,14 +179,16 @@ async function setDefaultConfiguration({ rootDir }) {
 
   console.log('\nadding configuration:')
 
-  lifecycle.missingPolicies.forEach(pattern => {
+  lifecycle.missingPolicies.forEach((pattern) => {
     console.log(`- lifecycle ${pattern}`)
     lifecycle.allowConfig[pattern] = false
   })
 
-  if(FEATURE.bins && bin.somePoliciesAreMissing) {
+  if (FEATURE.bins && bin.somePoliciesAreMissing) {
     bin.allowConfig = prepareBinScriptsPolicy(bin.binCandidates)
-    console.log(`- bin scripts linked: ${Object.keys(bin.allowConfig).join(',')}`)
+    console.log(
+      `- bin scripts linked: ${Object.keys(bin.allowConfig).join(',')}`
+    )
   }
 
   // update package json
@@ -194,25 +204,24 @@ async function setDefaultConfiguration({ rootDir }) {
  */
 async function printPackagesList({ rootDir }) {
   const {
-    configs: {
-      bin,
-      lifecycle,
-    },
+    configs: { bin, lifecycle },
   } = await loadAllPackageConfigurations({ rootDir })
 
   printPackagesByBins(bin)
   printPackagesByScriptConfiguration(lifecycle)
 }
 
-
 /**
  *
  * @param {PrintMissingPoliciesIfAnyOpts} param0
  */
-function printMissingPoliciesIfAny({ missingPolicies = [], packagesWithScripts = new Map() }) {
-  if(missingPolicies.length) {
+function printMissingPoliciesIfAny({
+  missingPolicies = [],
+  packagesWithScripts = new Map(),
+}) {
+  if (missingPolicies.length) {
     console.log('packages missing configuration:')
-    missingPolicies.forEach(pattern => {
+    missingPolicies.forEach((pattern) => {
       const collection = packagesWithScripts.get(pattern) || []
       console.log(`- ${pattern} [${collection.length} location(s)]`)
     })
@@ -254,7 +263,7 @@ async function installBinScripts(allowedBins) {
 async function installBinFirewall(firewalledBins, link) {
   // Note how we take the path of the original package so that the bin is added at the appropriate level of node_modules nesting
   for (const { bin, path: packagePath } of firewalledBins) {
-    await linkBinAbsolute({path: packagePath, bin, link, force: true } )
+    await linkBinAbsolute({ path: packagePath, bin, link, force: true })
   }
 }
 
@@ -281,7 +290,6 @@ async function runScript({ path, event }) {
   })
 }
 
-
 const bannedBins = new Set(['node', 'npm', 'yarn', 'pnpm'])
 
 /**
@@ -291,9 +299,9 @@ function prepareBinScriptsPolicy(binCandidates) {
   /** @type {Record<string,string>} */
   const policy = {}
   // pick direct dependencies without conflicts and enable them by default unless colliding with bannedBins
-  for ( const [bin, infos] of binCandidates.entries()) {
-    const binsFromDirectDependencies = infos.filter(i => i.isDirect)
-    if(binsFromDirectDependencies.length === 1 && !bannedBins.has(bin)) {
+  for (const [bin, infos] of binCandidates.entries()) {
+    const binsFromDirectDependencies = infos.filter((i) => i.isDirect)
+    if (binsFromDirectDependencies.length === 1 && !bannedBins.has(bin)) {
       // there's no conflicts, seems fairly obvious choice to put it up
       policy[bin] = binsFromDirectDependencies[0].fullLinkPath
     }
@@ -301,15 +309,10 @@ function prepareBinScriptsPolicy(binCandidates) {
   return policy
 }
 
-
 /**
  * @param {BinsConfig} param0
  */
-function printPackagesByBins({
-  allowedBins,
-  excessPolicies,
-}) {
-
+function printPackagesByBins({ allowedBins, excessPolicies }) {
   console.log('\n# allowed packages with bin scripts')
   if (allowedBins.length) {
     allowedBins.forEach(({ canonicalName, bin }) => {
@@ -320,8 +323,10 @@ function printPackagesByBins({
   }
 
   if (excessPolicies.length) {
-    console.log('\n# packages with bin scripts that no longer need configuration (package or script removed or script path outdated)')
-    excessPolicies.forEach(bin => {
+    console.log(
+      '\n# packages with bin scripts that no longer need configuration (package or script removed or script path outdated)'
+    )
+    excessPolicies.forEach((bin) => {
       console.log(`- ${bin}`)
     })
   }
@@ -337,10 +342,9 @@ function printPackagesByScriptConfiguration({
   missingPolicies,
   excessPolicies,
 }) {
-
   console.log('\n# allowed packages with lifecycle scripts')
   if (allowedPatterns.length) {
-    allowedPatterns.forEach(pattern => {
+    allowedPatterns.forEach((pattern) => {
       const collection = packagesWithScripts.get(pattern) || []
       console.log(`- ${pattern} [${collection.length} location(s)]`)
     })
@@ -350,7 +354,7 @@ function printPackagesByScriptConfiguration({
 
   console.log('\n# disallowed packages with lifecycle scripts')
   if (disallowedPatterns.length) {
-    disallowedPatterns.forEach(pattern => {
+    disallowedPatterns.forEach((pattern) => {
       const collection = packagesWithScripts.get(pattern) || []
       console.log(`- ${pattern} [${collection.length} location(s)]`)
     })
@@ -360,15 +364,17 @@ function printPackagesByScriptConfiguration({
 
   if (missingPolicies.length) {
     console.log('\n# unconfigured packages with lifecycle scripts')
-    missingPolicies.forEach(pattern => {
+    missingPolicies.forEach((pattern) => {
       const collection = packagesWithScripts.get(pattern) || []
       console.log(`- ${pattern} [${collection.length} location(s)]`)
     })
   }
 
   if (excessPolicies.length) {
-    console.log('\n# packages with lifecycle scripts that no longer need configuration due to package or scripts removal')
-    excessPolicies.forEach(pattern => {
+    console.log(
+      '\n# packages with lifecycle scripts that no longer need configuration due to package or scripts removal'
+    )
+    excessPolicies.forEach((pattern) => {
       const collection = packagesWithScripts.get(pattern) || []
       console.log(`- ${pattern} [${collection.length} location(s)]`)
     })
@@ -380,10 +386,13 @@ function printPackagesByScriptConfiguration({
  * @param {SavePackageConfigurationsOpts} param0
  * @returns {Promise<void>}
  */
-async function savePackageConfigurations({ rootDir, conf: {
-  packageJson,
-  configs: { lifecycle, bin },
-} }) {
+async function savePackageConfigurations({
+  rootDir,
+  conf: {
+    packageJson,
+    configs: { lifecycle, bin },
+  },
+}) {
   // update package json
   if (!packageJson.lavamoat) {
     packageJson.lavamoat = {}
@@ -403,19 +412,33 @@ async function savePackageConfigurations({ rootDir, conf: {
  */
 async function loadAllPackageConfigurations({ rootDir }) {
   const packagesWithScriptsLifecycle = new Map()
+  /** @type {BinCandidates} */
   const binCandidates = new Map()
 
-  const dependencyMap = await loadCanonicalNameMap({ rootDir, includeDevDeps: true })
-  const sortedDepEntries = Array.from(dependencyMap.entries()).sort(sortBy(([, canonicalName]) => canonicalName))
-  const packageJson = JSON.parse(await fs.readFile(path.join(rootDir, 'package.json'), 'utf8'))
-  const directDeps = new Set([...Object.keys(packageJson.devDependencies||{}),...Object.keys(packageJson.dependencies||{})])
+  const dependencyMap = await loadCanonicalNameMap({
+    rootDir,
+    includeDevDeps: true,
+  })
+  const sortedDepEntries = Array.from(dependencyMap.entries()).sort(
+    sortBy(([, canonicalName]) => canonicalName)
+  )
+  const packageJson = /** @type {LavamoatPackageJson} */ (
+    JSON.parse(await fs.readFile(path.join(rootDir, 'package.json'), 'utf8'))
+  )
+  const directDeps = new Set([
+    ...Object.keys(packageJson.devDependencies || {}),
+    ...Object.keys(packageJson.dependencies || {}),
+  ])
 
   for (const [filePath, canonicalName] of sortedDepEntries) {
     // const canonicalName = getCanonicalNameForPath({ rootDir, filePath: filePath })
+    /** @type {LavamoatPackageJson} */
     let depPackageJson
     // eslint-disable-next-line no-useless-catch
     try {
-      depPackageJson = JSON.parse(await fs.readFile(path.join(filePath, 'package.json'), 'utf-8'))
+      depPackageJson = JSON.parse(
+        await fs.readFile(path.join(filePath, 'package.json'), 'utf-8')
+      )
     } catch (err) {
       // FIXME: leftovers of code that used to work
       // const branchIsOptional = branch.some(node => node.optional)
@@ -425,9 +448,12 @@ async function loadAllPackageConfigurations({ rootDir }) {
       throw err
     }
     const depScripts = depPackageJson.scripts || {}
-    const lifeCycleScripts = ['preinstall', 'install', 'postinstall'].filter(name => Object.prototype.hasOwnProperty.call(depScripts, name))
+    const lifeCycleScripts = ['preinstall', 'install', 'postinstall'].filter(
+      (name) => Object.prototype.hasOwnProperty.call(depScripts, name)
+    )
 
     if (lifeCycleScripts.length) {
+      /** @type {{canonicalName: string, path: string, scripts: LavamoatPackageJson['scripts']}[]} */
       const collection = packagesWithScriptsLifecycle.get(canonicalName) || []
       collection.push({
         canonicalName,
@@ -438,9 +464,12 @@ async function loadAllPackageConfigurations({ rootDir }) {
     }
 
     if (FEATURE.bins && depPackageJson.bin) {
-      const binsList = Object.entries(normalizeBin(depPackageJson)?.bin || {})
+      const binsList = /** @type {[string, string][]} */ (
+        Object.entries(normalizeBin(depPackageJson)?.bin || {})
+      )
 
       binsList.forEach(([name, link]) => {
+        /** @type {BinInfo[]} */
         const collection = binCandidates.get(name) || []
         if (collection.length === 0) {
           binCandidates.set(name, collection)
@@ -451,7 +480,7 @@ async function loadAllPackageConfigurations({ rootDir }) {
           bin: name,
           path: filePath,
           link,
-          fullLinkPath: path.relative(rootDir,path.join(filePath, link)),
+          fullLinkPath: path.relative(rootDir, path.join(filePath, link)),
           canonicalName,
         })
       })
@@ -471,7 +500,10 @@ async function loadAllPackageConfigurations({ rootDir }) {
     }),
   }
 
-  const somePoliciesAreMissing = !!(configs.lifecycle.missingPolicies.length || configs.bin.somePoliciesAreMissing)
+  const somePoliciesAreMissing = !!(
+    configs.lifecycle.missingPolicies.length ||
+    configs.bin.somePoliciesAreMissing
+  )
 
   return {
     packageJson,
@@ -482,7 +514,7 @@ async function loadAllPackageConfigurations({ rootDir }) {
 
 /**
  * Adds helpful redundancy to the config object thus producing a full ScriptsConfig type
- * @param {*} config
+ * @param {import('type-fest').SetRequired<Partial<ScriptsConfig>, 'packagesWithScripts'>} config
  * @return {ScriptsConfig}
  */
 function indexLifecycleConfiguration(config) {
@@ -490,37 +522,62 @@ function indexLifecycleConfiguration(config) {
   // packages with config
   const configuredPatterns = Object.keys(config.allowConfig)
   // select allowed + disallowed
-  config.allowedPatterns = Object.entries(config.allowConfig).filter(([, packageData]) => !!packageData).map(([pattern]) => pattern)
+  config.allowedPatterns = Object.entries(config.allowConfig)
+    .filter(([, packageData]) => !!packageData)
+    .map(([pattern]) => pattern)
 
-  config.disallowedPatterns = Object.entries(config.allowConfig).filter(([, packageData]) => !packageData).map(([pattern]) => pattern)
+  config.disallowedPatterns = Object.entries(config.allowConfig)
+    .filter(([, packageData]) => !packageData)
+    .map(([pattern]) => pattern)
 
-  config.missingPolicies = Array.from(config.packagesWithScripts.keys())
-    .filter(pattern => !configuredPatterns.includes(pattern))
+  config.missingPolicies = Array.from(
+    config.packagesWithScripts.keys() ?? []
+  ).filter((pattern) => !configuredPatterns.includes(pattern))
 
-  config.excessPolicies = configuredPatterns.filter(pattern => !config.packagesWithScripts.has(pattern))
+  config.excessPolicies = configuredPatterns.filter(
+    (pattern) => !config.packagesWithScripts.has(pattern)
+  )
 
-  return config
+  return /** @type {ScriptsConfig} */ (config)
 }
 
 /**
- * Adds helpful redundancy to the config object thus producing a full ScriptsConfig type
- * @param {*} config
+ * Adds helpful redundancy to the config object thus producing a full {@link BinsConfig} type
+ * @param {import('type-fest').SetRequired<Partial<BinsConfig>, 'binCandidates'>} config
  * @return {BinsConfig}
  */
 function indexBinsConfiguration(config) {
   // only autogenerate the initial config. A better heuristic would be to detect if any scripts from direct dependencies are missing
-  config.somePoliciesAreMissing = !config.allowConfig && config.binCandidates.size > 0
-  config.excessPolicies = Object.keys(config.allowConfig || {}).filter(b => !config.binCandidates.has(b))
-  config.allowedBins = Object.entries(config.allowConfig || {}).map(([bin, fullPath]) => config.binCandidates.get(bin)?.find((/** @type BinInfo */ candidate) => candidate.fullLinkPath === fullPath)).filter(a => a)
+  config.somePoliciesAreMissing =
+    !config.allowConfig && config.binCandidates.size > 0
+  config.excessPolicies = Object.keys(config.allowConfig || {}).filter(
+    (b) => !config.binCandidates.has(b)
+  )
+  config.allowedBins = /** @type {BinInfo[]} */ (
+    Object.entries(config.allowConfig || {})
+      .map(([bin, fullPath]) =>
+        config.binCandidates
+          .get(bin)
+          ?.find(
+            (/** @type BinInfo */ candidate) =>
+              candidate.fullLinkPath === fullPath
+          )
+      )
+      .filter((a) => a)
+  )
 
-  config.firewalledBins = Array.from(config.binCandidates.values()).flat().filter(binInfo => !config.allowedBins.includes(binInfo))
-  return config
+  config.firewalledBins = Array.from(config.binCandidates.values())
+    .flat()
+    .filter((binInfo) => !config.allowedBins?.includes(binInfo))
+  return /** @type {BinsConfig} */ (config)
 }
 
 /**
  *
- * @param {(value: any) => any} getterFn
- * @returns {(a: any, b: any) => 1|-1|0}
+ * @template T
+ * @template U
+ * @param {(value: T) => U} getterFn
+ * @returns {(a: T, b: T) => 1|-1|0}
  */
 function sortBy(getterFn) {
   return (a, b) => {
@@ -542,8 +599,8 @@ function sortBy(getterFn) {
  * @property {string} path
  */
 
-
 /**
+ *
  * @typedef SavePackageConfigurationsOpts
  * @property {string} rootDir
  * @property {PkgConfs} conf
@@ -575,4 +632,19 @@ function sortBy(getterFn) {
  * @typedef PrintMissingPoliciesIfAnyOpts
  * @property {string[]} [missingPolicies]
  * @property {Map<string,unknown[]>} [packagesWithScripts]
+ */
+
+/**
+ * @typedef PkgLavamoatConfig
+ * @property {Record<string,any>} [allowScripts]
+ * @property {Record<string,any>} [allowBins]
+ * @property {Record<string,any>} [allowConfig]
+ * @property {Record<string,any>} [allowedPatterns]
+ * @property {Record<string,any>} [disallowedPatterns]
+ * @property {Record<string,any>} [missingPolicies]
+ * @property {Record<string,any>} [excessPolicies]
+ */
+
+/**
+ * @typedef {import('type-fest').PackageJson & {lavamoat: PkgLavamoatConfig}} LavamoatPackageJson
  */

--- a/packages/allow-scripts/src/setup.js
+++ b/packages/allow-scripts/src/setup.js
@@ -1,7 +1,8 @@
-const { existsSync,
-        appendFileSync,
-        readFileSync,
-        writeFileSync,
+const {
+  existsSync,
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
 } = require('fs')
 const { spawnSync } = require('child_process')
 const path = require('path')
@@ -27,7 +28,6 @@ const YARN3 = {
     SCRIPTS: 'enableScripts: false',
   },
 }
-
 
 module.exports = {
   writeRcFile,
@@ -64,11 +64,13 @@ function isEntryPresent(entry, file) {
  *
  * @param {WriteRcFileContentOpts} param0
  */
-function writeRcFileContent({file, entry}) {
+function writeRcFileContent({ file, entry }) {
   const rcPath = addInstallParentDir(file)
 
   if (isEntryPresent(entry, file)) {
-    console.log(`@lavamoat/allow-scripts: file ${rcPath} already exists with entry: ${entry}.`)
+    console.log(
+      `@lavamoat/allow-scripts: file ${rcPath} already exists with entry: ${entry}.`
+    )
   } else {
     appendFileSync(rcPath, entry + '\n')
     console.log(`@lavamoat/allow-scripts: added entry to ${rcPath}: ${entry}.`)
@@ -86,14 +88,16 @@ let binsBlockedMemo
  * @returns {boolean}
  */
 function areBinsBlocked({ noMemoization = false } = {}) {
-  if(noMemoization || binsBlockedMemo === undefined) {
-    binsBlockedMemo = isEntryPresent(NPM.CONF.BINS, NPM.RCFILE) || isEntryPresent(YARN1.CONF.BINS, YARN1.RCFILE)
+  if (noMemoization || binsBlockedMemo === undefined) {
+    binsBlockedMemo =
+      isEntryPresent(NPM.CONF.BINS, NPM.RCFILE) ||
+      isEntryPresent(YARN1.CONF.BINS, YARN1.RCFILE)
     // Once yarn3 support via plugin comes in, this function would need to detect that, or cease to exist.
   }
   return binsBlockedMemo
 }
 
-function writeRcFile () {
+function writeRcFile() {
   const yarnRcExists = existsSync(addInstallParentDir(YARN1.RCFILE))
   const yarnYmlExists = existsSync(addInstallParentDir(YARN3.RCFILE))
   const npmRcExists = existsSync(addInstallParentDir(NPM.RCFILE))
@@ -106,7 +110,7 @@ function writeRcFile () {
       exists: yarnRcExists,
       entry: YARN1.CONF.SCRIPTS,
     })
-    if(FEATURE.bins) {
+    if (FEATURE.bins) {
       configs.push({
         file: YARN1.RCFILE,
         exists: yarnRcExists,
@@ -128,7 +132,7 @@ function writeRcFile () {
       exists: npmRcExists,
       entry: NPM.CONF.SCRIPTS,
     })
-    if(FEATURE.bins) {
+    if (FEATURE.bins) {
       configs.push({
         file: NPM.RCFILE,
         exists: npmRcExists,
@@ -140,7 +144,7 @@ function writeRcFile () {
   configs.forEach(writeRcFileContent)
 }
 
-function editPackageJson () {
+function editPackageJson() {
   let cmd, cmdArgs
 
   if (existsSync('./.npmrc')) {
@@ -155,23 +159,34 @@ function editPackageJson () {
 
   if (result.status !== 0) {
     process.stderr.write(result.stderr)
-    console.log('@lavamoat/allow-scripts: Could not add @lavamoat/preinstall-always-fail.')
+    console.log(
+      '@lavamoat/allow-scripts: Could not add @lavamoat/preinstall-always-fail.'
+    )
   } else {
-    console.log('@lavamoat/allow-scripts: Added dependency @lavamoat/preinstall-always-fail.')
+    console.log(
+      '@lavamoat/allow-scripts: Added dependency @lavamoat/preinstall-always-fail.'
+    )
   }
 
-  if(FEATURE.bins) {
+  if (FEATURE.bins) {
     // no motivation to fix lint here, there's a better implementation of this in a neighboring branch
-    // eslint-disable-next-line n/global-require
-    const packageJson = require(addInstallParentDir('package.json'))
-    if(!packageJson.scripts) {
+    const packageJson = /** @type {import('type-fest').PackageJson} */ (
+      require(addInstallParentDir('package.json'))
+    )
+    if (!packageJson.scripts) {
       packageJson.scripts = {}
     }
     // If you think `node ` is redundant below, be aware that `./cli.js` won't work on Windows,
     // but passing a unix-style path to node on Windows works fine.
-    packageJson.scripts['allow-scripts'] = 'node ./node_modules/@lavamoat/allow-scripts/src/cli.js --experimental-bins'
-    console.log('@lavamoat/allow-scripts: Adding allow-scripts as a package.json script with direct path.')
-    writeFileSync(addInstallParentDir('package.json'), JSON.stringify(packageJson, null, 2))
+    packageJson.scripts['allow-scripts'] =
+      'node ./node_modules/@lavamoat/allow-scripts/src/cli.js --experimental-bins'
+    console.log(
+      '@lavamoat/allow-scripts: Adding allow-scripts as a package.json script with direct path.'
+    )
+    writeFileSync(
+      addInstallParentDir('package.json'),
+      JSON.stringify(packageJson, null, 2)
+    )
   }
 }
 

--- a/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
@@ -1,4 +1,4 @@
-declare module "bin-links/lib/bin-target.js" {
+declare module 'bin-links/lib/bin-target.js' {
   namespace binTarget {
     interface BinTargetOptions {
       top?: string;

--- a/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
@@ -1,4 +1,5 @@
-declare module "bin-links/lib/is-windows.js" {
-  var isWindows: boolean;
-  export = isWindows;
+declare module 'bin-links/lib/is-windows.js' {
+  // eslint-disable-next-line no-var
+  var isWindows: boolean
+  export = isWindows
 }

--- a/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
@@ -1,4 +1,4 @@
-declare module "bin-links/lib/link-bin.js" {
+declare module 'bin-links/lib/link-bin.js' {
   namespace linkBin {
     interface LinkBinOptions {
       path: string;

--- a/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
@@ -1,4 +1,4 @@
-declare module "bin-links/lib/shim-bin.js" {
+declare module 'bin-links/lib/shim-bin.js' {
   namespace shimBin {
     interface ShimBinOptions {
       path: string;

--- a/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
+++ b/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
@@ -1,19 +1,16 @@
-declare module "npm-normalize-package-bin" {
-  namespace normalizePackageBin {
-    interface PackageBin {
-      name: string;
-      bin?: string | Record<string, string>;
-    }
+declare module 'npm-normalize-package-bin' {
+  import type { PackageJson } from 'type-fest'
 
-    interface NormalizedPackageBin {
-      name: string;
-      bin?: Record<string, string>;
+  namespace normalizePackageBin {
+    export { PackageJson }
+    export type NormalizedBinPackageJson = Omit<PackageJson, 'bin'> & {
+      bin?: Partial<Record<string, string>>
     }
   }
 
   function normalizePackageBin(
-    pkg: normalizePackageBin.PackageBin
-  ): normalizePackageBin.NormalizedPackageBin;
+    pkg: normalizePackageBin.PackageJson
+  ): normalizePackageBin.NormalizedBinPackageJson
 
-  export = normalizePackageBin;
+  export = normalizePackageBin
 }

--- a/packages/allow-scripts/src/types/npmcli__run-script.d.ts
+++ b/packages/allow-scripts/src/types/npmcli__run-script.d.ts
@@ -1,22 +1,23 @@
-declare module "@npmcli/run-script" {
-  import { StdioOptions } from "node:child_process";
-  import type PromiseSpawn from "@npmcli/promise-spawn";
+declare module '@npmcli/run-script' {
+  import { StdioOptions } from 'node:child_process'
+  // eslint-disable-next-line n/no-extraneous-import
+  import type PromiseSpawn from '@npmcli/promise-spawn'
 
   namespace npmRunScript {
     interface RunScriptOptions {
-      event: string;
-      path: string;
-      scriptShell?: string;
-      env?: Record<string, string>;
-      stdio?: StdioOptions;
-      stdioString?: boolean;
-      banner?: boolean;
+      event: string
+      path: string
+      scriptShell?: string
+      env?: Record<string, string>
+      stdio?: StdioOptions
+      stdioString?: boolean
+      banner?: boolean
     }
   }
 
   function npmRunScript(
-    opts: npmRunScript.RunScriptOptions
-  ): ReturnType<typeof PromiseSpawn>;
+    opts: npmRunScript.RunScriptOptions,
+  ): ReturnType<typeof PromiseSpawn>
 
-  export = npmRunScript;
+  export = npmRunScript
 }

--- a/packages/yarn-plugin-allow-scripts/sources/index.ts
+++ b/packages/yarn-plugin-allow-scripts/sources/index.ts
@@ -1,4 +1,5 @@
 import { Plugin } from '@yarnpkg/core'
+// eslint-disable-next-line n/no-extraneous-import
 import { execute } from '@yarnpkg/shell'
 
 const plugin: Plugin = {
@@ -9,7 +10,7 @@ const plugin: Plugin = {
       if (exitCode !== 0) {
         // We have to use `process.exit` here rather than setting `process.exitCode`
         // because Yarn will override any exit code set in this hook.
-        // eslint-disable-next-line node/no-process-exit
+        // eslint-disable-next-line n/no-process-exit
         process.exit(exitCode)
       }
     },


### PR DESCRIPTION
This adds `@typescript-eslint/parser` & its ilk; typescript files (just `.d.ts` for now) are now linted.
