### PR TITLE
chore(deps): upgrade type-fest across entire repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "lint-staged": "^13.2.3",
         "memfs": "^4.3.0",
         "prettier": "^3.0.2",
-        "type-fest": "^2.19.0",
+        "type-fest": "^4.7.1",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -15682,11 +15682,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16854,17 +16854,6 @@
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
-      }
-    },
-    "packages/core/node_modules/type-fest": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
-      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/lavapack": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lavamoat-monorepo",
   "private": true,
   "overrides": {
-    "type-fest": "^2.19.0",
+    "type-fest": "$type-fest",
     "util": "^0.12.5"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "lint-staged": "^13.2.3",
     "memfs": "^4.3.0",
     "prettier": "^3.0.2",
-    "type-fest": "^2.19.0",
+    "type-fest": "^4.7.1",
     "typescript": "^5.2.2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
`lavamoat-core`'s `type-fest` is out-of-sync with the rest; now they are all the same.
