### PR TITLE
Fix a quirk in webpack plugin's cjs support

### DIFF
--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -20,7 +20,7 @@ if (LOCKDOWN_ON) {
   lockdown(LAVAMOAT.options.lockdown)
 } else {
   warn(
-    'LavaMoat: runtime execution started without SES present, switching to no-op.',
+    'LavaMoat: runtime execution started without SES present, switching to no-op.'
   )
 }
 
@@ -41,8 +41,8 @@ const stricterScopeTerminator = freeze(
     freeze({
       // TODO: emulate a reference error in a getter.
       has: freeze(() => true),
-    }),
-  ),
+    })
+  )
 )
 
 // Policy implementation
@@ -62,7 +62,7 @@ const enforcePolicy = (requestedResourceId, referrerResourceId) => {
     return
   }
   throw Error(
-    `Policy does not allow importing ${requestedResourceId} from ${referrerResourceId}`,
+    `Policy does not allow importing ${requestedResourceId} from ${referrerResourceId}`
   )
 }
 
@@ -82,12 +82,12 @@ const installGlobalsForPolicy = (resourceId, packageCompartmentGlobal) => {
       rootCompartmentGlobalThis,
       LAVAMOAT.policy.resources[resourceId] || {},
       globalThis,
-      packageCompartmentGlobal,
+      packageCompartmentGlobal
     )
 
     defineProperties(
       packageCompartmentGlobal,
-      getOwnPropertyDescriptors(endowments),
+      getOwnPropertyDescriptors(endowments)
     )
   }
 }
@@ -95,7 +95,7 @@ const installGlobalsForPolicy = (resourceId, packageCompartmentGlobal) => {
 const compartmentMap = new Map()
 const findResourceId = (moduleId) => {
   const found = LAVAMOAT.idmap.find(([, moduleIds]) =>
-    moduleIds.includes(moduleId),
+    moduleIds.includes(moduleId)
   )
   if (found) {
     return found[0]
@@ -147,11 +147,13 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
       {
         has: (target, prop) => {
           warn(
-            `A module attempted to read ${String(prop)} directly from webpack's module cache`,
+            `A module attempted to read ${String(
+              prop
+            )} directly from webpack's module cache`
           )
           return false
         },
-      },
+      }
     )
 
     // override nmd to limit what it can mutate
@@ -170,6 +172,14 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
   defineProperty(runtimeHandler, 'module', {
     get: () => module,
     set: () => {},
+  })
+  // Make it possible to overwrite `exports` locally despite runtimeHandler being frozen
+  let exportsReference = runtimeHandler.exports
+  defineProperty(runtimeHandler, 'exports', {
+    get: () => exportsReference,
+    set: (value) => {
+      exportsReference = value
+    },
   })
   freeze(runtimeHandler)
 

--- a/packages/webpack/test/fixtures/main/main.js
+++ b/packages/webpack/test/fixtures/main/main.js
@@ -1,4 +1,5 @@
 import { hello as helloCommonJS } from 'commonjs-package'
+import { re } from 'commonjs-quirks'
 import { hello as helloES6 } from 'es6-module-package'
 import 'side-effects-package/styles.css'
 import { hello as helloTypeScript } from 'typescript-package'
@@ -12,11 +13,12 @@ import './src/style.css'
 function run() {
   console.log(
     helloCommonJS(),
+    JSON.stringify(re),
     helloES6(),
     helloTypeScript(),
     helloUMD(),
     thing(),
-    what,
+    what
   )
 }
 

--- a/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/index.js
@@ -1,0 +1,2 @@
+// this is how semver package exports itself, minified
+var i = (exports = module.exports = {}).re = []

--- a/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/package.json
+++ b/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "commonjs-quirks",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/webpack/test/fixtures/main/package.json
+++ b/packages/webpack/test/fixtures/main/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "commonjs-package": "1.0.0",
+    "commonjs-quirks": "1.0.0",
     "es6-module-package": "1.0.0",
     "side-effects-package": "1.0.0",
     "typescript-package": "1.0.0",


### PR DESCRIPTION
The test causes the following error:
```
'Cannot assign to read only property \'exports\' of object \'[object Object]\'',
```

The fix: runtimeHandler was frozen, `exports` was not a local variable like in regular module closures, so it had to be made writable. Having a getter there is a bit wasteful, but alternatives would mean a larger bundle or riskier implementation