### PR TITLE
chore(ci): fix release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json",
   "packages/aa": "3.1.2",
   "packages/allow-scripts": "2.3.1",
-  "packages/browserify": "15.7.0",
-  "packages/core": "14.2.0",
-  "packages/lavapack": "5.2.0",
+  "packages/browserify": "15.7.1",
+  "packages/core": "14.2.1",
+  "packages/lavapack": "5.2.1",
   "packages/node": "7.1.0",
   "packages/preinstall-always-fail": "1.0.0",
   "packages/tofu": "6.0.2",


### PR DESCRIPTION
It appears that the `$schema` field was throwing it off. Further, some versions were out-of-date.