### PR TITLE
fix(tofu): parse private names

### DIFF
--- a/packages/tofu/src/findGlobals.js
+++ b/packages/tofu/src/findGlobals.js
@@ -55,6 +55,11 @@ function findGlobals (ast) {
         }
       }
 
+      // private names are not globals
+      if (parentType === 'PrivateName' && path.parent.id === path.node) {
+        return
+      }
+
       // save global
       saveGlobal(path)
     },

--- a/packages/tofu/src/util.js
+++ b/packages/tofu/src/util.js
@@ -42,7 +42,9 @@ function getNameFromNode (node) {
     return node.name
   } else if (node.type === 'ThisExpression') {
     return 'this'
-  } else {
+  } else if (node.type === 'PrivateName') {
+    return `#${node.id.name}`
+  }else {
     throw new Error(`unknown ast node type when trying to get name: "${node.type}"`)
   }
 }
@@ -139,7 +141,7 @@ function objToMap (obj) {
 function mapToObj (map) {
   const obj = {}
   map.forEach((value, key) => {
-    obj[key] = value 
+    obj[key] = value
   })
   return obj
 }

--- a/packages/tofu/test/fixtures/class.js
+++ b/packages/tofu/test/fixtures/class.js
@@ -1,10 +1,12 @@
 class MyClass extends SuperClass {
+    #i;
     constructor(a) {
         super();
         this.a = a;
+        this.#i = 'i';
     }
     get b() {
-        return this.a;
+        return this.a + this.#i;
     }
     set b(_b) {
         this.a = _b;


### PR DESCRIPTION
This updates `getNameFromNode()` to understand what to do with private names, and also updates `findGlobals()` to ignore private names.

Closes #642

I probably want @kumavis to look at this, because I'm not sure of the intent here.  I'm fairly confident my change in `findGlobals()` is correct, but--what is the name returned by  `getNameForNode()` used for?  