### PR TITLE
chore(ci): do not upgrade to npm@10.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
+          cache: 'npm'
       - name: Upgrade npm # for workspace support
-        run: npm i -g npm
+        run: npm i -g npm@9 # npm@9 supports our supported Node.js versions
       - name: Install Dependencies
         uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
         with:


### PR DESCRIPTION
**CI is currently broken on all branches until this is fixed.**

`npm` @ v10.x is incompatible with Node.js v14.x
