### PR TITLE
chore(node): fix tests when running on apple silicon

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run test:npm && npm run test:yarn1",
     "test:prepare": "node ./test/prepare.js",
-    "test:npm": "cross-env LAVAMOAT_PM=npm@latest npm run test:prepare && ava",
+    "test:npm": "npm run test:prepare && ava",
     "test:yarn1": "cross-env LAVAMOAT_PM=yarn@1 npm run test:prepare && ava",
     "lint:deps": "depcheck"
   },


### PR DESCRIPTION
- This also fixes a problem where `npm@10.x` would complain if run under Node.js v16.x.
- Fixes a problem where the system `corepack` was used instead of the one required by the workspace root.  I think we can drop `corepack` from our dev deps once we ditch Node.js v16.
- Removes some dead Node.js-v14-specific code.

`keccak` does not ship binaries for Apple Silicon.  We have to build them ourselves.  However, it seems that the root `ignore-scripts = true` means (maybe?) that `npm rebuild` does not necessarily invoke `node-gyp-build`--at least in `keccak`.  To make it build, we have to execute `node-gyp-build` directly.  If we _don't_ have this problem with other native modules, I'm going to guess this is a misconfiguration on the part of `keccak`--but if we _do_ have this problem, it might be an npm bug or misfeature.