### PR TITLE
chore(vscode): auto-run fix and format on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
-  "editor.tabSize": 2,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.formatDocument": true
+  },
+  "prettier.useEditorConfig": true
 }


### PR DESCRIPTION
This runs `prettier` and `eslint --fix` upon save of any fixable, formattable, and non-ignored file in the repo.

The same thing happens as a pre-commit hook.

Some people may not like this idea, because there are reasons to dislike it.  I prefer to have my code formatted as I write it, so this makes me more nimble.  However, it can be a problem if you edit a file then decide not to commit your changes -- you'll need to `git checkout -- <file>` to clean your workspace, because any save via the editor will reformat again.

Anyway: if this is not popular with all of the VSCode users here, I'll close it.