### PR TITLE
feat(allow-scripts): generate & ship typescript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,7 @@ temp/
 # JetBrains
 .idea
 
+packages/allow-scripts/types
+
 # VScode
 .vscode

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "checkJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "types": ["node"]
+  },
+  "extends": "@tsconfig/node14/tsconfig.json"
+}

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -9,5 +9,5 @@
     "composite": true,
     "types": ["node"]
   },
-  "extends": "@tsconfig/node14/tsconfig.json"
+  "extends": "@tsconfig/node16/tsconfig.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
         "@commitlint/config-conventional": "^17.6.7",
-        "@tsconfig/node14": "^14.1.0",
+        "@tsconfig/node16": "^16.1.1",
         "@types/node": "^20.5.9",
         "@types/yargs": "^17.0.24",
         "ava": "^5.3.1",
@@ -2648,16 +2648,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
-      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
-      "dev": true
-    },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
+      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+      "dev": true
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "18.6.4",
@@ -15853,6 +15848,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/ts-node/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
     "node_modules/ts-node/node_modules/arg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
         "@commitlint/config-conventional": "^17.6.7",
+        "@tsconfig/node14": "^14.1.0",
+        "@types/node": "^20.5.9",
+        "@types/yargs": "^17.0.24",
         "ava": "^5.3.1",
         "conventional-changelog-conventionalcommits": "^6.1.0",
         "depcheck": "^1.4.0",
@@ -27,7 +30,8 @@
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
         "memfs": "^4.3.0",
-        "prettier": "^3.0.2"
+        "prettier": "^3.0.2",
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=14.0.0 <=20.x"
@@ -2645,9 +2649,10 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
+      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
@@ -2815,13 +2820,23 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.4.5",
-      "license": "MIT"
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
+      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/npmcli__promise-spawn": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/npmcli__promise-spawn/-/npmcli__promise-spawn-6.0.1.tgz",
+      "integrity": "sha512-U1AMMUXInsu02LjqkF4rdJ/MjSc6kFBz/4+jGfpUqqKrdWNvIcDgoKYhNLxdyDsiXmK3Hggz4QO+fov/I0p/gg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2937,6 +2952,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.25.tgz",
+      "integrity": "sha512-gy7iPgwnzNvxgAEi2bXOHWCVOG6f7xsprVJH4MjlAWeBmJ7vh/Y1kwMtUrs64ztf24zVIRCpr3n/z6gm9QIkgg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+      "dev": true
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.1",
@@ -3216,8 +3246,7 @@
     },
     "node_modules/@yarnpkg/builder/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/cli": {
       "version": "3.5.1",
@@ -3272,8 +3301,7 @@
     },
     "node_modules/@yarnpkg/cli/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/core": {
       "version": "3.5.1",
@@ -3339,8 +3367,7 @@
     },
     "node_modules/@yarnpkg/core/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/extensions": {
       "version": "1.1.2",
@@ -3365,8 +3392,7 @@
     },
     "node_modules/@yarnpkg/fslib/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/json-proxy": {
       "version": "2.1.1",
@@ -3381,8 +3407,7 @@
     },
     "node_modules/@yarnpkg/json-proxy/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/libzip": {
       "version": "2.3.0",
@@ -3397,8 +3422,7 @@
     },
     "node_modules/@yarnpkg/libzip/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/nm": {
       "version": "3.1.0",
@@ -3425,8 +3449,7 @@
     },
     "node_modules/@yarnpkg/parsers/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-compat": {
       "version": "3.1.11",
@@ -3461,8 +3484,7 @@
     },
     "node_modules/@yarnpkg/plugin-dlx/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-essentials": {
       "version": "3.3.0",
@@ -3491,8 +3513,7 @@
     },
     "node_modules/@yarnpkg/plugin-essentials/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-file": {
       "version": "2.3.1",
@@ -3510,8 +3531,7 @@
     },
     "node_modules/@yarnpkg/plugin-file/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-git": {
       "version": "2.6.5",
@@ -3534,8 +3554,7 @@
     },
     "node_modules/@yarnpkg/plugin-git/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-github": {
       "version": "2.3.1",
@@ -3554,8 +3573,7 @@
     },
     "node_modules/@yarnpkg/plugin-github/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-http": {
       "version": "2.2.1",
@@ -3573,8 +3591,7 @@
     },
     "node_modules/@yarnpkg/plugin-http/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-init": {
       "version": "3.2.1",
@@ -3595,8 +3612,7 @@
     },
     "node_modules/@yarnpkg/plugin-init/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-link": {
       "version": "2.2.1",
@@ -3614,8 +3630,7 @@
     },
     "node_modules/@yarnpkg/plugin-link/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-nm": {
       "version": "3.1.5",
@@ -3642,8 +3657,7 @@
     },
     "node_modules/@yarnpkg/plugin-nm/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-npm": {
       "version": "2.7.3",
@@ -3687,8 +3701,7 @@
     },
     "node_modules/@yarnpkg/plugin-npm-cli/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-npm/node_modules/ssri": {
       "version": "6.0.2",
@@ -3699,8 +3712,7 @@
     },
     "node_modules/@yarnpkg/plugin-npm/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-pack": {
       "version": "3.2.0",
@@ -3722,8 +3734,7 @@
     },
     "node_modules/@yarnpkg/plugin-pack/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-patch": {
       "version": "3.2.4",
@@ -3744,8 +3755,7 @@
     },
     "node_modules/@yarnpkg/plugin-patch/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-pnp": {
       "version": "3.2.9",
@@ -3770,8 +3780,7 @@
     },
     "node_modules/@yarnpkg/plugin-pnp/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-pnpm": {
       "version": "1.1.3",
@@ -3794,8 +3803,7 @@
     },
     "node_modules/@yarnpkg/plugin-pnpm/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/plugin-stage": {
       "version": "3.1.3",
@@ -3815,8 +3823,7 @@
     },
     "node_modules/@yarnpkg/plugin-stage/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@yarnpkg/pnp": {
       "version": "3.3.2",
@@ -3867,8 +3874,7 @@
     },
     "node_modules/@yarnpkg/shell/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@zeit/schemas": {
       "version": "2.29.0",
@@ -5183,8 +5189,7 @@
     },
     "node_modules/browserify/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5488,8 +5493,7 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -5504,8 +5508,7 @@
     },
     "node_modules/cheerio-select/node_modules/css-select": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -5519,8 +5522,7 @@
     },
     "node_modules/cheerio-select/node_modules/css-what": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -5530,8 +5532,7 @@
     },
     "node_modules/cheerio-select/node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -5543,19 +5544,17 @@
     },
     "node_modules/cheerio-select/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/cheerio-select/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -5568,8 +5567,7 @@
     },
     "node_modules/cheerio-select/node_modules/domutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -5581,8 +5579,7 @@
     },
     "node_modules/cheerio-select/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -5592,8 +5589,7 @@
     },
     "node_modules/cheerio-select/node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -6496,18 +6492,16 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "delaunator": "5"
       },
@@ -6835,9 +6829,8 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.0"
       }
@@ -7548,9 +7541,8 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8122,9 +8114,8 @@
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -8649,9 +8640,8 @@
     },
     "node_modules/fs-monkey": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8795,9 +8785,8 @@
     },
     "node_modules/gh-pages/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8869,9 +8858,8 @@
     },
     "node_modules/glob": {
       "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
-      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
@@ -8906,9 +8894,8 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8921,9 +8908,8 @@
     },
     "node_modules/glob/node_modules/minipass": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9455,9 +9441,8 @@
     },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.18"
       }
@@ -10272,9 +10257,8 @@
     },
     "node_modules/json-joy": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.6.0.tgz",
-      "integrity": "sha512-vJtJD89T0OOZFMaENe95xKCOdibMev/lELkclTdhZxLplwbBPxneWNuctUPizk2nLqtGfBxwCXVO42G9LBoFBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "arg": "^5.0.2",
         "hyperdyperid": "^1.2.0"
@@ -10769,9 +10753,8 @@
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lodash.debounce": {
@@ -10786,9 +10769,8 @@
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lodash.isfunction": {
@@ -11082,9 +11064,8 @@
     },
     "node_modules/memfs": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.3.0.tgz",
-      "integrity": "sha512-bOMyYalKCLeEkd5l3sYv0XIsVPQW+2oGhYm8LwD1htXS637VmIdoXVrWPxZdbJlEogDIrTnm6wqqZBrYb7ZFPw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "json-joy": "^9.2.0",
         "thingies": "^1.11.1"
@@ -11894,8 +11875,7 @@
     },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11913,8 +11893,7 @@
     },
     "node_modules/node-gyp/node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -11922,8 +11901,7 @@
     },
     "node_modules/node-gyp/node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -11979,16 +11957,6 @@
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/node-gyp/node_modules/ssri": {
-      "version": "9.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/node-gyp/node_modules/unique-filename": {
@@ -12585,8 +12553,7 @@
     },
     "node_modules/parse5": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -12596,8 +12563,7 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
@@ -12608,19 +12574,17 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -12633,8 +12597,7 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -13132,9 +13095,8 @@
     },
     "node_modules/prettier": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13457,9 +13419,8 @@
     },
     "node_modules/quill-delta": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-diff": "^1.3.0",
@@ -14142,8 +14103,7 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14169,9 +14129,8 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -14616,7 +14575,7 @@
       "version": "0.18.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@endo/env-options": "^0.1.3"
+        "@endo/env-options": "^0.1.4"
       }
     },
     "node_modules/set-blocking": {
@@ -14837,9 +14796,8 @@
     },
     "node_modules/source-map-explorer/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14985,6 +14943,16 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -15510,9 +15478,8 @@
     },
     "node_modules/temp/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15632,9 +15599,8 @@
     },
     "node_modules/thingies": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.12.0.tgz",
-      "integrity": "sha512-AiGqfYC1jLmJagbzQGuoZRM48JPsr9yB734a7K6wzr34NMhjUPrWSQrkF7ZBybf3yCerCL2Gcr02kMv4NmaZfA==",
       "dev": true,
+      "license": "Unlicense",
       "engines": {
         "node": ">=10.18"
       },
@@ -15883,6 +15849,12 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
@@ -15920,9 +15892,8 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
@@ -15994,9 +15965,10 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16504,9 +16476,8 @@
     },
     "node_modules/webpack-dev-middleware/node_modules/memfs": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.4"
       },
@@ -17010,10 +16981,13 @@
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "4.0.1",
         "npm-normalize-package-bin": "^3.0.0",
-        "yargs": "^16.2.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "allow-scripts": "src/cli.js"
+      },
+      "devDependencies": {
+        "@types/npmcli__promise-spawn": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17254,11 +17228,10 @@
     },
     "packages/perf/node_modules/concat-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
         "node >= 6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -17268,8 +17241,7 @@
     },
     "packages/perf/node_modules/lavamoat-browserify": {
       "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/lavamoat-browserify/-/lavamoat-browserify-15.7.4.tgz",
-      "integrity": "sha512-fNBZrIO9yKbKJ0KAAT1ZIIpqPA//b5H34ZZlqh6IlkcfYmHdi9ArU053qzApERurZFAdFrwECYtGq2LcjgM1Fw==",
+      "license": "MIT",
       "dependencies": {
         "@lavamoat/aa": "^3.1.0",
         "@lavamoat/lavapack": "^5.2.4",
@@ -17290,16 +17262,14 @@
     },
     "packages/perf/node_modules/source-map": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
     },
     "packages/perf/node_modules/through2": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
@@ -17332,8 +17302,7 @@
     },
     "packages/survey/node_modules/cheerio": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -17352,8 +17321,7 @@
     },
     "packages/survey/node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -17365,19 +17333,17 @@
     },
     "packages/survey/node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "packages/survey/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -17390,8 +17356,7 @@
     },
     "packages/survey/node_modules/domutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -17403,8 +17368,7 @@
     },
     "packages/survey/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -17414,8 +17378,6 @@
     },
     "packages/survey/node_modules/htmlparser2": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -17423,6 +17385,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -17510,18 +17473,16 @@
     },
     "packages/viz/node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "packages/viz/node_modules/d3": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
-      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -17560,9 +17521,8 @@
     },
     "packages/viz/node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -17572,18 +17532,16 @@
     },
     "packages/viz/node_modules/d3-axis": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-brush": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -17597,9 +17555,8 @@
     },
     "packages/viz/node_modules/d3-chord": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -17609,9 +17566,8 @@
     },
     "packages/viz/node_modules/d3-contour": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -17621,18 +17577,16 @@
     },
     "packages/viz/node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-drag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -17643,9 +17597,8 @@
     },
     "packages/viz/node_modules/d3-dsv": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -17668,18 +17621,16 @@
     },
     "packages/viz/node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-fetch": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -17689,9 +17640,8 @@
     },
     "packages/viz/node_modules/d3-force": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -17703,18 +17653,16 @@
     },
     "packages/viz/node_modules/d3-format": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-geo": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -17724,18 +17672,16 @@
     },
     "packages/viz/node_modules/d3-hierarchy": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -17745,54 +17691,48 @@
     },
     "packages/viz/node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-polygon": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-random": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-selection": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -17802,9 +17742,8 @@
     },
     "packages/viz/node_modules/d3-time": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -17814,9 +17753,8 @@
     },
     "packages/viz/node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -17826,18 +17764,16 @@
     },
     "packages/viz/node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/viz/node_modules/d3-transition": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -17854,9 +17790,8 @@
     },
     "packages/viz/node_modules/d3-zoom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -17891,9 +17826,8 @@
     },
     "packages/viz/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
     "@commitlint/config-conventional": "^17.6.7",
-    "@tsconfig/node14": "^14.1.0",
+    "@tsconfig/node16": "^16.1.1",
     "@types/node": "^20.5.9",
     "@types/yargs": "^17.0.24",
     "ava": "^5.3.1",
@@ -23,9 +23,9 @@
     "glob": "^10.3.4",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
-    "typescript": "^5.2.2",
     "memfs": "^4.3.0",
-    "prettier": "^3.0.2"
+    "prettier": "^3.0.2",
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=14.0.0 <=20.x"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
     "@commitlint/config-conventional": "^17.6.7",
+    "@tsconfig/node14": "^14.1.0",
+    "@types/node": "^20.5.9",
+    "@types/yargs": "^17.0.24",
     "ava": "^5.3.1",
     "conventional-changelog-conventionalcommits": "^6.1.0",
     "depcheck": "^1.4.0",
@@ -20,6 +23,7 @@
     "glob": "^10.3.4",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
+    "typescript": "^5.2.2",
     "memfs": "^4.3.0",
     "prettier": "^3.0.2"
   },
@@ -27,7 +31,10 @@
     "node": ">=14.0.0 <=20.x"
   },
   "scripts": {
-    "build": "npm run --workspaces --if-present build",
+    "build": "npm run --workspaces --if-present build && npm run build:types",
+    "build:types": "tsc -b",
+    "clean:types": "tsc -b --clean",
+    "watch:types": "tsc -b --watch",
     "lint:commit": "commitlint",
     "lint:deps": "npm run --workspaces --if-present lint:deps",
     "lint:eslint": "eslint .",
@@ -39,7 +46,8 @@
     "release:dry-run": "node scripts/publish.js --dry-run --newPkg=${npm_config_newpkg}",
     "release:rebuild": "npm run rebuild && npm run test:prep && npm run test:workspaces",
     "release": "npm run release:rebuild && npm run release:publish --newPkg=${npm_config_newpkg}",
-    "rebuild": "npm run --workspaces --if-present rebuild",
+    "rebuild": "npm run --workspaces --if-present rebuild && npm run rebuild:types",
+    "rebuild:types": "npm run clean:types && npm run build:types",
     "setup": "allow-scripts",
     "test:prep": "npm run --workspaces --if-present test:prep",
     "test:workspaces": "npm run --workspaces --if-present test",

--- a/packages/allow-scripts/.depcheckrc.yml
+++ b/packages/allow-scripts/.depcheckrc.yml
@@ -1,3 +1,7 @@
 ignores:
   # monorepo deps
   - 'ava'
+  - "@types/npmcli__promise-spawn"
+
+  # only types (from @types/npmcli__promise-spawn) are referenced
+  - "@npmcli/promise-spawn"

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -15,7 +15,7 @@
     "@npmcli/run-script": "^6.0.0",
     "bin-links": "4.0.1",
     "npm-normalize-package-bin": "^3.0.0",
-    "yargs": "^16.2.0"
+    "yargs": "^17.7.2"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,9 @@
   "description": "A tool for running only the dependency lifecycle hooks specified in an allowlist.",
   "directories": {
     "test": "test"
+  },
+  "devDependencies": {
+    "@types/npmcli__promise-spawn": "^6.0.0"
   },
   "scripts": {
     "test": "npm run test:run",
@@ -45,5 +48,6 @@
       "test/*.spec.js"
     ],
     "timeout": "30s"
-  }
+  },
+  "types": "./types/index.d.ts"
 }

--- a/packages/allow-scripts/src/cli.js
+++ b/packages/allow-scripts/src/cli.js
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 
-const yargs = require('yargs')
-const {
-  runAllowedPackages,
-  setDefaultConfiguration,
-  printPackagesList,
-} = require('./index.js')
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const { runAllowedPackages, setDefaultConfiguration, printPackagesList } = require('./index.js')
 const { writeRcFile, editPackageJson } = require('./setup.js')
 const { FEATURE } = require('./toggles')
 
@@ -14,7 +11,7 @@ start().catch((err) => {
   process.exit(1)
 })
 
-async function start() {
+async function start () {
   const rootDir = process.cwd()
 
   const parsedArgs = parseArgs()
@@ -44,15 +41,13 @@ async function start() {
     }
     // (error) unrecognized
     default: {
-      throw new Error(
-        `@lavamoat/allow-scripts - unknown command "${parsedArgs.command}"`
-      )
+      throw new Error(`@lavamoat/allow-scripts - unknown command "${parsedArgs.command}"`)
     }
   }
 }
 
-function parseArgs() {
-  const argsParser = yargs
+function parseArgs () {
+  const argsParser = yargs(hideBin(process.argv))
     .usage('Usage: $0 <command> [options]')
     .command('$0', 'run the allowed scripts')
     .command('run', 'run the allowed scripts')
@@ -60,14 +55,13 @@ function parseArgs() {
     .command('setup', 'configure local repository to use allow-scripts')
     .option('experimental-bins', {
       alias: 'bin',
-      describe:
-        'opt-in to set up experimental protection against bin script confusion',
+      describe: 'opt-in to set up experimental protection against bin script confusion',
       type: 'boolean',
       default: false,
     })
     .help()
 
-  const parsedArgs = argsParser.parse()
+  const parsedArgs = argsParser.parseSync()
   parsedArgs.command = parsedArgs._[0]
 
   return parsedArgs

--- a/packages/allow-scripts/src/linker.js
+++ b/packages/allow-scripts/src/linker.js
@@ -1,20 +1,17 @@
 // @ts-check
 // All of this is derived from the main functionality of bin-links that unfortunately would not allow for absolute path links
+
 const binTarget = require('bin-links/lib/bin-target.js')
 const isWindows = require('bin-links/lib/is-windows.js')
-const linkBin = isWindows
-  ? require('bin-links/lib/shim-bin.js')
-  : require('bin-links/lib/link-bin.js')
+const linkBin = isWindows ? require('bin-links/lib/shim-bin.js') : require('bin-links/lib/link-bin.js')
+
 
 const { dirname, resolve, relative } = require('path')
 
-const linkBinRelative = ({
-  path,
-  bin,
-  link,
-  top = undefined,
-  force = true,
-}) => {
+/**
+ * @param {LinkBinOpts} opts
+ */
+const linkBinRelative = ({ path, bin, link, top = undefined, force = true }) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
   const absFrom = resolve(path, link)
@@ -22,13 +19,10 @@ const linkBinRelative = ({
   return linkBin({ path, from, to, absFrom, force })
 }
 
-const linkBinAbsolute = ({
-  path,
-  bin,
-  link,
-  top = undefined,
-  force = true,
-}) => {
+/**
+ * @param {LinkBinOpts} opts
+ */
+const linkBinAbsolute = ({ path, bin, link, top = undefined, force = true }) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
   const absFrom = link
@@ -40,3 +34,12 @@ module.exports = {
   linkBinRelative,
   linkBinAbsolute,
 }
+
+/**
+ * @typedef LinkBinOpts
+ * @property {string} path
+ * @property {string} bin
+ * @property {string} link
+ * @property {string} [top]
+ * @property {boolean} [force]
+ */

--- a/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
@@ -1,0 +1,12 @@
+declare module "bin-links/lib/bin-target.js" {
+  namespace binTarget {
+    interface BinTargetOptions {
+      top?: string;
+      path: string;
+    }
+  }
+
+  function binTarget(opts: binTarget.BinTargetOptions): string;
+
+  export = binTarget;
+}

--- a/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/is-windows.d.ts
@@ -1,0 +1,4 @@
+declare module "bin-links/lib/is-windows.js" {
+  var isWindows: boolean;
+  export = isWindows;
+}

--- a/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
@@ -1,0 +1,15 @@
+declare module "bin-links/lib/link-bin.js" {
+  namespace linkBin {
+    interface LinkBinOptions {
+      path: string;
+      from: string;
+      to: string;
+      absFrom: string;
+      force: boolean;
+    }
+  }
+
+  function linkBin(opts: linkBin.LinkBinOptions): Promise<boolean>;
+
+  export = linkBin;
+}

--- a/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
@@ -1,0 +1,15 @@
+declare module "bin-links/lib/shim-bin.js" {
+  namespace shimBin {
+    interface ShimBinOptions {
+      path: string;
+      from: string;
+      to: string;
+      absFrom: string;
+      force: boolean;
+    }
+  }
+
+  function shimBin(opts: shimBin.ShimBinOptions): Promise<boolean>;
+
+  export = shimBin;
+}

--- a/packages/allow-scripts/src/types/lavamoat__aa.d.ts
+++ b/packages/allow-scripts/src/types/lavamoat__aa.d.ts
@@ -1,0 +1,15 @@
+// XXX: temporary while `@lavamoat/aa` exports no types
+
+declare module "@lavamoat/aa" {
+  export interface Resolver {
+    sync(path: string, opts: { basedir: string }): string;
+  }
+  export interface LoadCanonicalNameMapOpts {
+    rootDir: string;
+    includeDevDeps?: boolean;
+    resolve?: Resolver;
+  }
+  export function loadCanonicalNameMap(
+    opts: LoadCanonicalNameMapOpts
+  ): Promise<Map<string, string>>;
+}

--- a/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
+++ b/packages/allow-scripts/src/types/npm-normalize-package-bin.d.ts
@@ -1,0 +1,19 @@
+declare module "npm-normalize-package-bin" {
+  namespace normalizePackageBin {
+    interface PackageBin {
+      name: string;
+      bin?: string | Record<string, string>;
+    }
+
+    interface NormalizedPackageBin {
+      name: string;
+      bin?: Record<string, string>;
+    }
+  }
+
+  function normalizePackageBin(
+    pkg: normalizePackageBin.PackageBin
+  ): normalizePackageBin.NormalizedPackageBin;
+
+  export = normalizePackageBin;
+}

--- a/packages/allow-scripts/src/types/npmcli__run-script.d.ts
+++ b/packages/allow-scripts/src/types/npmcli__run-script.d.ts
@@ -1,0 +1,22 @@
+declare module "@npmcli/run-script" {
+  import { StdioOptions } from "node:child_process";
+  import type PromiseSpawn from "@npmcli/promise-spawn";
+
+  namespace npmRunScript {
+    interface RunScriptOptions {
+      event: string;
+      path: string;
+      scriptShell?: string;
+      env?: Record<string, string>;
+      stdio?: StdioOptions;
+      stdioString?: boolean;
+      banner?: boolean;
+    }
+  }
+
+  function npmRunScript(
+    opts: npmRunScript.RunScriptOptions
+  ): ReturnType<typeof PromiseSpawn>;
+
+  export = npmRunScript;
+}

--- a/packages/allow-scripts/tsconfig.json
+++ b/packages/allow-scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "types",
+    "rootDir": "src",
+    "skipLibCheck": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "packages/allow-scripts"
+    }
+  ]
+}


### PR DESCRIPTION
This is a PoC for creating (and shipping) declaration files for LavaMoat packages.

Right now, I've fully typed the sources (not the tests) of @lavamoat/allow-scripts, which now validates the types in "strict" mode. TypeScript is configured for incremental builds (preferable for monorepos), but only builds one module as a PoC.

To generate types, execute npm run build:types in the @lavamoat/allow-scripts workspace. They will be output into packages/allow-scripts/types (which is not under VCS).

I added available type declarations (from DefinitelyTyped), but I had to write a handful of my own for external modules. These do not appear to be re-exported. AFAICT (but I haven't tested it!) there aren't any type declarations that are needed as production dependencies (in @lavamoat/allow-scripts, anyway).

I took some liberties tweaking existing types (narrowing where appropriate, separating @typedefs so that descriptions would be picked up, etc.). I'd prefer if we used the T[] syntax for arrays instead of Array<T>, but that's just my personal preference and I stuck to the current convention.

I note that these .d.ts files I created have semicolons which is a byproduct of my IDE's default formatting. If we intend to keep any of these around, I'd recommend pulling in @typescript-eslint/plugin and its ilk.
