### PR TITLE
refactor(core): consolidate endowments logic

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -2,10 +2,10 @@
 // this module has been written so that it required directly or copied and added to the template with a small wrapper
 module.exports = endowmentsToolkit
 
-// utilities for generating the endowments object based on a globalRef and a config
+// utilities for generating the endowments object based on a globalRef and a packagePolicy
 
-// The config uses a period-deliminated path notation to pull out deep values from objects
-// These utilities help create an object populated with only the deep properties specified in the config
+// The packagePolicy uses a period-deliminated path notation to pull out deep values from objects
+// These utilities help create an object populated with only the deep properties specified in the packagePolicy
 
 function endowmentsToolkit({ createFunctionWrapper = defaultCreateFunctionWrapper } = {}) {
   return {
@@ -19,40 +19,39 @@ function endowmentsToolkit({ createFunctionWrapper = defaultCreateFunctionWrappe
   }
 
   /**
-   *
-   * @function getEndowmentsForConfig
+   * @function getEndowmentsForConfig Creates an object populated with only the deep properties specified in the packagePolicy
    * @param {object} sourceRef - Object from which to copy properties
-   * @param {object} config - LavaMoat package config
+   * @param {object} packagePolicy - LavaMoat policy item representing a package
    * @param {object} unwrapTo - For getters and setters, when the this-value is unwrapFrom, is replaced as unwrapTo
    * @param {object} unwrapFrom - For getters and setters, the this-value to replace (default: targetRef)
    * @return {object} - The targetRef
    *
    */
-  function getEndowmentsForConfig(sourceRef, config, unwrapTo, unwrapFrom) {
-    if (!config.globals) {
+  function getEndowmentsForConfig(sourceRef, packagePolicy, unwrapTo, unwrapFrom) {
+    if (!packagePolicy.globals) {
       return {}
     }
-    // validate read access from config
+    // validate read access from packagePolicy
     const whitelistedReads = []
     const explicitlyBanned = []
-    Object.entries(config.globals).forEach(([path, configValue]) => {
+    Object.entries(packagePolicy.globals).forEach(([path, packagePolicyValue]) => {
       const pathParts = path.split('.')
       // disallow dunder proto in path
       const pathContainsDunderProto = pathParts.some(pathPart => pathPart === '__proto__')
       if (pathContainsDunderProto) {
-        throw new Error(`Lavamoat - "__proto__" disallowed when creating minial view. saw "${path}"`)
+        throw new Error(`Lavamoat - "__proto__" disallowed when creating minimal view. saw "${path}"`)
       }
       // false means no access. It's necessary so that overrides can also be used to tighten the policy
-      if (configValue === false) {
+      if (packagePolicyValue === false) {
         explicitlyBanned.push(path)
         return
       }
       // write access handled elsewhere
-      if (configValue === 'write') {
+      if (packagePolicyValue === 'write') {
         return
       }
-      if (configValue !== true) {
-        throw new Error(`LavaMoat - unrecognizable policy value (${typeof configValue}) for path "${path}"`)
+      if (packagePolicyValue !== true) {
+        throw new Error(`LavaMoat - unrecognizable policy value (${typeof packagePolicyValue}) for path "${path}"`)
       }
       whitelistedReads.push(path)
     })

--- a/packages/core/src/generateKernel.js
+++ b/packages/core/src/generateKernel.js
@@ -9,9 +9,8 @@ const path = require('path')
 const kernelTemplate = fs.readFileSync(path.join(__dirname, '/kernelTemplate.js'), 'utf-8')
 const kernelCoreTemplate = fs.readFileSync(path.join(__dirname, '/kernelCoreTemplate.js'), 'utf-8')
 const sesSrc = fs.readFileSync(path.join(__dirname, '/../lib/lockdown.umd.js'), 'utf-8')
-const makeGetEndowmentsForConfigSrc = fs.readFileSync(path.join(__dirname, '/makeGetEndowmentsForConfig.js'), 'utf-8')
+const endowmentsToolkitSrc = fs.readFileSync(path.join(__dirname, '/endowmentsToolkit.js'), 'utf-8')
 const makePrepareRealmGlobalFromConfigSrc = fs.readFileSync(path.join(__dirname, '/makePrepareRealmGlobalFromConfig.js'), 'utf-8')
-const makeGeneralUtilsSrc = fs.readFileSync(path.join(__dirname, '/makeGeneralUtils.js'), 'utf-8')
 const strictScopeTerminatorSrc = fs.readFileSync(path.join(__dirname, '/../lib/strict-scope-terminator.js'), 'utf-8')
 
 module.exports = {
@@ -69,9 +68,8 @@ function generateKernel (_opts = {}) {
 // takes the kernelCoreTemplate and populates it with the libraries
 function generateKernelCore () {
   let output = kernelCoreTemplate
-  output = replaceTemplateRequire(output, 'makeGetEndowmentsForConfig', makeGetEndowmentsForConfigSrc)
+  output = replaceTemplateRequire(output, 'endowmentsToolkit', endowmentsToolkitSrc)
   output = replaceTemplateRequire(output, 'makePrepareRealmGlobalFromConfig', makePrepareRealmGlobalFromConfigSrc)
-  output = replaceTemplateRequire(output, 'makeGeneralUtils', makeGeneralUtilsSrc)
   output = replaceTemplateRequire(output, 'strict-scope-terminator', strictScopeTerminatorSrc)
   return output
 }

--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -66,9 +66,8 @@
     reportStatsHook = () => {},
   }) {
     // "templateRequire" calls are inlined in "generateKernel"
-    const generalUtils = templateRequire('makeGeneralUtils')()
-    const { getEndowmentsForConfig, makeMinimalViewOfRef, applyEndowmentPropDescTransforms, copyWrappedGlobals } = templateRequire('makeGetEndowmentsForConfig')(generalUtils)
-    const { prepareCompartmentGlobalFromConfig } = templateRequire('makePrepareRealmGlobalFromConfig')(generalUtils)
+    const { getEndowmentsForConfig, makeMinimalViewOfRef, applyEndowmentPropDescTransforms, copyWrappedGlobals, createFunctionWrapper } = templateRequire('endowmentsToolkit')()
+    const { prepareCompartmentGlobalFromConfig } = templateRequire('makePrepareRealmGlobalFromConfig')({ createFunctionWrapper })
     const { strictScopeTerminator } = templateRequire('strict-scope-terminator')
 
     const scuttleOpts = generateScuttleOpts(scuttleGlobalThis)
@@ -431,6 +430,7 @@
       }
 
       // transform functions, getters & setters on prop descs. Solves SES scope proxy bug
+      // WARNING: this part should be unnecessary since SES refactor into multiple nested with statements
       Object.entries(Object.getOwnPropertyDescriptors(endowments))
         // ignore non-configurable properties because we are modifying endowments in place
         .filter(([, propDesc]) => propDesc.configurable)

--- a/packages/core/src/makeGeneralUtils.js
+++ b/packages/core/src/makeGeneralUtils.js
@@ -1,5 +1,8 @@
 module.exports = makeGeneralUtils
 
+/**
+ * @deprecated - inlined in endowmentsToolkit (see core/src/endowmentsToolkit.js)
+ */
 function makeGeneralUtils () {
   return {
     createFunctionWrapper,

--- a/packages/core/src/makePrepareRealmGlobalFromConfig.js
+++ b/packages/core/src/makePrepareRealmGlobalFromConfig.js
@@ -35,6 +35,11 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
     const topLevelWriteAccessKeys = getTopLevelWriteAccessFromPackageConfig(globalsConfig)
     const topLevelReadAccessKeys = getTopLevelReadAccessFromPackageConfig(globalsConfig)
 
+    // NOTE: getters for read should only ever be needed on props marked for 'write' (unless we want to allow sloppy behavior from the root compartment modifying everything...)
+    // Making a pass over the entire policy and collecting the names of writable items would limit the number of getters created here to the minimum.
+    // the change should not be introduced here though as we don't want to change the existing behavior of lavamoat-browserify
+    // If you're looking at this for the purpose of moving the code to the new core toolkit for endowments building, there's likely a copy of this functionality already
+
     // define accessors
 
     // allow read access via globalStore or packageCompartmentGlobal

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -1,9 +1,8 @@
 const test = require('ava')
-const makeGetEndowmentsForConfig = require('../src/makeGetEndowmentsForConfig.js')
-const makeGeneralUtils = require('../src/makeGeneralUtils.js')
+const endowmentsToolkit = require('../src/endowmentsToolkit.js')
 
 function prepareTest() {
-  const { getEndowmentsForConfig } = makeGetEndowmentsForConfig(makeGeneralUtils())
+  const { getEndowmentsForConfig } = endowmentsToolkit()
   return getEndowmentsForConfig
 }
 


### PR DESCRIPTION
This is not the major refactoring of core that we were sometimes discussing.
I'm refactoring the endowments bit so that they're more ready to use externally as a toolkit for putting the globals in place.
