### PR TITLE
feat(webpack): wip handle globals and resolution of node builtins

### DIFF
--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -116,6 +116,14 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
     // Scope Terminator not being present in the output causes the wrapper closure to run a no-op instaed of the module body
     return create(null)
   }
+
+  if (!compartmentMap.has(resourceId)) {
+    // Endow original Math and Date, because SES tames them and we don't need that
+    const c = new Compartment({ Math, Date })
+    installGlobalsForPolicy(resourceId, c.globalThis)
+    compartmentMap.set(resourceId, c)
+  }
+
   let overrides = create(null)
 
   // modules may reference `require` dynamically, but that's something we don't want to allow
@@ -156,6 +164,9 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
       }
     )
 
+    // webpack rewrites regerences to `global` to `__webpack_require__.g` in the bundle
+    policyRequire.g = compartmentMap.get(resourceId).globalThis
+
     // override nmd to limit what it can mutate
     // @ts-expect-error - webpack runtime is not typed
     policyRequire.nmd = (moduleReference) => {
@@ -182,13 +193,6 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
     },
   })
   freeze(runtimeHandler)
-
-  if (!compartmentMap.has(resourceId)) {
-    // Endow original Math and Date, because SES tames them and we don't need that
-    const c = new Compartment({ Math, Date })
-    installGlobalsForPolicy(resourceId, c.globalThis)
-    compartmentMap.set(resourceId, c)
-  }
 
   return {
     [NAME_scopeTerminator]: stricterScopeTerminator,

--- a/packages/webpack/test/e2e-main.spec.js
+++ b/packages/webpack/test/e2e-main.spec.js
@@ -7,6 +7,7 @@ test.before(async (t) => {
   await t.notThrowsAsync(async () => {
     t.context.build = await scaffold(webpackConfig)
   }, 'Expected the build to succeed')
+  console.log(t.context.build.stdout)
   t.context.bundle = t.context.build.snapshot['/dist/app.js']
 })
 
@@ -21,7 +22,7 @@ test('webpack/main - default warning gets printed', (t) => {
 test('webpack/main - warns about excluded modules', (t) => {
   t.regex(
     t.context.build.stdout,
-    /WARNING.*excluded modules.*src\/style\.css.*side-effects-package\/styles\.css/s,
+    /WARNING.*excluded modules.*src\/style\.css.*side-effects-package\/styles\.css/s
   ) // `s` for multiline matching
 })
 
@@ -48,7 +49,7 @@ test('webpack/main - modules were included', (t) => {
 test('webpack/main - treeshaking works', (t) => {
   t.assert(
     !t.context.bundle.includes('13371337'),
-    'Expected treeshakeable reference to be excluded',
+    'Expected treeshakeable reference to be excluded'
   )
 })
 
@@ -56,16 +57,16 @@ test('webpack/main - css extraction works', (t) => {
   const files = Object.keys(t.context.build.snapshot)
   t.assert(
     files.includes('/dist/styles/app.css'),
-    `Expected /dist/styles/app.css to be among files: ${files.join()}`,
+    `Expected /dist/styles/app.css to be among files: ${files.join()}`
   )
   const styles = t.context.build.snapshot['/dist/styles/app.css']
   t.true(
     styles.includes('.app-main'),
-    `Expected styles to include '.app-main', but got: ${styles}`,
+    `Expected styles to include '.app-main', but got: ${styles}`
   )
   t.true(
     styles.includes('.side-effects-package'),
-    `Expected styles to include '.side-effects-package', but got: ${styles}`,
+    `Expected styles to include '.side-effects-package', but got: ${styles}`
   )
 })
 

--- a/packages/webpack/test/e2e-manual.js
+++ b/packages/webpack/test/e2e-manual.js
@@ -1,0 +1,20 @@
+const { scaffold, runScriptWithSES } = require('./scaffold.js')
+const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
+const webpackConfig = {
+  ...webpackConfigDefault,
+  mode: 'development',
+  devtool: false,
+}
+
+const fs = require('fs')
+
+scaffold(webpackConfig).then(({ stdout, snapshot }) => {
+  console.log(stdout)
+  fs.mkdirSync('./tmp', { recursive: true })
+  const now = new Date()
+  fs.writeFileSync(
+    `./tmp/bundle_${now.toISOString()}.js`,
+    '/* eslint-disable */\n' + snapshot['/dist/app.js']
+  )
+  runScriptWithSES(snapshot['/dist/app.js'])
+})

--- a/packages/webpack/test/fixtures/main/main.js
+++ b/packages/webpack/test/fixtures/main/main.js
@@ -1,5 +1,6 @@
 import { hello as helloCommonJS } from 'commonjs-package'
 import { re } from 'commonjs-quirks'
+import { hello as helloBuiltins } from 'builtins-package'
 import { hello as helloES6 } from 'es6-module-package'
 import 'side-effects-package/styles.css'
 import { hello as helloTypeScript } from 'typescript-package'

--- a/packages/webpack/test/fixtures/main/node_modules/builtins-package/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/builtins-package/index.js
@@ -1,0 +1,5 @@
+
+const subtle = global.crypto && global.crypto.subtle
+const a = require('util')
+
+module.exports.hello = () => "hello from builtins-package"+subtle+a

--- a/packages/webpack/test/fixtures/main/node_modules/builtins-package/package.json
+++ b/packages/webpack/test/fixtures/main/node_modules/builtins-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "builtins-package",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/webpack/test/fixtures/main/package.json
+++ b/packages/webpack/test/fixtures/main/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "commonjs-package": "1.0.0",
     "commonjs-quirks": "1.0.0",
+    "builtins-package": "1.0.0",
     "es6-module-package": "1.0.0",
     "side-effects-package": "1.0.0",
     "typescript-package": "1.0.0",

--- a/packages/webpack/test/fixtures/main/webpack.config.js
+++ b/packages/webpack/test/fixtures/main/webpack.config.js
@@ -41,6 +41,14 @@ module.exports = {
     }),
     new HtmlWebpackPlugin(),
   ],
+  resolve: {
+    alias: {
+      // crypto: require.resolve('crypto-browserify'), // deliberately left out, becasue we're testing for ignored modules
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      util: require.resolve('util/'),
+    },
+  },
   module: {
     rules: [
       {

--- a/packages/webpack/tsconfig.json
+++ b/packages/webpack/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "types"
+    "outDir": "types",
+    "strict": false
   }
 }


### PR DESCRIPTION
- added handling of `global` via webpack
- testing and exploring the way node builtins are aliased and how that affects policy enforcement
- looking into workspace level dependencies handling (they're identified as `external:../../` which is not ideal) - probably to be fixed in another PR targeting `aa`