### PR TITLE
Some improvements to naugtur/extract-scuttling-in-core

### DIFF
--- a/packages/core/src/kernelCoreTemplate.js
+++ b/packages/core/src/kernelCoreTemplate.js
@@ -69,7 +69,7 @@
     const { getEndowmentsForConfig, makeMinimalViewOfRef, applyEndowmentPropDescTransforms, copyWrappedGlobals, createFunctionWrapper } = templateRequire('endowmentsToolkit')()
     const { prepareCompartmentGlobalFromConfig } = templateRequire('makePrepareRealmGlobalFromConfig')({ createFunctionWrapper })
     const { strictScopeTerminator } = templateRequire('strict-scope-terminator')
-    const { applyDefaultScuttling } = templateRequire('scuttle')
+    const { scuttle } = templateRequire('scuttle')
 
     const moduleCache = new Map()
     const packageCompartmentCache = new Map()
@@ -78,7 +78,7 @@
     const rootPackageName = '$root$'
     const rootPackageCompartment = createRootPackageCompartment(globalRef)
 
-    applyDefaultScuttling(globalRef, scuttleGlobalThis)
+    scuttle(globalRef, scuttleGlobalThis)
 
     const kernel = {
       internalRequire,


### PR DESCRIPTION
* consolidating scuttle.js export into one instead of two [ctx](https://github.com/LavaMoat/LavaMoat/pull/758#discussion_r1403033509)
* improve readability and effectiveness of `shouldAvoidProp` [ctx](https://github.com/LavaMoat/LavaMoat/pull/758#discussion_r1391763925)
* cache intrinsics in scuttle module for "defensive coding"