### PR TITLE
chore(github): adds a CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# adds everybody as a reviewer on all the PRs
+* @LavaMoat/devs
+
+*eslint* @boneskull
+tsconfig*.json @boneskull
+*release-please* @boneskull
+.husky/**/* @boneskull
+.config/README.md @boneskull
+renovate* @boneskull

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,9 @@
 * @LavaMoat/devs
 
 *eslint* @boneskull
-tsconfig*.json @boneskull
+tsconfig*.json @boneskull @legobeat
+yarn.lock @legobeat
+{,packages/*/}package.json @legobeat
 *release-please* @boneskull
 .husky/**/* @boneskull
 .config/README.md @boneskull

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,8 @@
 *eslint* @boneskull
 tsconfig*.json @boneskull @legobeat
 yarn.lock @legobeat
-{,packages/*/}package.json @legobeat
+packages/*/package.json @legobeat
+package.json @legobeat
 *release-please* @boneskull
 .husky/**/* @boneskull
 .config/README.md @boneskull


### PR DESCRIPTION
This adds a `CODEOWNERS` file which assigns reviewers to PRs automatically.  It can also be used for branch protection rules, but we are not doing so currently.

My idea was that if there is a specific area you, as a maintainer, would like to review, then you can add yourself to this file.