### PR TITLE
chore: reconfigure eslint

### DIFF
--- a/.config/README.md
+++ b/.config/README.md
@@ -68,3 +68,57 @@ In addition the root `tsconfig.json` serves as the "default" for files in the re
    > If your entry point is not in `src/`, you will need to add `"rootDir": ".."` to `src/tsconfig.json`'s `compilerOptions`, then add `../index.js` (or whatever it is) to the `includes` property.
 5. _If you have an `exports` field_, [read this](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) and do that.
 6. Add `types`, `!tsconfig.json` and `!*.tsbuildinfo` to the `files` prop of your `package.json`. If it doesn't exist, create it, and add whatever other files you need to put in the published package. Check your work with `npm pack --dry-run`.
+
+## ESLint Configuration
+
+This directory contains the following configuration(s):
+
+- [`eslintrc.typed-workspace.js`](./eslintrc.typed-workspace.js) - to be extended in the `.eslintrc.js` of a TypeScript-enabled workspace.
+
+  This config uses a type-aware parser (`@typescript-eslint/parser`) to provide more accurate linting, which works on both TypeScript sources and JavaScript sources (those which are type-checked, anyhow).
+
+### How to Configure a Workspace for ESLint
+
+All workspaces will inherit config from the [root ESLint config][].
+
+Please use a CJS file named `.eslintrc.js` (for consistency).
+
+#### TypeScript-Enabled Workspaces
+
+For TS-enabled workspaces, **an `.eslintrc.js` file is required**.
+
+Scaffold your `.eslintrc.js` like so:
+
+```js
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  extends: '../../.config/eslintrc.typed-workspace',
+}
+```
+
+#### Everything Else
+
+For other workspaces, **`.eslintrc.js` is optional**. It is only necessary if the workspace needs no changes from the [root ESLint config][].
+
+It's recommended to use this as a starting point, as it will give you in-editor feedback if your config is invalid:
+
+```js
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  // go to town here
+}
+```
+
+### Resources
+
+- [ESLint Configuration Docs](https://eslint.org/docs/user-guide/configuring)
+
+[root ESLint config]: ../.eslintrc.js

--- a/.config/README.md
+++ b/.config/README.md
@@ -1,16 +1,16 @@
 # Some Config Files Are Here
 
-In here, config files some.
+> All config files in this directory should be documented in this `README`.
 
 ## TypeScript Configuration
 
 We have three (3) TypeScript configuration files here:
 
-- `tsconfig.workspace.json` - "Base" config for workspaces in this repo.
-- `tsconfig.src.json` - Config for files within a workspace's `src/` directory (sources).
-- `tsconfig.test.json` Config for files within a workspace's `test/` directory (tests).
+- [`tsconfig.workspace.json`][] - "Base" config for workspaces in this repo.
+- [`tsconfig.src.json`][] - Config for files within a workspace's `src/` directory (sources).
+- [`tsconfig.test.json`][] Config for files within a workspace's `test/` directory (tests).
 
-In addition, we have a `tsconfig.json` in the workspace (project) root, configured for incremental builds. This file maintains references to `tsconfig.json` files in each workspace which needs types to be checked and/or built.
+In addition, [the `tsconfig.json` in workspace root][root `tsconfig.json`] is configured for incremental builds. This file maintains references to `tsconfig.json` files in each workspace which needs types to be checked and/or built.
 
 In addition the root `tsconfig.json` serves as the "default" for files in the repo which do not otherwise have an ancestor `tsconfig.json` file.
 
@@ -48,11 +48,9 @@ In addition the root `tsconfig.json` serves as the "default" for files in the re
 
    This file controls how and where `tsc` emits declarations; our convention is to dump them all in `types/`. We also want to publish these types along with our packages (see step 6).
 
-   `tsconfig.src.json` contains `checkJs: true`; `tsc` will expect _all_ `.js` files to be well-typed. If that's not applicable to the package you're setting up, override the value to `false` and add `// @ts-check` to the top of each file needing typechecking. 
+   `tsconfig.src.json` contains `checkJs: true`; `tsc` will expect _all_ `.js` files to be well-typed. If that's not applicable to the package you're setting up, override the value to `false` and add `// @ts-check` to the top of each file needing typechecking.
 
-   If you are a glutton for punishment, add `strict: true` to this config file. It's not the default for this repository tho.
-
-3. If you are typechecking your tests, create a `test/tsconfig.json` file in the workspace and set its contents to:
+3. _If you are typechecking your tests_, create a `test/tsconfig.json` file in the workspace and set its contents to:
 
    ```json
    {
@@ -62,26 +60,168 @@ In addition the root `tsconfig.json` serves as the "default" for files in the re
    }
    ```
 
-   You may need to omit e.g., test fixtures; you can use the `exclude` prop for this. `tsc` will not build declarations from files in `test`.
+   You may need to omit e.g., test fixtures; you can use the `exclude` prop for this.
 
 4. Add a `types` prop in your workspace's `package.json` pointing to the declaration file that corresponds to your entry point. Generally this is `types/index.d.ts`.
    > If your entry point is not in `src/`, you will need to add `"rootDir": ".."` to `src/tsconfig.json`'s `compilerOptions`, then add `../index.js` (or whatever it is) to the `includes` property.
 5. _If you have an `exports` field_, [read this](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) and do that.
 6. Add `types`, `!tsconfig.json` and `!*.tsbuildinfo` to the `files` prop of your `package.json`. If it doesn't exist, create it, and add whatever other files you need to put in the published package. Check your work with `npm pack --dry-run`.
+7. Add your workspace to the `references` array in the [root `tsconfig.json`][] file, like so:
+
+   ```json
+   {
+     "references": [
+       {
+         "path": "./packages/some-other-workspace/tsconfig.json"
+       },
+       {
+         "path": "./packages/<WORKSPACE-NAME>/tsconfig.json"
+       }
+     ]
+   }
+   ```
+
+> [!TIP] Use Strict
+>
+> Use `{"strict": true}` in the `compilerOptions` of your `src/tsconfig.json` for maximum safety against `null` and `undefined` values.
+>
+> This is less important for tests.
+
+### TypeScript-Related Miscellany
+
+This section contains sundry hints & tips picked up from working in this monorepo with TypeScript.
+
+#### Importing `package.json` from `src/`
+
+If you want import the workspace's `package.json` from any code in `src/`, TS will complain. The solution this will cause TS to write types to `types/src/*.d.ts` instead of `types/*.d.ts`. Try the following:
+
+1. Add [`"resolveJsonModule": true`](https://www.typescriptlang.org/tsconfig#resolveJsonModule) to the `compilerOptions` of your `src/tsconfig.json`.
+2. Add [`"rootDir": ".."`](https://www.typescriptlang.org/tsconfig#rootDir) to the `compilerOptions` of your `src/tsconfig.json`.
+3. Modify the `types` reference in your workspace's `package.json` to point to `types/src/index.d.ts` instead of `types/index.d.ts`.
+
+#### Caught Exceptions in Strict Mode
+
+In strict mode, any caught exception will be of type `unknown`, because it's nearly impossible to infer what it could be.
+
+_Any code which interacts with a value of type `unknown` cannot make any assumptions about its type whatsoever,_ so you must use a [_type assertion_](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) to get it to the type you want.
+
+> [!TIP] Type Assertions in JS
+>
+> A type assertion in JS looks like:
+>
+> ```js
+> const newValue = /** @type {SomeType} */ (value)
+> ```
+>
+> **The parentheses are required.** You cannot redefine the type of `value` this way; you can only assign it to a new variable or use it in an expression.
+
+```js
+try {
+  doSomethingThatThrows()
+} catch (e) {
+  // this will be a TS error because `e` is `unknown`
+  if (e.code === 'ENOENT') {
+    // ...
+  }
+  // this could be used for many exceptions thrown from Node.js APIs
+  // but only use it if you're sure!
+  if (/** @type {NodeJS.ErrnoException} */ (e).code === 'ENOENT') {
+    // this will be a TS error because the type assertion is not "permanent";
+    // i.e. `e`` is still `unknown`
+    throw new Error(`File not found: ${e.code}`)
+  }
+  // if you're not-so-sure about it, do something like this.
+  if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') {
+    // this is NOT a TS error because TS has now inferred the type
+    throw new Error(`File not found: ${e.code}`)
+  }
+  // this is also fine (when not mixing global contexts), but `e` will
+  // be a basic MDN-style Error object.
+  if (e instanceof Error) {
+    // ...
+  }
+}
+```
+
+Read on for a better way.
+
+#### Type Guards
+
+A better way is to define a custom _type guard_ ([playground example](https://www.typescriptlang.org/play#example/type-guards)):
+
+```js
+/**
+ * Type guard for {@link NodeJS.ErrnoException}
+ *
+ * @param {unknown} e
+ * @returns {e is NodeJS.ErrnoException}
+ */
+function isErrnoException(e) {
+  return Boolean(
+    e && typeof e === 'object' && 'code' in e && typeof e.code === 'string'
+  )
+}
+
+// usage:
+
+try {
+  doSomethingThatThrows()
+} catch (e) {
+  if (isErrnoException(e) && e.code === 'ENOENT') {
+    // ...
+  }
+}
+```
+
+> [!NOTE] Type Guards Return Booleans
+>
+> Type guards return the type `<param> is T`, but the _value_ must always be a `boolean`.
+
+#### Assertion Functions
+
+If you're more of the assertive type, you can create an [_assertion function_](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) instead:
+
+```js
+/**
+ * Assertion function for {@link NodeJS.ErrnoException}
+ *
+ * @param {unknown} e
+ * @returns {asserts e is NodeJS.ErrnoException}
+ */
+function assertErrnoException(e) {
+  if (e && typeof e === 'object' && 'code' in e && typeof e.code === 'string') {
+    return
+  }
+  // this does not error even if `e` is unknown, because anything can be coerced
+  // to a string. ESLint might not like it, though!
+  throw new Error(`Assertion failed: isErrnoException: ${e}`)
+}
+
+// usage:
+
+try {
+  doSomethingThatThrows()
+} catch (e) {
+  assertErrNoException(e)
+  // do something with e.code
+}
+```
 
 ## ESLint Configuration
 
 This directory contains the following configuration(s):
 
-- [`eslintrc.typed-workspace.js`](./eslintrc.typed-workspace.js) - to be extended in the `.eslintrc.js` of a TypeScript-enabled workspace.
+- [`eslintrc.typed-workspace.js`][] - to be extended in the `.eslintrc.js` of a TypeScript-enabled workspace.
 
-  This config uses a type-aware parser (`@typescript-eslint/parser`) to provide more accurate linting, which works on both TypeScript sources and JavaScript sources (those which are type-checked, anyhow).
+  This config uses a type-aware parser ([@typescript-eslint/parser](https://npm.im/@typescript-eslint/parser)) to provide more accurate linting, which works on both TypeScript sources and JavaScript sources (those which are type-checked, anyhow).
 
 ### How to Configure a Workspace for ESLint
 
-All workspaces will inherit config from the [root ESLint config][].
+If you're adding a new workspace, this is how to configure it for proper linting.
 
-Please use a CJS file named `.eslintrc.js` (for consistency).
+> [!IMPORTANT] ESLint Config Inheritance
+>
+> **All** workspaces inherit config from the [root ESLint config][].
 
 #### TypeScript-Enabled Workspaces
 
@@ -117,8 +257,16 @@ module.exports = {
 }
 ```
 
+> [!NOTE]
+> Any configuration within the above object applies to all files within this workspace; this means it _should not_ be an object containing a single `overrides` property.
+
 ### Resources
 
 - [ESLint Configuration Docs](https://eslint.org/docs/user-guide/configuring)
 
 [root ESLint config]: ../.eslintrc.js
+[`tsconfig.workspace.json`]: ./tsconfig.workspace.json
+[`tsconfig.src.json`]: ./tsconfig.src.json
+[`tsconfig.test.json`]: ./tsconfig.test.json
+[root `tsconfig.json`]: ../tsconfig.json
+[`eslintrc.typed-workspace.js`]: ./eslintrc.typed-workspace.js

--- a/.config/eslintrc.typed-workspace.js
+++ b/.config/eslintrc.typed-workspace.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+/**
+ * Contains configuration for workspaces which contain well-typed JavaScript
+ * sources.
+ *
+ * Workspaces which are _fully_ typed (have `checkJs: true` enabled) with
+ * _strict mode enabled_ should extend
+ * `plugin:@typescript-eslint/recommended-type-checked` instead (via override).
+ *
+ * This configuration is dependent upon the convention we use for
+ * `tsconfig.json`. Moving a `tsconfig.json` or otherwise monkeying with the
+ * `parserOptions.project` settings here will **break stuff** because of how
+ * `@typescript-eslint/parser` reads `tsconfig.json` files. Caution is advised!
+ *
+ * @see {@link https://typescript-eslint.io/linting/typed-linting/monorepos}
+ * @packageDocumentation
+ */
+
+const path = require('node:path')
+
+/**
+ * @satisfies {import('eslint').Linter.Config}
+ */
+module.exports = {
+  overrides: [
+    {
+      files: './{src,test}/**/*.{js,ts}',
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        // this needs to point to the dir containing the root `tsconfig.json`.
+        // unsure if this will be resolved relative to _this_ file or the extending
+        // config, so let's just use an absolute path!
+        tsconfigRootDir: path.join(__dirname, '..'),
+        project: true,
+      },
+      overrides: [
+        {
+          files: `./{src,test}/**/*.ts`,
+          extends: ['plugin:@typescript-eslint/recommended-type-checked'],
+        },
+        {
+          files: `./{src,test}/**/*.js`,
+          extends: ['plugin:@typescript-eslint/recommended'],
+          rules: {
+            // default to CommonJS; override if using ESM
+            '@typescript-eslint/no-var-requires': 'off',
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/packages/aa/.depcheckrc.yml
+++ b/packages/aa/.depcheckrc.yml
@@ -1,5 +1,6 @@
 ignores:
   # monorepo deps
   - 'ava'
+  - '@typescript-eslint/parser'
   # types
-  - "@types/resolve"
+  - '@types/resolve'

--- a/packages/aa/.eslintrc.js
+++ b/packages/aa/.eslintrc.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  extends: '../../.config/eslintrc.typed-workspace',
+}

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -110,12 +110,13 @@ test('project 1 - resolution failure', async (t) => {
   const rootDir = path.join(__dirname, 'projects', '1')
   /** @type {import('../src/index.js').Resolver} */
   const resolver = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sync: (moduleId, { basedir }) => {
       throw new Error('grumble')
     },
   }
   await t.throwsAsync(async () => {
-    const canonicalNameMap = await loadCanonicalNameMap({
+    await loadCanonicalNameMap({
       rootDir,
       resolve: resolver,
     })
@@ -131,6 +132,7 @@ test('project 1 - resolution missing silently', async (t) => {
   ]
 
   const resolver = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sync: (moduleId, { basedir }) => {
       throw errors.pop()
     },

--- a/packages/allow-scripts/.depcheckrc.yml
+++ b/packages/allow-scripts/.depcheckrc.yml
@@ -2,6 +2,7 @@ ignores:
   # monorepo deps
   - 'ava'
   - '@types/npmcli__promise-spawn'
+  - '@typescript-eslint/parser'
 
   # only types (from @types/npmcli__promise-spawn) are referenced
   - '@npmcli/promise-spawn'

--- a/packages/allow-scripts/.eslintrc.js
+++ b/packages/allow-scripts/.eslintrc.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  extends: '../../.config/eslintrc.typed-workspace',
+}

--- a/packages/browserify/.eslintrc.js
+++ b/packages/browserify/.eslintrc.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  overrides: [
+    {
+      files: ['./test/**/*.js'],
+      rules: {
+        'n/no-missing-require': 'off',
+      },
+      env: {
+        browser: true,
+      },
+    },
+  ],
+}

--- a/packages/browserify/test/globalRef.spec.js
+++ b/packages/browserify/test/globalRef.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 const test = require('ava')
 const { runScenario } = require('./util')
 const {

--- a/packages/browserify/test/globalWrites.spec.js
+++ b/packages/browserify/test/globalWrites.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 const test = require('ava')
 const {
   createScenarioFromScaffold,

--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -33,17 +33,17 @@ function overrideDepsWithLocalPackages(projectDir, log) {
 
   // link all of the workspaces to the temp dir project. no need to unlink
   // first; this will overwrite any already-present links
-  const res = spawnSync(
+  const res2 = spawnSync(
     'npm',
     ['install', '--ignore-scripts', ...Object.values(localPkgPaths)],
     { cwd: projectDir, encoding: 'utf8' }
   )
-  if (res.status !== 0) {
-    const err = res.stderr
+  if (res2.status !== 0) {
+    const err = res2.stderr
     log({
       err,
-      out: res.stdout,
-      status: res.status,
+      out: res2.stdout,
+      status: res2.status,
     })
     throw new Error(err)
   }

--- a/packages/core/.depcheckrc.yml
+++ b/packages/core/.depcheckrc.yml
@@ -3,6 +3,7 @@ ignores:
   - 'ses'
   # monorepo deps
   - 'ava'
+  - '@typescript-eslint/parser'
   # tests - fake packages
   - 'abc'
   - 'xyz'

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  extends: '../../.config/eslintrc.typed-workspace',
+  overrides: [
+    {
+      files: ['./{src,test}/**/*.{js,ts}'],
+      globals: {
+        Compartment: 'readonly',
+        templateRequire: 'readonly',
+        lockdown: 'readonly',
+      },
+    },
+    {
+      files: ['./src/*Template.js'],
+      globals: {
+        __lavamoatDebugOptions__: 'readonly',
+        __lavamoatSecurityOptions__: 'readonly',
+        self: 'readonly',
+        __createKernelCore__: 'readonly',
+      },
+    },
+    {
+      files: ['./lib/*.js'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+    {
+      files: ['test/**/*.js'],
+      rules: {
+        'n/no-missing-require': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['/test/scenarios/**/*', '/lib/*.umd.js'],
+}

--- a/packages/core/test/globals.spec.js
+++ b/packages/core/test/globals.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef, @typescript-eslint/no-unused-vars */
+
 const test = require('ava')
 const { createScenarioFromScaffold, runScenario } = require('./util')
 

--- a/packages/lavapack/.eslintrc.js
+++ b/packages/lavapack/.eslintrc.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  overrides: [
+    {
+      files: ['./src/*-template.js'],
+      globals: {
+        templateRequire: 'readonly',
+        self: 'readonly',
+        __reportStatsHook__: 'readonly',
+        __createKernel__: 'readonly',
+      },
+    },
+    {
+      files: ['test/**/*.js'],
+      rules: {
+        'n/no-missing-require': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['/bundle.js', '/src/runtime-cjs.js', '/src/runtime.js'],
+}

--- a/packages/lavapack/test/sourcemaps.spec.js
+++ b/packages/lavapack/test/sourcemaps.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable ava/no-skip-test */
+/* eslint-disable ava/no-skip-test, no-undef, n/no-missing-require */
 // to be migrated into lavapack from lavamoat-browserify
 
 const test = require('ava')

--- a/packages/node/.eslintrc.js
+++ b/packages/node/.eslintrc.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  overrides: [
+    {
+      files: ['./test/**/*.js'],
+      rules: {
+        'n/no-missing-require': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['/test/projects/**/*'],
+}

--- a/packages/perf/.eslintrc.js
+++ b/packages/perf/.eslintrc.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  globals: {
+    lockdown: 'readonly',
+    Compartment: 'readonly',
+  },
+  ignorePatterns: ['/trials/**/*'],
+}

--- a/packages/survey/.eslintrc.js
+++ b/packages/survey/.eslintrc.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  ignorePatterns: ['/mitm/**/*'],
+}

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 const test = require('ava')
 const deepEqual = require('deep-equal')
 const { inspectGlobals } = require('../src/index')

--- a/packages/viz/.eslintrc.js
+++ b/packages/viz/.eslintrc.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  extends: ['plugin:react/recommended'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+  plugins: ['react', 'import'],
+  rules: {
+    'no-negated-condition': 'off',
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
+    'import/no-unassigned-import': 'off',
+    'import/unambiguous': 'off',
+    'react/prop-types': 'off',
+    'n/no-missing-import': 'off',
+  },
+  overrides: [
+    {
+      files: ['./src/App.test.js'],
+      env: {
+        mocha: true,
+      },
+    },
+  ],
+  ignorePatterns: ['/dist', '/src/example-policies'],
+}

--- a/packages/webpack/test/e2e-hack.spec.js
+++ b/packages/webpack/test/e2e-hack.spec.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+// eslint-disable-next-line ava/no-import-test-files
 const { scaffold, runScriptWithSES, runScript } = require('./scaffold.js')
 const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
 
@@ -29,15 +30,12 @@ test('webpack/hack/loader - bundle runs without reaching the FLAG', (t) => {
     () => {
       runScriptWithSES(t.context.build.snapshot['/dist/hack1.js'], { FLAG })
     },
-    { message: /FLAG is not a function/ },
+    { message: /FLAG is not a function/ }
   )
 })
 
 test('webpack/hack/loader - doublecheck in reported excluded files', (t) => {
-  t.notRegex(
-    t.context.build.stdout,
-    /excluded modules.*hack.js/s,
-  ) // `s` for multiline matching
+  t.notRegex(t.context.build.stdout, /excluded modules.*hack.js/s) // `s` for multiline matching
 })
 
 test('webpack/hack/fetch - disallows fetch', (t) => {
@@ -45,7 +43,7 @@ test('webpack/hack/fetch - disallows fetch', (t) => {
     () => {
       runScriptWithSES(t.context.build.snapshot['/dist/hack2.js'], {})
     },
-    { message: /fetch is not a function/ },
+    { message: /fetch is not a function/ }
   )
 })
 
@@ -54,6 +52,6 @@ test('webpack/hack/fetch - cannot pollute prototypes', (t) => {
     () => {
       runScriptWithSES(t.context.build.snapshot['/dist/hack3.js'], {})
     },
-    { message: /Cannot add property polluted, object is not extensible/ },
+    { message: /Cannot add property polluted, object is not extensible/ }
   )
 })

--- a/packages/webpack/test/e2e-main.spec.js
+++ b/packages/webpack/test/e2e-main.spec.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+// eslint-disable-next-line ava/no-import-test-files
 const { scaffold, runScriptWithSES } = require('./scaffold.js')
 const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
 
@@ -21,7 +22,7 @@ test('webpack/main - default warning gets printed', (t) => {
 test('webpack/main - warns about excluded modules', (t) => {
   t.regex(
     t.context.build.stdout,
-    /WARNING.*excluded modules.*src\/style\.css.*side-effects-package\/styles\.css/s,
+    /WARNING.*excluded modules.*src\/style\.css.*side-effects-package\/styles\.css/s
   ) // `s` for multiline matching
 })
 
@@ -48,7 +49,7 @@ test('webpack/main - modules were included', (t) => {
 test('webpack/main - treeshaking works', (t) => {
   t.assert(
     !t.context.bundle.includes('13371337'),
-    'Expected treeshakeable reference to be excluded',
+    'Expected treeshakeable reference to be excluded'
   )
 })
 
@@ -56,16 +57,16 @@ test('webpack/main - css extraction works', (t) => {
   const files = Object.keys(t.context.build.snapshot)
   t.assert(
     files.includes('/dist/styles/app.css'),
-    `Expected /dist/styles/app.css to be among files: ${files.join()}`,
+    `Expected /dist/styles/app.css to be among files: ${files.join()}`
   )
   const styles = t.context.build.snapshot['/dist/styles/app.css']
   t.true(
     styles.includes('.app-main'),
-    `Expected styles to include '.app-main', but got: ${styles}`,
+    `Expected styles to include '.app-main', but got: ${styles}`
   )
   t.true(
     styles.includes('.side-effects-package'),
-    `Expected styles to include '.side-effects-package', but got: ${styles}`,
+    `Expected styles to include '.side-effects-package', but got: ${styles}`
   )
 })
 

--- a/packages/webpack/test/e2e-ses-dependency.spec.js
+++ b/packages/webpack/test/e2e-ses-dependency.spec.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+// eslint-disable-next-line ava/no-import-test-files
 const { scaffold, runScriptWithSES, runScript } = require('./scaffold.js')
 const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
 
@@ -29,6 +30,6 @@ test('webpack/ses-dependency - test the test', (t) => {
     () => {
       runScriptWithSES(t.context.build.snapshot['/dist/throws.js'], {})
     },
-    { message: /This error should not have been thrown/ },
+    { message: /This error should not have been thrown/ }
   )
 })

--- a/packages/yarn-plugin-allow-scripts/.eslintrc.js
+++ b/packages/yarn-plugin-allow-scripts/.eslintrc.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  ignorePatterns: ['/bundles'],
+}


### PR DESCRIPTION
The aim here is:

- to avoid excess churn in the root `.eslintrc.js` file
- to provide some reusable config for workspaces
- allow execution of ESLint from the workspace root _and_ any workspace directory while retaining proper ignore patterns
- validate the shape of configs via TS
- maximize compat with `@typescript-eslint/parser`, which should be used whenever we have a reasonable amount of typed JS
- re-enable some rules; create exceptions at the file level
- enable warnings for path concatenation

This may make `.eslintignore` redundant again.

## Reviewers:

- This PR contains a change which applies lint fixes to the codebase.  It is here because CI would fail otherwise.
- To review this, you'll want to look at changes in **`.config/`**, any **`.eslintrc.js`** and any **`.depcheckrc`** files. You can ignore anything else unless you want to look at what actually changes.
