### PR TITLE
chore(browserify): de-yarn tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18418,11 +18418,6 @@
         "three": ">=0.86.0"
       }
     },
-    "node_modules/throat": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "license": "MIT"
@@ -19951,7 +19946,6 @@
         "keccak": "^3.0.2",
         "source-map-explorer": "^2.5.3",
         "sourcemap-validator": "^2.1.0",
-        "throat": "^5.0.0",
         "tmp-promise": "^3.0.3",
         "vinyl-buffer": "^1.0.1",
         "watchify": "^4.0.0"

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -31,7 +31,6 @@
     "keccak": "^3.0.2",
     "source-map-explorer": "^2.5.3",
     "sourcemap-validator": "^2.1.0",
-    "throat": "^5.0.0",
     "tmp-promise": "^3.0.3",
     "vinyl-buffer": "^1.0.1",
     "watchify": "^4.0.0"


### PR DESCRIPTION
This removes usages of "yarn" from browserify tests. Dep "throat" is no longer needed.