### PR TITLE
ci: Add alpine-based Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git/
+.github/
+Dockerfile
+Dockerfile-*
+.dockerignore
+.vscode/
+.husky/
+.editorconfig
+*.log
+node_modules/
+docs/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3
         with:
           driver: docker-container
           driver-opts: |
-            image=docker.io/moby/buildkit:master@sha256:1b6abfd9bbfbf129245dc1f288aa38f064dfee8d608b8be9086936f5580c78f2
+            image=docker.io/moby/buildkit:master@sha256:c8029e1a3e837c6e3b3c7dc97114385e902a2a321306bd6aa5c86da3ab6414db
       - name: Build OCI image
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75  # v6
         with:
           # Use local cache dir when running using Act; gha cache otherwise
           cache-from: type=${{ env.ACT && 'local,src=/tmp/act-cache' || 'gha' }}
@@ -27,39 +27,21 @@ jobs:
           file: ./Dockerfile
           load: true
           push: false
-          tags: dev:latest
-      - name: lint
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
-        with:
-          image: dev:latest
-          run: 'npm run lint && npm run lint:fix'
-      - name: publish-dry-run
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
-        with:
-          image: dev:latest
-          run: |
-            # note: package scripts only seem to support maximum a single unpublished package present in the repository
-            newpkg_path=$(jq -r 'to_entries|map(select(.value=="0.0.0"))[0].key' .release-please-manifest.json)
-            export npm_config_newpkg=$(jq -r .name "${newpkg_path}/package.json")
-            echo "New package: ${npm_config_newpkg}"
-            # these two commands should be identical
-            npm run release:dry-run
-            npm run release:publish -- --dryRun
+          tags: 'dev:latest'
       - name: rebuild
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:
-          image: dev:latest
-          run: npm run setup && npm run rebuild
-      - name: lint:git
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+          image: 'dev:latest'
+          run: |
+            npm run setup && npm run rebuild
+      - name: lint
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:
-          image: dev:latest
-          run: >
-            git init -b main &&
-              git add README.md && npm run lint:staged &&
-              git commit -m 'docs: Add README.md' && npm run lint:commit -- -e
+          image: 'dev:latest'
+          run: 'npm run lint'
       - name: test
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:
-          image: dev:latest
-          run: npm run test:prep && npm run test
+          image: 'dev:latest'
+          run: |
+            npm run test:prep && npm run test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3
         with:
-          driver: docker-container
+          driver: docker-container # for advanced features like build caching when running Act locally
           driver-opts: |
             image=docker.io/moby/buildkit:master@sha256:c8029e1a3e837c6e3b3c7dc97114385e902a2a321306bd6aa5c86da3ab6414db
       - name: Build OCI image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: CI-Docker
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test-dev-alpine:
+    name: test-dev-alpine
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
+        with:
+          driver: docker-container
+          driver-opts: |
+            image=docker.io/moby/buildkit:master@sha256:1b6abfd9bbfbf129245dc1f288aa38f064dfee8d608b8be9086936f5580c78f2
+      - name: Build OCI image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5
+        with:
+          # Use local cache dir when running using Act; gha cache otherwise
+          cache-from: type=${{ env.ACT && 'local,src=/tmp/act-cache' || 'gha' }}
+          cache-to: type=${{ env.ACT && 'local,dest=/tmp/act-cache' || 'gha' }},mode=max
+          context: .
+          file: ./Dockerfile
+          load: true
+          push: false
+          tags: dev:latest
+      - name: lint
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: dev:latest
+          run: 'npm run lint && npm run lint:fix'
+      - name: publish-dry-run
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: dev:latest
+          run: |
+            # note: package scripts only seem to support maximum a single unpublished package present in the repository
+            newpkg_path=$(jq -r 'to_entries|map(select(.value=="0.0.0"))[0].key' .release-please-manifest.json)
+            export npm_config_newpkg=$(jq -r .name "${newpkg_path}/package.json")
+            echo "New package: ${npm_config_newpkg}"
+            # these two commands should be identical
+            npm run release:dry-run
+            npm run release:publish -- --dryRun
+      - name: rebuild
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: dev:latest
+          run: npm run setup && npm run rebuild
+      - name: lint:git
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: dev:latest
+          run: >
+            git init -b main &&
+              git add README.md && npm run lint:staged &&
+              git commit -m 'docs: Add README.md' && npm run lint:commit -- -e
+      - name: test
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: dev:latest
+          run: npm run test:prep && npm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,15 +93,30 @@ This section describes how to configure your development environment to hack on 
 
 #### Platform
 
-LavaMoat can comfortably be developed using Linux, macOS, or Windows (but we recommend using WSL on Windows).
+LavaMoat officially supports building on the following operating systems and architectures:
+
+- Latest Ubuntu LTS [`x86_64`]
+- Debian Stable [`x86_64`]
+- Latest Alpine Linux Stable [`x86_64`]
+
+On a best-effort basis, development should also be expected to work on:
+
+- macOS 13.5+ [`x86_64` / `aarch64`]
+- Windows Subsystem for Linux 1 [`x86_64`]
+- Windows Subsystem for Linux 2 [`x86_64` / `aarch64`]
+- Latest Ubuntu LTS [`aarch64`]
+- Debian Stable [`aarch64`]
+- Latest Alpine Linux Stable [`aarch64`]
+
+Developer experience reports for supported and unsupported platforms and compatibility fixes are welcome.
 
 #### Node.js
 
-LavaMoat is distributed as a [Node.js][node] command-line tool. You'll want to install the latest LTS version (see the [Node.js release schedule][release-schedule] for more information).
+LavaMoat is distributed as a [Node.js][node] command-line tool. You'll want to install the active LTS version (see the [Node.js release schedule][release-schedule] for more information).
 
 :::tip
 
-Don't have Node.js installed? You can [download and install Node.js from the official site][node-download], but we recommend using a Node.js version manager (e.g., [nvm][]).
+Don't have Node.js installed? You can [download and install Node.js from the official site][node-download].
 
 :::
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.2
+
+# development and testing image
+# contains the entire built source-repository under /app
+
+ARG NODE_VERSION=18
+ARG BASE_IMAGE_DIGEST=sha256:ea8e360a721d870337fe899c70ea7def62f2a72cf1b6f7beb8a3ccaac8b6049c # docker.io/library/node:18-alpine
+FROM docker.io/library/node:${NODE_VERSION}-alpine@${BASE_IMAGE_DIGEST}
+
+WORKDIR /app
+
+RUN apk add --no-cache \
+    bash git jq \
+    # for node-gyp builds \
+    python3 build-base make \
+  && chown node:node /app
+
+COPY --chown=node:node . .
+USER node
+
+ARG GIT_USER_NAME="Your Name"
+ARG GIT_USER_EMAIL="you@example.com"
+RUN git config --global user.email "${GIT_USER_EMAIL}" && \
+  git config --global user.name "${GIT_USER_NAME}" && \
+  npm ci && \
+  npm run setup && \
+  npm run build
+
+ENTRYPOINT ["/usr/local/bin/npm"]


### PR DESCRIPTION
- Adds an integration test running ~all~ basic package scripts inside an Alpine Linux Docker container to cross-check for any implicit runtime dependencies on the `ubuntu-latest` environment in GitHub Actions.
- Adds `Development` section to `CONTRIBUTING.md` with information on supported development environments.
  - Took the conservative stance here and only including tested environments (ubuntu+alpine) - considering those two, Debian seems safe enough as well.

The `node:18-alpine` base image does not have `glibc` and many other other packages common in other distros like Ubuntu, and comes with a different default shell.