### PR TITLE
chore(ci): fix tag for renovate

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,16 +15,16 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # tag=v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Upgrade npm # for workspace support
         run: npm i -g npm@9 # npm@9 supports our supported Node.js versions
       - name: Install Dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1.8.25
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts
@@ -49,7 +49,7 @@ jobs:
       - name: Upgrade npm # for workspace support
         run: npm i -g npm@9 # npm@9 supports our supported Node.js versions
       - name: Install Dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1.8.25
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts


### PR DESCRIPTION
Renovate was complaining about the comment for the digest on our usages of `bahmutov/npm-install`, so I just reset the comment to be the tag matching the SHA.