### PR TITLE
fix(lavapack): specify what to publish despite gitignore

### DIFF
--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -30,6 +30,7 @@
     "rebuild": "npm run build",
     "build": "node ./src/build-runtime.js"
   },
+  "files": ["src/", "CHANGELOG.md"],
   "author": "kumavis",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Generating files prior to publishing works. But npm reads .gitignore and avoids packing them.

https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package
https://docs.npmjs.com/cli/v9/configuring-npm/package-json?v=true#files