### PR TITLE
chore(deps): pin typescript to patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "memfs": "^4.3.0",
         "prettier": "^3.0.2",
         "type-fest": "^4.7.1",
-        "typescript": "^5.2.2"
+        "typescript": "~5.2.2"
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
@@ -15727,9 +15727,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "memfs": "^4.3.0",
     "prettier": "^3.0.2",
     "type-fest": "^4.7.1",
-    "typescript": "^5.2.2"
+    "typescript": "~5.2.2"
   },
   "optionalDependencies": {
     "corepack": "0.20.0"


### PR DESCRIPTION
TypeScript does not follow semver; all minors are breaking.