### PR TITLE
fix(lavapack): espree should be a dep, not a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3594,7 +3594,6 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3612,7 +3611,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7658,7 +7656,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -7735,7 +7732,6 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -16869,6 +16865,7 @@
       "dependencies": {
         "combine-source-map": "^0.8.0",
         "convert-source-map": "^2.0.0",
+        "espree": "^9.5.2",
         "json-stable-stringify": "^1.0.2",
         "JSONStream": "^1.3.5",
         "lavamoat-core": "^15.0.0",
@@ -16877,7 +16874,6 @@
         "umd": "^3.0.3"
       },
       "devDependencies": {
-        "espree": "^9.5.2",
         "mississippi": "^4.0.0",
         "source-map": "^0.7.4"
       },

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -13,6 +13,7 @@
     "JSONStream": "^1.3.5",
     "combine-source-map": "^0.8.0",
     "convert-source-map": "^2.0.0",
+    "espree": "^9.5.2",
     "json-stable-stringify": "^1.0.2",
     "lavamoat-core": "^15.0.0",
     "readable-stream": "^3.6.0",
@@ -20,7 +21,6 @@
     "umd": "^3.0.3"
   },
   "devDependencies": {
-    "espree": "^9.5.2",
     "mississippi": "^4.0.0",
     "source-map": "^0.7.4"
   },


### PR DESCRIPTION
It's referenced in `src/builder-runtime.js`

cc @kumavis 