### PR TITLE
chore: use npm for browserify tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18400,11 +18400,6 @@
         "three": ">=0.86.0"
       }
     },
-    "node_modules/throat": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "license": "MIT"
@@ -19933,7 +19928,6 @@
         "keccak": "^3.0.2",
         "source-map-explorer": "^2.5.3",
         "sourcemap-validator": "^2.1.0",
-        "throat": "^5.0.0",
         "tmp-promise": "^3.0.3",
         "vinyl-buffer": "^1.0.1",
         "watchify": "^4.0.0"

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -31,7 +31,6 @@
     "keccak": "^3.0.2",
     "source-map-explorer": "^2.5.3",
     "sourcemap-validator": "^2.1.0",
-    "throat": "^5.0.0",
     "tmp-promise": "^3.0.3",
     "vinyl-buffer": "^1.0.1",
     "watchify": "^4.0.0"

--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -81,6 +81,7 @@
       "globals": {
         "__dirname": true,
         "__filename.slice": true,
+        "console.error": true,
         "console.warn": true,
         "process.cwd": true,
         "setTimeout": true
@@ -91,6 +92,7 @@
         "@lavamoat/lavapack>through2": true,
         "@lavamoat/lavapack>umd": true,
         "browserify>JSONStream": true,
+        "external:../../node_modules/espree/dist/espree.cjs": true,
         "json-stable-stringify": true,
         "lavamoat-core": true,
         "readable-stream": true
@@ -788,6 +790,25 @@
     "duplexify>end-of-stream>once": {
       "packages": {
         "duplexify>end-of-stream>once>wrappy": true
+      }
+    },
+    "external:../../node_modules/acorn-jsx/index.js": {
+      "packages": {
+        "external:../../node_modules/acorn-jsx/xhtml.js": true,
+        "external:../../node_modules/acorn/dist/acorn.js": true
+      }
+    },
+    "external:../../node_modules/acorn/dist/acorn.js": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "external:../../node_modules/espree/dist/espree.cjs": {
+      "packages": {
+        "external:../../node_modules/acorn-jsx/index.js": true,
+        "external:../../node_modules/acorn/dist/acorn.js": true,
+        "external:../../node_modules/eslint-visitor-keys/dist/eslint-visitor-keys.cjs": true
       }
     },
     "json-stable-stringify": {


### PR DESCRIPTION
This changes the `lavamoat-browserify` tests to use `npm` instead of `yarn`, and installs via absolute path instead of `npm link`; this does not modify the global `node_modules` folder.

Note: a test fixture policy file is updated.

This supercedes #683.

Closes #682