### PR TITLE
chore: normalize repository & engines fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "lavamoat-monorepo",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "workspaces": [
         "packages/*"
       ],
@@ -18575,6 +18574,10 @@
         "ses": "^0.18.5",
         "typescript": "^5.0.2",
         "webpack": "^5.84.1"
+      },
+      "engines": {
+        "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+        "npm": ">=7.0.0"
       },
       "peerDependencies": {
         "webpack": "^5.80.2"

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -44,7 +44,11 @@
   },
   "author": "kumavis",
   "license": "MIT",
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/browserify"
+  },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,11 @@
   },
   "author": "kumavis",
   "license": "MIT",
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/core"
+  },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -38,7 +38,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LavaMoat/lavamoat.git"
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/lavapack"
   },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,7 +32,11 @@
     "test": "test"
   },
   "author": "kumavis",
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/node"
+  },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -2,7 +2,7 @@
   "name": "@lavamoat/preinstall-always-fail",
   "version": "2.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "package.json",
   "scripts": {
     "test": "exit 0",
     "preinstall": "echo \"Don't run npm lifecycle scripts by default! Create a .yarnrc or .npmrc and set enableScripts: false. Then, whitelist them with @lavamoat/allow-scripts\" && exit 1"

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -2,7 +2,6 @@
   "name": "@lavamoat/preinstall-always-fail",
   "version": "2.0.0",
   "description": "",
-  "main": "package.json",
   "scripts": {
     "test": "exit 0",
     "preinstall": "echo \"Don't run npm lifecycle scripts by default! Create a .yarnrc or .npmrc and set enableScripts: false. Then, whitelist them with @lavamoat/allow-scripts\" && exit 1"

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -19,7 +19,11 @@
     "test": "test"
   },
   "author": "kumavis",
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/tofu"
+  },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -63,7 +63,11 @@
     ]
   },
   "servedPath": "./",
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/viz"
+  },
   "author": "kumavis <aaron@kumavis.me>",
   "license": "MIT",
   "bugs": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -37,9 +37,17 @@
   "files": [
     "src"
   ],
-  "repository": "git+https://github.com/LavaMoat/lavamoat.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "directory": "packages/webpack"
+  },
   "bugs": {
     "url": "https://github.com/LavaMoat/lavamoat/issues"
   },
-  "homepage": "https://github.com/LavaMoat/lavamoat#readme"
+  "homepage": "https://github.com/LavaMoat/lavamoat#readme",
+  "engines": {
+    "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+    "npm": ">=7.0.0"
+  }
 }


### PR DESCRIPTION
This ensures that the `repository` props in each workspace's `package.json` is in the object format and references its directory within this monorepo.
