### PR TITLE
chore(ci): do not use npm ci

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,15 +20,20 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
+          cache: 'npm'
       - name: Upgrade npm # for workspace support
         run: npm i -g npm
       - name: Install Dependencies
         uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
         with:
           useRollingCache: true
-          install-command: npm ci --foreground-scripts
+          install-command: npm install --foreground-scripts
       - name: Lint
         run: npm run lint
       - name: Test
         run: npm test
+
+      - # if `npm install` updated `package-lock.json`, this ensures
+        # a clean install works as expected
+        name: Check Lockfile
+        run: npm ci


### PR DESCRIPTION
`npm ci` rimrafs `node_modules` then installs everything in `package-lock.json`.  However, it is highly likely that the result of running `npm install` in a development environment will result in a very different tree, which updates `package-lock.json`.  If one of the dependencies installed ships a poorly-built shrinkwrap file, the updated `package-lock.json` will contain potentially incompatible software from the shrinkwrap. This will be manifested _upon the next `npm ci`_ because it _strictly_ installs what's in `package-lock.json`.

TL;DR: `npm ci` is fast, but using it exclusively in CI can be dangerous.