### PR TITLE
chore: upgrade lerna to v7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-react": "^7.33.0",
         "husky": "^8.0.3",
-        "lerna": "^7.1.4",
+        "lerna": "^7.3.0",
         "lint-staged": "^13.2.3",
         "prettier": "^3.0.2"
       },
@@ -2492,9 +2492,10 @@
       "license": "MIT"
     },
     "node_modules/@lerna/child-process": {
-      "version": "7.1.4",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.3.0.tgz",
+      "integrity": "sha512-rA+fGUo2j/LEq6w1w8s6oVikLbJTWoIDVpYMc7bUCtwDOUuZKMQiRtjmpavY3fTm7ltu42f4AKflc2A70K4wvA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "execa": "^5.0.0",
@@ -2505,37 +2506,319 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "7.1.4",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-7.3.0.tgz",
+      "integrity": "sha512-fjgiKjg9VXwQ4ZKKsrXICEKRiC3yo6+FprR0mc55uz0s5e9xupoSGLobUTTBdE7ncNB3ibqml8dfaAn/+ESajQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lerna/child-process": "7.1.4",
+        "@lerna/child-process": "7.3.0",
+        "@npmcli/run-script": "6.0.2",
+        "@nx/devkit": ">=16.5.1 < 17",
+        "@octokit/plugin-enterprise-rest": "6.0.1",
+        "@octokit/rest": "19.0.11",
+        "byte-size": "8.1.1",
+        "chalk": "4.1.0",
+        "clone-deep": "4.0.1",
+        "cmd-shim": "6.0.1",
+        "columnify": "1.6.0",
+        "conventional-changelog-core": "5.0.1",
+        "conventional-recommended-bump": "7.0.1",
+        "cosmiconfig": "^8.2.0",
         "dedent": "0.7.0",
+        "execa": "5.0.0",
         "fs-extra": "^11.1.1",
+        "get-stream": "6.0.0",
+        "git-url-parse": "13.1.0",
+        "glob-parent": "5.1.2",
+        "globby": "11.1.0",
+        "graceful-fs": "4.2.11",
+        "has-unicode": "2.0.1",
+        "ini": "^1.3.8",
         "init-package-json": "5.0.0",
+        "inquirer": "^8.2.4",
+        "is-ci": "3.0.1",
+        "is-stream": "2.0.0",
+        "js-yaml": "4.1.0",
+        "libnpmpublish": "7.3.0",
+        "load-json-file": "6.2.0",
+        "lodash": "^4.17.21",
+        "make-dir": "4.0.0",
+        "minimatch": "3.0.5",
+        "multimatch": "5.0.0",
+        "node-fetch": "2.6.7",
         "npm-package-arg": "8.1.1",
+        "npm-packlist": "5.1.1",
+        "npm-registry-fetch": "^14.0.5",
+        "npmlog": "^6.0.2",
+        "nx": ">=16.5.1 < 17",
+        "p-map": "4.0.0",
+        "p-map-series": "2.1.0",
+        "p-queue": "6.6.2",
         "p-reduce": "^2.1.0",
         "pacote": "^15.2.0",
         "pify": "5.0.0",
+        "read-cmd-shim": "4.0.0",
+        "read-package-json": "6.0.4",
+        "resolve-from": "5.0.0",
+        "rimraf": "^4.4.1",
         "semver": "^7.3.4",
+        "signal-exit": "3.0.7",
         "slash": "^3.0.0",
+        "ssri": "^9.0.1",
+        "strong-log-transformer": "2.1.0",
+        "tar": "6.1.11",
+        "temp-dir": "1.0.0",
+        "upath": "2.0.1",
+        "uuid": "^9.0.0",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "5.0.0",
+        "write-file-atomic": "5.0.1",
+        "write-pkg": "4.0.0",
+        "yargs": "16.2.0",
         "yargs-parser": "20.2.4"
       },
       "engines": {
         "node": "^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@lerna/create/node_modules/pify": {
-      "version": "5.0.0",
+    "node_modules/@lerna/create/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/glob/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/glob/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lerna/create/node_modules/pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2580,8 +2863,9 @@
     },
     "node_modules/@npmcli/git": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
+      "integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@npmcli/promise-spawn": "^6.0.0",
         "lru-cache": "^7.4.4",
@@ -2598,8 +2882,9 @@
     },
     "node_modules/@npmcli/git/node_modules/which": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2612,8 +2897,9 @@
     },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.0.2.tgz",
+      "integrity": "sha512-xACzLPhnfD51GKvTOOuNX2/V4G4mz9/1I2MfDoye9kBM3RYe5g2YbscsaGoTlaWqkxeiapBWyseULVKpSVHtKQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "npm-bundled": "^3.0.0",
         "npm-normalize-package-bin": "^3.0.0"
@@ -2627,8 +2913,9 @@
     },
     "node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-3.0.0.tgz",
+      "integrity": "sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "npm-normalize-package-bin": "^3.0.0"
       },
@@ -2713,11 +3000,12 @@
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "16.6.0",
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.7.4.tgz",
+      "integrity": "sha512-hH03oF+yVmaf19UZfyLDSuVEh0KasU5YfYezuNsdRkXNdTU/WmpDrk4qoo0j6fVoMPrqbbPOn1YMRtulP2WyYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "nx": "16.6.0",
+        "nx": "16.7.4",
         "tslib": "^2.3.0"
       },
       "bin": {
@@ -2725,9 +3013,10 @@
       }
     },
     "node_modules/@nrwl/tao/node_modules/tslib": {
-      "version": "2.6.1",
-      "dev": true,
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/@nx/devkit": {
       "version": "16.6.0",
@@ -2775,13 +3064,110 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.6.0",
+    "node_modules/@nx/nx-darwin-arm64": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.7.4.tgz",
+      "integrity": "sha512-pRNjxn6KlcR6iGkU1j/1pzcogwXFv97pYiZaibpF7UV0vfdEUA3EETpDcs+hbNAcKMvVtn/TgN857/5LQ/lGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-darwin-x64": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.7.4.tgz",
+      "integrity": "sha512-GANXeabAAWRoF85WDla2ZPxtr8vnqvXjwyCIhRCda8hlKiVCpM98GemucN25z97G5H6MgyV9Dd9t9jrr2Fn0Og==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-freebsd-x64": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.7.4.tgz",
+      "integrity": "sha512-zmBBDYjPaHhIHx1YASUJJIy+oz7mCrj5f0f3kOzfMraQOjkQZ0xYgNNUzBqmnYu1855yiphu94MkAMYJnbk0jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.7.4.tgz",
+      "integrity": "sha512-d3Cmz/vdtoSasTUANoh4ZYLJESNA3+PCP/HnXNqmrr6AEHo+T8DcI+qsamO3rmYUSFxTMAeMyoihZMU8OKGZ1A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.7.4.tgz",
+      "integrity": "sha512-W1u4O78lTHCwvUP0vakeKWFXeSZ13nYzbd6FARICnImY2my8vz41rLm6aU9TYWaiOGEGL2xKpHKSgiNwbLjhFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.7.4.tgz",
+      "integrity": "sha512-Dc8IQFvhfH/Z3GmhBBNNxGd2Ehw6Y5SePEgJj1c2JyPdoVtc2OjGzkUaZkT4z5z77VKtju6Yi10T6Enps+y+kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.7.4.tgz",
+      "integrity": "sha512-4B58C/pXeuovSznBOeicsxNieBApbGMoi2du8jR6Is1gYFPv4l8fFHQHHGAa1l5XJC5JuGJqFywS4elInWprNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2791,15 +3177,48 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "16.6.0",
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.7.4.tgz",
+      "integrity": "sha512-spqqvEdGSSeV2ByJHkex5m8MRQfM6lQlnon25XgVBdPR47lKMWSikUsaWCiE7bVAFU9BFyWY2L4HfZ4+LiNY7A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.7.4.tgz",
+      "integrity": "sha512-etNnbuCcSqAYOeDcS6si6qw0WR/IS87ovTzLS17ETKpdHcHN5nM4l02CQyupKiD58ShxrXHxXmvgBfbXxoN5Ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.7.4.tgz",
+      "integrity": "sha512-y6pugK6ino1wvo2FbgtXG2cVbEm3LzJwOSBKBRBXSWhUgjP7T92uGfOt6KVQKpaqDvS9lA9TO/2DcygcLHXh7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -2969,9 +3388,10 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
+      "integrity": "sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^3.2.1",
         "node-gyp-build": "^4.3.0"
@@ -2986,8 +3406,9 @@
     },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "3.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3861,8 +4282,9 @@
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
     },
     "node_modules/@yarnpkg/nm": {
       "version": "3.1.0",
@@ -4262,8 +4684,9 @@
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4737,8 +5160,9 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/ava": {
       "version": "5.3.1",
@@ -5036,9 +5460,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6531,8 +6956,9 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7416,8 +7842,9 @@
     },
     "node_modules/dedent": {
       "version": "0.7.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "dev": true
     },
     "node_modules/deep-equal": {
       "version": "2.2.1",
@@ -7523,8 +7950,9 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7860,11 +8288,15 @@
       "license": "0BSD"
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer": {
@@ -9089,8 +9521,9 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
       }
@@ -9312,8 +9745,9 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -10489,8 +10923,9 @@
     },
     "node_modules/init-package-json": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-5.0.0.tgz",
+      "integrity": "sha512-kBhlSheBfYmq3e0L1ii+VKe3zBTLL5lDCDWR+f9dLmEGSB3MqLlMlsolubSsyI88Bg6EA+BIMlomAnQ1SwgQBw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "npm-package-arg": "^10.0.0",
         "promzard": "^1.0.0",
@@ -10506,8 +10941,9 @@
     },
     "node_modules/init-package-json/node_modules/hosted-git-info": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
@@ -10517,8 +10953,9 @@
     },
     "node_modules/init-package-json/node_modules/npm-package-arg": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
+      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "proc-log": "^3.0.0",
@@ -11308,8 +11745,9 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -11452,12 +11890,13 @@
       }
     },
     "node_modules/lerna": {
-      "version": "7.1.4",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-7.3.0.tgz",
+      "integrity": "sha512-Dt8TH+J+c9+3MhTYcm5OxnNzXb87WG7GPNj3kidjYJjJY7KxIMDNU37qBTYRWA1h3wAeNKBplXVQYUPkGcYgkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lerna/child-process": "7.1.4",
-        "@lerna/create": "7.1.4",
+        "@lerna/child-process": "7.3.0",
+        "@lerna/create": "7.3.0",
         "@npmcli/run-script": "6.0.2",
         "@nx/devkit": ">=16.5.1 < 17",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -11494,7 +11933,7 @@
         "libnpmpublish": "7.3.0",
         "load-json-file": "6.2.0",
         "lodash": "^4.17.21",
-        "make-dir": "3.1.0",
+        "make-dir": "4.0.0",
         "minimatch": "3.0.5",
         "multimatch": "5.0.0",
         "node-fetch": "2.6.7",
@@ -11671,6 +12110,21 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lerna/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lerna/node_modules/minimatch": {
@@ -13463,8 +13917,9 @@
     },
     "node_modules/node-machine-id": {
       "version": "1.1.12",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
+      "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.10",
@@ -13564,9 +14019,10 @@
       "license": "ISC"
     },
     "node_modules/npm-install-checks": {
-      "version": "6.1.1",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.2.0.tgz",
+      "integrity": "sha512-744wat5wAAHsxa4590mWO0tJ8PKxR8ORZsH9wGpQc3nWTzozMAgBN/XyqYw7mg3yqLM8dLwEnwSfKMmXAjF69g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -13583,8 +14039,9 @@
     },
     "node_modules/npm-package-arg": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.1.tgz",
+      "integrity": "sha512-CsP95FhWQDwNqiYS+Q0mZ7FAEDytDZAkNxQqea6IaAFJTAY9Lhhqyl0irU/6PMc7BGfUmnsbHcqxJD7XuVM/rg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^3.0.6",
         "semver": "^7.0.0",
@@ -13596,13 +14053,15 @@
     },
     "node_modules/npm-package-arg/node_modules/builtins": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "dev": true
     },
     "node_modules/npm-package-arg/node_modules/hosted-git-info": {
       "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13612,8 +14071,9 @@
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13623,8 +14083,9 @@
     },
     "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "builtins": "^1.0.3"
       }
@@ -13682,8 +14143,9 @@
     },
     "node_modules/npm-pick-manifest": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
+      "integrity": "sha512-1dKY+86/AIiq1tkKVD3l0WI+Gd3vkknVGAggsFeBkTvbhMQ1OND/LKkYv4JtXPKUJ8bOTCyLiqEg2P6QNdK+Gg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^6.0.0",
         "npm-normalize-package-bin": "^3.0.0",
@@ -13696,8 +14158,9 @@
     },
     "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
@@ -13707,8 +14170,9 @@
     },
     "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
+      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "proc-log": "^3.0.0",
@@ -13794,12 +14258,13 @@
       }
     },
     "node_modules/nx": {
-      "version": "16.6.0",
+      "version": "16.7.4",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-16.7.4.tgz",
+      "integrity": "sha512-L0Cbikk5kO+IBH0UQ2BOAut5ndeHXBlACKzjOPOCluY8WYh2sxWYt9/N/juFBN3XXRX7ionTr1PhWUzNE0Mzqw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@nrwl/tao": "16.6.0",
+        "@nrwl/tao": "16.7.4",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.0-rc.46",
@@ -13809,7 +14274,7 @@
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",
         "cliui": "^7.0.2",
-        "dotenv": "~10.0.0",
+        "dotenv": "~16.3.1",
         "enquirer": "~2.3.6",
         "fast-glob": "3.2.7",
         "figures": "3.2.0",
@@ -13839,16 +14304,16 @@
         "nx": "bin/nx.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "16.6.0",
-        "@nx/nx-darwin-x64": "16.6.0",
-        "@nx/nx-freebsd-x64": "16.6.0",
-        "@nx/nx-linux-arm-gnueabihf": "16.6.0",
-        "@nx/nx-linux-arm64-gnu": "16.6.0",
-        "@nx/nx-linux-arm64-musl": "16.6.0",
-        "@nx/nx-linux-x64-gnu": "16.6.0",
-        "@nx/nx-linux-x64-musl": "16.6.0",
-        "@nx/nx-win32-arm64-msvc": "16.6.0",
-        "@nx/nx-win32-x64-msvc": "16.6.0"
+        "@nx/nx-darwin-arm64": "16.7.4",
+        "@nx/nx-darwin-x64": "16.7.4",
+        "@nx/nx-freebsd-x64": "16.7.4",
+        "@nx/nx-linux-arm-gnueabihf": "16.7.4",
+        "@nx/nx-linux-arm64-gnu": "16.7.4",
+        "@nx/nx-linux-arm64-musl": "16.7.4",
+        "@nx/nx-linux-x64-gnu": "16.7.4",
+        "@nx/nx-linux-x64-musl": "16.7.4",
+        "@nx/nx-win32-arm64-msvc": "16.7.4",
+        "@nx/nx-win32-x64-msvc": "16.7.4"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.4.2",
@@ -14487,8 +14952,9 @@
     },
     "node_modules/pacote": {
       "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz",
+      "integrity": "sha512-rJVZeIwHTUta23sIZgEIM62WYwbmGbThdbnkt81ravBplQv+HjyroqnLRNH2+sLJHcGZmLRmhPwACqhfTcOmnA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^4.0.0",
         "@npmcli/installed-package-contents": "^2.0.1",
@@ -14517,20 +14983,31 @@
       }
     },
     "node_modules/pacote/node_modules/fs-minipass": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "minipass": "^5.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/pacote/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/pacote/node_modules/hosted-git-info": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
@@ -14540,8 +15017,9 @@
     },
     "node_modules/pacote/node_modules/ignore-walk": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
+      "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "minimatch": "^9.0.0"
       },
@@ -14551,8 +15029,9 @@
     },
     "node_modules/pacote/node_modules/minimatch": {
       "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -14565,16 +15044,18 @@
     },
     "node_modules/pacote/node_modules/minipass": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pacote/node_modules/npm-package-arg": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
+      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "proc-log": "^3.0.0",
@@ -14587,8 +15068,9 @@
     },
     "node_modules/pacote/node_modules/npm-packlist": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-7.0.4.tgz",
+      "integrity": "sha512-d6RGEuRrNS5/N84iglPivjaJPxhDbZmlbTwTDX2IbcRHG5bZCdtysYMhwiPvcF4GisXHGn7xsxv+GQ7T/02M5Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "ignore-walk": "^6.0.0"
       },
@@ -15439,8 +15921,9 @@
     },
     "node_modules/promzard": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-1.0.0.tgz",
+      "integrity": "sha512-KQVDEubSUHGSt5xLakaToDFrSoZhStB8dXLzk2xvwR67gJktrHFvpR63oZgHyK19WKbHFLXJqCPXdVR3aBP8Ig==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "read": "^2.0.0"
       },
@@ -15500,8 +15983,9 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -15880,8 +16364,9 @@
     },
     "node_modules/read": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read/-/read-2.1.0.tgz",
+      "integrity": "sha512-bvxi1QLJHcaywCAEsAk4DG3nVoqiY2Csps3qzWalhj5hFqRn1d/OixkFXtLO1PrgHUcAP0FNaSY/5GYNfENFFQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "mute-stream": "~1.0.0"
       },
@@ -15933,8 +16418,9 @@
     },
     "node_modules/read-package-json": {
       "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
+      "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^10.2.2",
         "json-parse-even-better-errors": "^3.0.0",
@@ -15957,9 +16443,10 @@
       }
     },
     "node_modules/read-package-json/node_modules/glob": {
-      "version": "10.3.3",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
@@ -15979,8 +16466,9 @@
     },
     "node_modules/read-package-json/node_modules/hosted-git-info": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
@@ -15990,8 +16478,9 @@
     },
     "node_modules/read-package-json/node_modules/minimatch": {
       "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -16003,17 +16492,19 @@
       }
     },
     "node_modules/read-package-json/node_modules/minipass": {
-      "version": "7.0.2",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/read-package-json/node_modules/normalize-package-data": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
+      "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "is-core-module": "^2.8.1",
@@ -16181,8 +16672,9 @@
     },
     "node_modules/read/node_modules/mute-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -18749,8 +19241,9 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -19604,7 +20097,7 @@
     },
     "packages/aa": {
       "name": "@lavamoat/aa",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "resolve": "^1.22.3"
@@ -19618,10 +20111,10 @@
     },
     "packages/allow-scripts": {
       "name": "@lavamoat/allow-scripts",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
-        "@lavamoat/aa": "^3.1.1",
+        "@lavamoat/aa": "^3.1.5",
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "4.0.1",
         "npm-normalize-package-bin": "^3.0.0",
@@ -19671,17 +20164,17 @@
     },
     "packages/browserify": {
       "name": "lavamoat-browserify",
-      "version": "16.0.0",
+      "version": "15.9.1",
       "license": "MIT",
       "dependencies": {
-        "@lavamoat/aa": "^3.1.0",
-        "@lavamoat/lavapack": "^5.2.4",
+        "@lavamoat/aa": "^3.1.5",
+        "@lavamoat/lavapack": "^5.4.1",
         "browser-resolve": "^2.0.0",
         "concat-stream": "^2.0.0",
         "convert-source-map": "^1.9.0",
         "duplexify": "^4.1.1",
         "json-stable-stringify": "^1.0.1",
-        "lavamoat-core": "^14.2.3",
+        "lavamoat-core": "^14.4.1",
         "pify": "^4.0.1",
         "readable-stream": "^3.6.0",
         "source-map": "^0.7.4",
@@ -19732,11 +20225,11 @@
     },
     "packages/core": {
       "name": "lavamoat-core",
-      "version": "14.4.0",
+      "version": "14.4.1",
       "license": "MIT",
       "dependencies": {
         "json-stable-stringify": "^1.0.2",
-        "lavamoat-tofu": "^6.0.3",
+        "lavamoat-tofu": "^6.2.1",
         "merge-deep": "^3.0.3"
       },
       "devDependencies": {
@@ -19749,14 +20242,14 @@
     },
     "packages/lavapack": {
       "name": "@lavamoat/lavapack",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "MIT",
       "dependencies": {
         "combine-source-map": "^0.8.0",
         "convert-source-map": "^2.0.0",
         "json-stable-stringify": "^1.0.2",
         "JSONStream": "^1.3.5",
-        "lavamoat-core": "^14.2.3",
+        "lavamoat-core": "^14.4.1",
         "readable-stream": "^3.6.0",
         "through2": "^4.0.2",
         "umd": "^3.0.3"
@@ -19791,17 +20284,17 @@
     },
     "packages/node": {
       "name": "lavamoat",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
         "@babel/highlight": "^7.18.6",
-        "@lavamoat/aa": "^3.1.0",
+        "@lavamoat/aa": "^3.1.5",
         "bindings": "^1.5.0",
         "htmlescape": "^1.1.1",
         "json-stable-stringify": "^1.0.2",
-        "lavamoat-core": "^14.2.3",
-        "lavamoat-tofu": "^6.0.3",
+        "lavamoat-core": "^14.4.1",
+        "lavamoat-tofu": "^6.2.1",
         "node-gyp-build": "^4.6.0",
         "resolve": "^1.22.3",
         "yargs": "^17.7.2"
@@ -19922,7 +20415,7 @@
     },
     "packages/preinstall-always-fail": {
       "name": "@lavamoat/preinstall-always-fail",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
@@ -20060,7 +20553,7 @@
     },
     "packages/tofu": {
       "name": "lavamoat-tofu",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.21.8",
@@ -20075,10 +20568,10 @@
     },
     "packages/viz": {
       "name": "lavamoat-viz",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
-        "lavamoat-core": "^14.2.3",
+        "lavamoat-core": "^14.4.1",
         "ncp": "^2.0.0",
         "open": "^7.0.3",
         "pify": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-react": "^7.33.0",
     "husky": "^8.0.3",
-    "lerna": "^7.1.4",
+    "lerna": "^7.3.0",
     "lint-staged": "^13.2.3",
     "prettier": "^3.0.2"
   },


### PR DESCRIPTION

lerna v7.1.4 uses a too-new version of nx which fails on Node.js v14.

we want to drop node v14 anyway, but this is breaking all of our builds now.
