### PR TITLE
chore(ci): add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,16 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: 'Renovate config for LavaMoat monorepo',
+  extends: [
+    'config:js-app', // everything gets pinned except peer deps (plus a bunch of other reasonable defaults)
+    'group:definitelyTyped', // groups all `@types/*` packages together
+    'helpers:pinGitHubActionDigests', // pins SHAs of GitHub actions
+    ':automergePatch', // automatically merges "patch" and "pin" PRs on check success
+    ':automergeDigest', // automatically merges "digest" PRs on check success
+    ':enableVulnerabilityAlerts', // enables GitHub vulnerability alerts
+    ':rebaseStalePrs', // automatically rebase stale PRs against main
+    ':semanticCommits', // use semantic commits
+    'group:linters', // group lint-related packages together
+  ],
+  transitiveRemediation: true,
+}


### PR DESCRIPTION
This adds a Renovate config. This is a JSON5 file because comments and no YAML support.

Based, roughly, on https://github.com/appium/appium/tree/master/renovate

Closes #635

* * *

Once this is merged, someone will need to add Renovate to the org and/or repo and disable Dependabot.

cc @leotm @naugtur 