### PR TITLE
chore(core): disabled n/no-extraneous-import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,6 @@ module.exports = {
     'n/prefer-promises/fs': 'error',
 
     // these rules seem broken in a monorepo
-    'n/no-extraneous-require': 'off',
     'n/no-unpublished-require': 'off',
 
     // we should probably actually fix these three and turn these back on
@@ -136,6 +135,10 @@ module.exports = {
         'no-undef': 'off',
         'n/no-path-concat': 'off', // this should be removed and the issues fixed
         'n/no-missing-require': 'off',
+
+        // these two are broken in monorepos that resolve dev deps from the workspace root
+        'n/no-extraneous-import': 'off',
+        'n/no-extraneous-require': 'off',
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17031,6 +17031,7 @@
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",
         "lavamoat": "^8.0.0",
+        "lavamoat-core": "^15.0.0",
         "lavamoat-tofu": "^7.0.0",
         "node-fetch": "^2.6.9",
         "p-limit": "^3.1.0"
@@ -18581,6 +18582,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@lavamoat/aa": "^4.0.0",
         "lavamoat-core": "^15.0.0"
       },
       "devDependencies": {

--- a/packages/survey/package.json
+++ b/packages/survey/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
     "lavamoat": "^8.0.0",
+    "lavamoat-core": "^15.0.0",
     "lavamoat-tofu": "^7.0.0",
     "node-fetch": "^2.6.9",
     "p-limit": "^3.1.0"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -7,6 +7,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@lavamoat/aa": "^4.0.0",
     "lavamoat-core": "^15.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Like `n/no-extraneous-require`, this rule is seemingly broken in monorepos.  Given `endomoat` must be a EJS pkg, this rule must be disabled.