### PR TITLE
Allow specifying `lockdownOptions` in `lavamoat-browserify`

### DIFF
--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -122,6 +122,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
   const nonAliasedOptions = [
     'scuttleGlobalThis',
     'scuttleGlobalThisExceptions',
+    'lockdownOptions',
     'bundleWithPrecompiledModules',
     'policyDebug',
     'projectRoot',
@@ -172,6 +173,7 @@ function getConfigurationFromPluginOpts (pluginOpts) {
     writeAutoPolicyDebug: Boolean(pluginOpts.writeAutoPolicyDebug),
     bundleWithPrecompiledModules: 'bundleWithPrecompiledModules' in pluginOpts ? Boolean(pluginOpts.bundleWithPrecompiledModules) : true,
     actionOverrides: {},
+    lockdownOptions: pluginOpts.lockdownOptions,
   }
 
   // check for action overrides

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -19,6 +19,7 @@
     // security options are hard-coded at build time
     const {
       scuttleGlobalThis,
+      lockdownOptions,
     } = __lavamoatSecurityOptions__
 
     function getGlobalRef () {
@@ -51,7 +52,7 @@
     // eslint-disable-next-line no-extra-semi
     ;templateRequire('ses')
 
-    const lockdownOptions = {
+    const DEFAULT_LOCKDOWN_OPTIONS = {
       // gives a semi-high resolution timer
       dateTaming: 'unsafe',
       // this is introduces non-determinism, but is otherwise safe
@@ -62,7 +63,7 @@
       stackFiltering: 'verbose',
     }
 
-    lockdown(lockdownOptions)
+    lockdown(Object.assign({}, DEFAULT_LOCKDOWN_OPTIONS, lockdownOptions ?? {}))
 
     // initialize the kernel
     const createKernelCore = __createKernelCore__

--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -61,6 +61,7 @@ function createPacker({
   bundleWithPrecompiledModules = true,
   scuttleGlobalThis = {},
   scuttleGlobalThisExceptions,
+  lockdownOptions = {},
 } = {}) {
   // stream/parser wrapping incase raw: false
   const parser = raw ? through.obj() : JSONStream.parse([true])
@@ -106,6 +107,7 @@ function createPacker({
 
   prelude = prelude.replace('__lavamoatSecurityOptions__', JSON.stringify({
     scuttleGlobalThis,
+    lockdownOptions,
   }))
 
   // note: pack stream cant started emitting data until its received its first module


### PR DESCRIPTION
Allow specifying `lockdownOptions` in `lavamoat-browserify` for more customizability.

Proposed fix for https://github.com/LavaMoat/LavaMoat/issues/693

Feedback appreciated!