### PR TITLE
fix: normalize pkg versions

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
-  "packages/aa": "3.1.2",
-  "packages/allow-scripts": "2.3.1",
-  "packages/browserify": "15.7.4",
-  "packages/core": "14.2.3",
-  "packages/lavapack": "5.2.4",
-  "packages/node": "7.1.2",
-  "packages/preinstall-always-fail": "1.0.0",
-  "packages/tofu": "6.0.3",
-  "packages/viz": "6.0.12"
+  "packages/aa": "3.1.4",
+  "packages/allow-scripts": "2.5.0",
+  "packages/browserify": "15.9.0",
+  "packages/core": "14.4.0",
+  "packages/lavapack": "5.4.0",
+  "packages/node": "7.3.0",
+  "packages/preinstall-always-fail": "1.0.2",
+  "packages/tofu": "6.2.0",
+  "packages/viz": "6.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19575,7 +19575,7 @@
     },
     "packages/aa": {
       "name": "@lavamoat/aa",
-      "version": "3.1.2",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "resolve": "^1.22.3"
@@ -19589,7 +19589,7 @@
     },
     "packages/allow-scripts": {
       "name": "@lavamoat/allow-scripts",
-      "version": "2.3.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@lavamoat/aa": "^3.1.1",
@@ -19642,11 +19642,11 @@
     },
     "packages/browserify": {
       "name": "lavamoat-browserify",
-      "version": "15.7.3",
+      "version": "16.0.0",
       "license": "MIT",
       "dependencies": {
         "@lavamoat/aa": "^3.1.0",
-        "@lavamoat/lavapack": "^5.2.3",
+        "@lavamoat/lavapack": "^5.2.4",
         "browser-resolve": "^2.0.0",
         "concat-stream": "^2.0.0",
         "convert-source-map": "^1.9.0",
@@ -19703,7 +19703,7 @@
     },
     "packages/core": {
       "name": "lavamoat-core",
-      "version": "14.2.3",
+      "version": "14.4.0",
       "license": "MIT",
       "dependencies": {
         "json-stable-stringify": "^1.0.2",
@@ -19720,7 +19720,7 @@
     },
     "packages/lavapack": {
       "name": "@lavamoat/lavapack",
-      "version": "5.2.3",
+      "version": "5.4.0",
       "license": "MIT",
       "dependencies": {
         "combine-source-map": "^0.8.0",
@@ -19762,7 +19762,7 @@
     },
     "packages/node": {
       "name": "lavamoat",
-      "version": "7.1.2",
+      "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -19838,9 +19838,62 @@
         "node": ">=14.0.0 <19.0.0"
       }
     },
+    "packages/perf/node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "packages/perf/node_modules/lavamoat-browserify": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/lavamoat-browserify/-/lavamoat-browserify-15.7.4.tgz",
+      "integrity": "sha512-fNBZrIO9yKbKJ0KAAT1ZIIpqPA//b5H34ZZlqh6IlkcfYmHdi9ArU053qzApERurZFAdFrwECYtGq2LcjgM1Fw==",
+      "dependencies": {
+        "@lavamoat/aa": "^3.1.0",
+        "@lavamoat/lavapack": "^5.2.4",
+        "browser-resolve": "^2.0.0",
+        "concat-stream": "^2.0.0",
+        "convert-source-map": "^1.9.0",
+        "duplexify": "^4.1.1",
+        "json-stable-stringify": "^1.0.1",
+        "lavamoat-core": "^14.2.3",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.6.0",
+        "source-map": "^0.7.4",
+        "through2": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0 <19.0.0"
+      }
+    },
+    "packages/perf/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "packages/perf/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
     "packages/preinstall-always-fail": {
       "name": "@lavamoat/preinstall-always-fail",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
@@ -19978,7 +20031,7 @@
     },
     "packages/tofu": {
       "name": "lavamoat-tofu",
-      "version": "6.0.3",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.21.8",
@@ -19993,7 +20046,7 @@
     },
     "packages/viz": {
       "name": "lavamoat-viz",
-      "version": "6.0.11",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "lavamoat-core": "^14.2.3",

--- a/packages/aa/package.json
+++ b/packages/aa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/aa",
-  "version": "3.1.2",
+  "version": "3.1.4",
   "main": "src/index.js",
   "bin": {
     "lavamoat-ls": "src/cli.js"

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/allow-scripts",
-  "version": "2.3.1",
+  "version": "2.5.0",
   "main": "src/index.js",
   "bin": {
     "allow-scripts": "src/cli.js"

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-browserify",
-  "version": "15.7.4",
+  "version": "15.9.0",
   "description": "browserify plugin for sandboxing dependencies with LavaMoat",
   "main": "src/index.js",
   "directories": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-core",
-  "version": "14.2.3",
+  "version": "14.4.0",
   "description": "LavaMoat kernel and utils",
   "main": "src/index.js",
   "directories": {

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/lavapack",
-  "version": "5.2.4",
+  "version": "5.4.0",
   "description": "LavaMoat packer",
   "publishConfig": {
     "access": "public"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
     "lavamoat": "src/cli.js",
     "lavamoat-run-command": "src/run-command.js"
   },
-  "version": "7.1.2",
+  "version": "7.3.0",
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/preinstall-always-fail",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-tofu",
-  "version": "6.0.3",
+  "version": "6.2.0",
   "main": "src/index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -2,7 +2,7 @@
   "name": "lavamoat-viz",
   "description": "This is a dashboard for exploring a dependency graph and LavaMoat policy file",
   "main": "index.js",
-  "version": "6.0.12",
+  "version": "6.2.0",
   "dependencies": {
     "lavamoat-core": "^14.2.3",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Due to the errant release, "newer" versions were published of all of these packages, but VCS did not reflect those new versions.  This updates the versions for each package to the "newest" version and changes the release-please manifest to point to those versions, so that next release will bump them.