### PR TITLE
fix(viz): upgrade d3 stuff for npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7145,155 +7145,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/d3": {
-      "version": "5.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-axis": "1",
-        "d3-brush": "1",
-        "d3-chord": "1",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-contour": "1",
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-dsv": "1",
-        "d3-ease": "1",
-        "d3-fetch": "1",
-        "d3-force": "1",
-        "d3-format": "1",
-        "d3-geo": "1",
-        "d3-hierarchy": "1",
-        "d3-interpolate": "1",
-        "d3-path": "1",
-        "d3-polygon": "1",
-        "d3-quadtree": "1",
-        "d3-random": "1",
-        "d3-scale": "2",
-        "d3-scale-chromatic": "1",
-        "d3-selection": "1",
-        "d3-shape": "1",
-        "d3-time": "1",
-        "d3-time-format": "2",
-        "d3-timer": "1",
-        "d3-transition": "1",
-        "d3-voronoi": "1",
-        "d3-zoom": "1"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-axis": {
-      "version": "1.0.12",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-binarytree": {
       "version": "0.2.2",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/d3-brush": {
-      "version": "1.1.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-color": {
-      "version": "1.4.1",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-contour": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.1.1"
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/d3-dispatch": {
-      "version": "1.0.6",
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-drag": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
+        "delaunator": "5"
       },
-      "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-fetch": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dsv": "1"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-force-3d": {
@@ -7335,56 +7210,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-format": {
-      "version": "1.4.5",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-geo": {
-      "version": "1.12.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "1.1.9",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
     "node_modules/d3-octree": {
       "version": "0.2.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/d3-path": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-polygon": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-quadtree": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-random": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
@@ -7413,14 +7242,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-scale-chromatic/node_modules/d3-color": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-scale-chromatic/node_modules/d3-interpolate": {
       "version": "3.0.1",
       "dev": true,
@@ -7439,14 +7260,6 @@
       "dependencies": {
         "internmap": "1 - 2"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-color": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -7490,89 +7303,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-time": "1"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-transition": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/d3-voronoi": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-zoom": {
-      "version": "1.8.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/d3/node_modules/d3-scale": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/d3/node_modules/d3-scale-chromatic": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
       }
     },
     "node_modules/dargs": {
@@ -7779,6 +7509,15 @@
     "node_modules/defined": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "dev": true,
+      "dependencies": {
+        "robust-predicates": "^3.0.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -9439,14 +9178,6 @@
       "dependencies": {
         "internmap": "1 - 2"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/force-graph/node_modules/d3-color": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -16844,6 +16575,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "dev": true
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "dev": true,
@@ -19910,17 +19647,17 @@
     },
     "packages/browserify": {
       "name": "lavamoat-browserify",
-      "version": "15.7.1",
+      "version": "15.7.3",
       "license": "MIT",
       "dependencies": {
         "@lavamoat/aa": "^3.1.0",
-        "@lavamoat/lavapack": "^5.2.1",
+        "@lavamoat/lavapack": "^5.2.3",
         "browser-resolve": "^2.0.0",
         "concat-stream": "^2.0.0",
         "convert-source-map": "^1.9.0",
         "duplexify": "^4.1.1",
         "json-stable-stringify": "^1.0.1",
-        "lavamoat-core": "^14.2.1",
+        "lavamoat-core": "^14.2.3",
         "pify": "^4.0.1",
         "readable-stream": "^3.6.0",
         "source-map": "^0.7.4",
@@ -19972,11 +19709,11 @@
     },
     "packages/core": {
       "name": "lavamoat-core",
-      "version": "14.2.1",
+      "version": "14.2.3",
       "license": "MIT",
       "dependencies": {
         "json-stable-stringify": "^1.0.2",
-        "lavamoat-tofu": "^6.0.2",
+        "lavamoat-tofu": "^6.0.3",
         "merge-deep": "^3.0.3"
       },
       "devDependencies": {
@@ -19989,14 +19726,14 @@
     },
     "packages/lavapack": {
       "name": "@lavamoat/lavapack",
-      "version": "5.2.1",
+      "version": "5.2.3",
       "license": "MIT",
       "dependencies": {
         "combine-source-map": "^0.8.0",
         "convert-source-map": "^2.0.0",
         "json-stable-stringify": "^1.0.2",
         "JSONStream": "^1.3.5",
-        "lavamoat-core": "^14.2.1",
+        "lavamoat-core": "^14.2.3",
         "readable-stream": "^3.6.0",
         "through2": "^4.0.2",
         "umd": "^3.0.3"
@@ -20031,7 +19768,7 @@
     },
     "packages/node": {
       "name": "lavamoat",
-      "version": "7.1.0",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -20040,8 +19777,8 @@
         "bindings": "^1.5.0",
         "htmlescape": "^1.1.1",
         "json-stable-stringify": "^1.0.2",
-        "lavamoat-core": "^14.2.1",
-        "lavamoat-tofu": "^6.0.2",
+        "lavamoat-core": "^14.2.3",
+        "lavamoat-tofu": "^6.0.3",
         "node-gyp-build": "^4.6.0",
         "resolve": "^1.22.3",
         "yargs": "^17.7.2"
@@ -20247,7 +19984,7 @@
     },
     "packages/tofu": {
       "name": "lavamoat-tofu",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.21.8",
@@ -20262,10 +19999,10 @@
     },
     "packages/viz": {
       "name": "lavamoat-viz",
-      "version": "6.0.9",
+      "version": "6.0.11",
       "license": "MIT",
       "dependencies": {
-        "lavamoat-core": "^14.2.1",
+        "lavamoat-core": "^14.2.3",
         "ncp": "^2.0.0",
         "open": "^7.0.3",
         "pify": "^4.0.1",
@@ -20285,7 +20022,7 @@
         "codemirror": "^5.54.0",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "^6.7.3",
-        "d3": "^5.12.0",
+        "d3": "^7.8.5",
         "esm": "^3.2.25",
         "gh-pages": "^2.2.0",
         "html-webpack-plugin": "^5.5.1",
@@ -20310,6 +20047,366 @@
         "node": ">=14.0.0 <19.0.0"
       }
     },
+    "packages/viz/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/viz/node_modules/d3": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/viz/node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "packages/viz/node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "packages/viz/node_modules/glob": {
       "version": "10.3.3",
       "dev": true,
@@ -20329,6 +20426,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/viz/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/viz/node_modules/minimatch": {

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -21,7 +21,7 @@
     "codemirror": "^5.54.0",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.7.3",
-    "d3": "^5.12.0",
+    "d3": "^7.8.5",
     "esm": "^3.2.25",
     "gh-pages": "^2.2.0",
     "html-webpack-plugin": "^5.5.1",


### PR DESCRIPTION
Supercedes #514

This is broken.
