### PR TITLE
chore(deps): fix lavamoat-tofu version in survey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17014,7 +17014,7 @@
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",
         "lavamoat": "^8.0.0",
-        "lavamoat-tofu": "^6.2.1",
+        "lavamoat-tofu": "^7.0.0",
         "node-fetch": "^2.6.9",
         "p-limit": "^3.1.0"
       },
@@ -17103,18 +17103,6 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
-      }
-    },
-    "packages/survey/node_modules/lavamoat-tofu": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/lavamoat-tofu/-/lavamoat-tofu-6.2.1.tgz",
-      "integrity": "sha512-FzEzwrM3mcH4HGiv802r1rpMIZJZaqQFUfm4yH3wrRJ9yh/etRKXJ6L4qK7jvCavZQZBWtDLorBpK8Qv3IOxdg==",
-      "dependencies": {
-        "@babel/parser": "^7.21.8",
-        "@babel/traverse": "^7.21.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "packages/survey/node_modules/p-limit": {

--- a/packages/survey/package.json
+++ b/packages/survey/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
     "lavamoat": "^8.0.0",
-    "lavamoat-tofu": "^6.2.1",
+    "lavamoat-tofu": "^7.0.0",
     "node-fetch": "^2.6.9",
     "p-limit": "^3.1.0"
   },


### PR DESCRIPTION
For some reason, "npm install lavamoat-tofu@latest -w packages/survey" does not upgrade to v7.0.0, which is why I missed it before.