### PR TITLE
chore(release-please): set initial bootstrap sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "2108f25d223576f8a01067ae2113ceccbc5e58ee",
   "packages": {
     "packages/aa": {},
     "packages/allow-scripts": {},


### PR DESCRIPTION
release-please should no longer consider SHAs before this one as being in the next release.