### PR TITLE
feat(aa): add custom resolver option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ packages/*/types
 .vscode
 
 !**/fixtures/main/node_modules
+packages/aa/test/projects/4/node_modules/aaa

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -38,9 +38,6 @@ const performantResolve = createPerformantResolve()
  * @see {@link https://nodejs.org/api/packages.html#subpath-exports}
  */
 function createPerformantResolve() {
-  if (performantResolve) {
-    return performantResolve
-  }
   /**
    * @param {string} filepath
    */
@@ -117,11 +114,14 @@ function wrappedResolveSync(resolve, depName, basedir) {
   } catch (e) {
     const err = /** @type {Error} */ (e)
     if (
-      ('code' in err && err.code !== 'MODULE_NOT_FOUND') ||
-      !err.message?.startsWith('Cannot find module')
+      err &&
+      typeof err === 'object' &&
+      (('code' in err && err.code === 'MODULE_NOT_FOUND') ||
+        err.message?.startsWith('Cannot find module'))
     ) {
-      throw err
+      return
     }
+    throw err
   }
 }
 

--- a/packages/aa/test/benchmark1.spec.js
+++ b/packages/aa/test/benchmark1.spec.js
@@ -1,0 +1,61 @@
+const { realpathSync, lstatSync } = require('node:fs')
+const path = require('node:path')
+const test = require('ava')
+
+function isSymlink(location) {
+  const info = lstatSync(location)
+  return info.isSymbolicLink()
+}
+
+const symlink = path.join(__dirname, './projects/4/node_modules/aaa')
+const notsymlink = path.join(__dirname, './projects/4/node_modules/bbb')
+
+const bench = (fn, name) => {
+  const t0 = performance.now()
+  for (let i = 0; i < 10000; i++) {
+    fn()
+  }
+  const t1 = performance.now()
+  return [name, t1 - t0]
+}
+
+const ratioIsBelow = (a, b, expected) => {
+  const ratio = a / b
+  return ratio < expected
+}
+
+test('[bench] isSymlink is significantly faster than realpathSync in a naive microbenchmark', (t) => {
+  const entries = [
+    bench(() => {
+      isSymlink(symlink)
+    }, 'isSymlink(symlink)'),
+    bench(() => {
+      isSymlink(notsymlink)
+    }, 'isSymlink(notsymlink)'),
+    bench(() => {
+      realpathSync(symlink)
+    }, 'realpathSync(symlink)'),
+    bench(() => {
+      realpathSync(notsymlink)
+    }, 'realpathSync(notsymlink)'),
+  ]
+
+  const results = Object.fromEntries(entries)
+  t.log({ results })
+  t.assert(
+    ratioIsBelow(
+      results['isSymlink(symlink)'],
+      results['realpathSync(symlink)'],
+      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+    ),
+    'expected isSymlink(symlink) to be much faster than realpathSync(symlink)'
+  )
+  t.assert(
+    ratioIsBelow(
+      results['isSymlink(notsymlink)'],
+      results['realpathSync(notsymlink)'],
+      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+    ),
+    'expected isSymlink(notsymlink) to be much faster than realpathSync(notsymlink)'
+  )
+})

--- a/packages/aa/test/benchmark1.spec.js
+++ b/packages/aa/test/benchmark1.spec.js
@@ -1,14 +1,19 @@
 const { realpathSync, lstatSync } = require('node:fs')
 const path = require('node:path')
 const test = require('ava')
+const { createProject4Symlink } = require('./utils')
 
 function isSymlink(location) {
   const info = lstatSync(location)
   return info.isSymbolicLink()
 }
 
-const symlink = path.join(__dirname, './projects/4/node_modules/aaa')
-const notsymlink = path.join(__dirname, './projects/4/node_modules/bbb')
+const symlink = path.normalize(
+  path.join(__dirname, './projects/4/node_modules/aaa')
+)
+const notsymlink = path.normalize(
+  path.join(__dirname, './projects/4/node_modules/bbb')
+)
 
 const bench = (fn, name) => {
   const t0 = performance.now()
@@ -24,7 +29,8 @@ const ratioIsBelow = (a, b, expected) => {
   return ratio < expected
 }
 
-test('[bench] isSymlink is significantly faster than realpathSync in a naive microbenchmark', (t) => {
+test('[bench] isSymlink is significantly faster than realpathSync in a naive microbenchmark', async (t) => {
+  await createProject4Symlink()
   const entries = [
     bench(() => {
       isSymlink(symlink)

--- a/packages/aa/test/benchmark1.spec.js
+++ b/packages/aa/test/benchmark1.spec.js
@@ -52,7 +52,9 @@ test('[bench] isSymlink is significantly faster than realpathSync in a naive mic
     ratioIsBelow(
       results['isSymlink(symlink)'],
       results['realpathSync(symlink)'],
-      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+      0.5 // the tradeoff is worth it up until close to 1, so this number can be increased.
+      // The ratio is under 0.2 on linux and windows, slihtly above that on mac in GH actions
+      // Setting to 0.5 to avoid flakiness
     ),
     'expected isSymlink(symlink) to be much faster than realpathSync(symlink)'
   )
@@ -60,7 +62,9 @@ test('[bench] isSymlink is significantly faster than realpathSync in a naive mic
     ratioIsBelow(
       results['isSymlink(notsymlink)'],
       results['realpathSync(notsymlink)'],
-      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+      0.5 // the tradeoff is worth it up until close to 1, so this number can be increased.
+      // The ratio is under 0.2 on linux and windows, slihtly above that on mac in GH actions
+      // Setting to 0.5 to avoid flakiness
     ),
     'expected isSymlink(notsymlink) to be much faster than realpathSync(notsymlink)'
   )

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -1,19 +1,26 @@
+const resolve = require('resolve')
 const path = require('path')
 const test = require('ava')
 const { loadCanonicalNameMap } = require('../src/index.js')
-
-test('project 1', async (t) => {
-  const canonicalNameMap = await loadCanonicalNameMap({
-    rootDir: path.join(__dirname, 'projects', '1'),
-  })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
+const { Module } = require('node:module')
+/**
+ *
+ * @param {import('../src/index.js').CanonicalNameMap} map
+ */
+function normalizeEntries(map) {
+  return [...map.entries()]
     .sort()
     .map(([packagePath, canonicalName]) => [
       path.relative(__dirname, packagePath),
       canonicalName,
     ])
-  t.deepEqual(normalizedMapEntries, [
+}
+
+test('project 1', async (t) => {
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir: path.join(__dirname, 'projects', '1'),
+  })
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/1', '$root$'],
     ['projects/1/node_modules/aaa', 'aaa'],
     ['projects/1/node_modules/bbb', 'bbb'],
@@ -25,14 +32,7 @@ test('project 2', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '2'),
   })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
-    .sort()
-    .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
-      canonicalName,
-    ])
-  t.deepEqual(normalizedMapEntries, [
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/2', '$root$'],
     ['projects/2/node_modules/aaa', 'aaa'],
     ['projects/2/node_modules/bbb', 'bbb'],
@@ -45,18 +45,33 @@ test('project 3', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '3'),
   })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
-    .sort()
-    .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
-      canonicalName,
-    ])
-  t.deepEqual(normalizedMapEntries, [
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/3', '$root$'],
     ['projects/3/node_modules/aaa', 'aaa'],
     ['projects/3/node_modules/bbb', 'bbb'],
     ['projects/3/node_modules/bbb/node_modules/good_dep', 'bbb>good_dep'],
     ['projects/3/node_modules/evil_dep', 'evil_dep'],
+  ])
+})
+
+test('custom Resolver', async (t) => {
+  const rootDir = path.join(__dirname, 'projects', '1')
+  /** @type {import('../src/index.js').Resolver} */
+  const resolver = {
+    sync: (moduleId, { basedir }) => {
+      return Module.createRequire(path.join(basedir, 'dummy.js')).resolve(
+        moduleId
+      )
+    },
+  }
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir,
+    resolve: resolver,
+  })
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
+    ['projects/1', '$root$'],
+    ['projects/1/node_modules/aaa', 'aaa'],
+    ['projects/1/node_modules/bbb', 'bbb'],
+    ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
   ])
 })

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -54,7 +54,26 @@ test('project 3', async (t) => {
   ])
 })
 
-test('custom Resolver', async (t) => {
+test('project 4 - workspace symlink', async (t) => {
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir: path.join(__dirname, 'projects', '4', 'packages', 'stuff'),
+  })
+  // normalize results to be relative
+  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
+    .sort()
+    .map(([packagePath, canonicalName]) => [
+      path.relative(__dirname, packagePath),
+      canonicalName,
+    ])
+  t.deepEqual(normalizedMapEntries, [
+    ['projects/4/node_modules/aaa', 'aaa'],
+    ['projects/4/node_modules/bbb', 'bbb'],
+    ['projects/4/packages/aaa', 'aaa'], // symlink resolved
+    ['projects/4/packages/stuff', '$root$'],
+  ])
+})
+
+test('project 1 - with custom resolver', async (t) => {
   const rootDir = path.join(__dirname, 'projects', '1')
   /** @type {import('../src/index.js').Resolver} */
   const resolver = {

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -1,10 +1,10 @@
-const resolve = require('resolve')
-const path = require('path')
+const path = require('node:path')
 const test = require('ava')
 const { loadCanonicalNameMap } = require('../src/index.js')
 const { Module } = require('node:module')
+const { createProject4Symlink, normalizePaths } = require('./utils.js')
+
 /**
- *
  * @param {import('../src/index.js').CanonicalNameMap} map
  */
 function normalizeEntries(map) {
@@ -20,57 +20,65 @@ test('project 1', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '1'),
   })
-  t.deepEqual(normalizeEntries(canonicalNameMap), [
-    ['projects/1', '$root$'],
-    ['projects/1/node_modules/aaa', 'aaa'],
-    ['projects/1/node_modules/bbb', 'bbb'],
-    ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
-  ])
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([
+      ['projects/1', '$root$'],
+      ['projects/1/node_modules/aaa', 'aaa'],
+      ['projects/1/node_modules/bbb', 'bbb'],
+      ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
+    ])
+  )
 })
 
 test('project 2', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '2'),
   })
-  t.deepEqual(normalizeEntries(canonicalNameMap), [
-    ['projects/2', '$root$'],
-    ['projects/2/node_modules/aaa', 'aaa'],
-    ['projects/2/node_modules/bbb', 'bbb'],
-    ['projects/2/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
-    ['projects/2/node_modules/good_dep', 'good_dep'],
-  ])
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([
+      ['projects/2', '$root$'],
+      ['projects/2/node_modules/aaa', 'aaa'],
+      ['projects/2/node_modules/bbb', 'bbb'],
+      ['projects/2/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
+      ['projects/2/node_modules/good_dep', 'good_dep'],
+    ])
+  )
 })
 
 test('project 3', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '3'),
   })
-  t.deepEqual(normalizeEntries(canonicalNameMap), [
-    ['projects/3', '$root$'],
-    ['projects/3/node_modules/aaa', 'aaa'],
-    ['projects/3/node_modules/bbb', 'bbb'],
-    ['projects/3/node_modules/bbb/node_modules/good_dep', 'bbb>good_dep'],
-    ['projects/3/node_modules/evil_dep', 'evil_dep'],
-  ])
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([
+      ['projects/3', '$root$'],
+      ['projects/3/node_modules/aaa', 'aaa'],
+      ['projects/3/node_modules/bbb', 'bbb'],
+      ['projects/3/node_modules/bbb/node_modules/good_dep', 'bbb>good_dep'],
+      ['projects/3/node_modules/evil_dep', 'evil_dep'],
+    ])
+  )
 })
 
 test('project 4 - workspace symlink', async (t) => {
+  await createProject4Symlink()
+
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '4', 'packages', 'stuff'),
   })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
-    .sort()
-    .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
-      canonicalName,
+
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([
+      ['projects/4/node_modules/aaa', 'aaa'],
+      ['projects/4/node_modules/bbb', 'bbb'],
+      ['projects/4/packages/aaa', 'aaa'], // symlink resolved
+      ['projects/4/packages/stuff', '$root$'],
     ])
-  t.deepEqual(normalizedMapEntries, [
-    ['projects/4/node_modules/aaa', 'aaa'],
-    ['projects/4/node_modules/bbb', 'bbb'],
-    ['projects/4/packages/aaa', 'aaa'], // symlink resolved
-    ['projects/4/packages/stuff', '$root$'],
-  ])
+  )
 })
 
 test('project 1 - with custom resolver', async (t) => {
@@ -87,10 +95,56 @@ test('project 1 - with custom resolver', async (t) => {
     rootDir,
     resolve: resolver,
   })
-  t.deepEqual(normalizeEntries(canonicalNameMap), [
-    ['projects/1', '$root$'],
-    ['projects/1/node_modules/aaa', 'aaa'],
-    ['projects/1/node_modules/bbb', 'bbb'],
-    ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
-  ])
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([
+      ['projects/1', '$root$'],
+      ['projects/1/node_modules/aaa', 'aaa'],
+      ['projects/1/node_modules/bbb', 'bbb'],
+      ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
+    ])
+  )
+})
+
+test('project 1 - resolution failure', async (t) => {
+  const rootDir = path.join(__dirname, 'projects', '1')
+  /** @type {import('../src/index.js').Resolver} */
+  const resolver = {
+    sync: (moduleId, { basedir }) => {
+      throw new Error('grumble')
+    },
+  }
+  await t.throwsAsync(async () => {
+    const canonicalNameMap = await loadCanonicalNameMap({
+      rootDir,
+      resolve: resolver,
+    })
+  })
+})
+
+test('project 1 - resolution missing silently', async (t) => {
+  const rootDir = path.join(__dirname, 'projects', '1')
+  /** @type {import('../src/index.js').Resolver} */
+  const errors = [
+    new Error('Cannot find module dude!'),
+    { code: 'MODULE_NOT_FOUND' },
+  ]
+
+  const resolver = {
+    sync: (moduleId, { basedir }) => {
+      throw errors.pop()
+    },
+  }
+  let canonicalNameMap
+  await t.notThrowsAsync(async () => {
+    canonicalNameMap = await loadCanonicalNameMap({
+      rootDir,
+      resolve: resolver,
+    })
+  })
+
+  t.deepEqual(
+    normalizeEntries(canonicalNameMap),
+    normalizePaths([['projects/1', '$root$']])
+  )
 })

--- a/packages/aa/test/projects/4/node_modules/aaa
+++ b/packages/aa/test/projects/4/node_modules/aaa
@@ -1,0 +1,1 @@
+../packages/aaa

--- a/packages/aa/test/projects/4/node_modules/aaa
+++ b/packages/aa/test/projects/4/node_modules/aaa
@@ -1,1 +1,0 @@
-../packages/aaa

--- a/packages/aa/test/projects/4/node_modules/bbb/package.json
+++ b/packages/aa/test/projects/4/node_modules/bbb/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bbb",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/aa/test/projects/4/package.json
+++ b/packages/aa/test/projects/4/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "4",
+  "version": "1.0.0",
+  "description": ""
+}

--- a/packages/aa/test/projects/4/packages/aaa/package.json
+++ b/packages/aa/test/projects/4/packages/aaa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aaa",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "main": "index.js",
+  "keywords": [],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/packages/aa/test/projects/4/packages/stuff/package.json
+++ b/packages/aa/test/projects/4/packages/stuff/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "aaa": "^1.0.0",
+    "bbb": "^1.0.0"
+  }
+}

--- a/packages/aa/test/utils.js
+++ b/packages/aa/test/utils.js
@@ -1,0 +1,28 @@
+const path = require('node:path')
+const { symlink } = require('node:fs/promises')
+const { existsSync } = require('node:fs')
+
+/**
+ * Normalizes paths in canonical name map entries
+ *
+ * @param {[string, string][]} arr
+ * @returns {[string, string][]}
+ */
+exports.normalizePaths = (arr) => {
+  return arr.map(([dirpath, name]) => [path.normalize(dirpath), name])
+}
+
+exports.osIndependentSymlink = async (target, src) => {
+  if (!existsSync(src)) {
+    await symlink(
+      target,
+      src,
+      'junction' // Ignored on POSIX, Windows only, same as pkg managers use
+    )
+  }
+}
+exports.createProject4Symlink = async () => {
+  const src = path.join(__dirname, 'projects', '4', 'node_modules', 'aaa')
+  const target = path.join(__dirname, 'projects', '4', 'packages', 'aaa')
+  await exports.osIndependentSymlink(target, src)
+}

--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -96,10 +96,10 @@
     },
     "@lavamoat/aa": {
       "builtin": {
-        "fs.readFileSync": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.relative": true
+        "node:fs.readFileSync": true,
+        "node:path.dirname": true,
+        "node:path.join": true,
+        "node:path.relative": true
       },
       "packages": {
         "browserify>resolve": true

--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -96,7 +96,9 @@
     },
     "@lavamoat/aa": {
       "builtin": {
+        "node:fs.lstatSync": true,
         "node:fs.readFileSync": true,
+        "node:fs.realpathSync": true,
         "node:path.dirname": true,
         "node:path.join": true,
         "node:path.relative": true


### PR DESCRIPTION
`loadCanonicalNameMap` now supports passing in a custom resolver, which is needed for actually resolving ESM packages, due to the inability of the [`resolve`](https://npm.im/resolve) package to do so.  

Implementing the custom resolver (from #811) would break our custom "performant resolver"; we may need to abandon it anyway, because `package.json` _must_ be read in order to resolve any package having an `exports` field.  

An alternative implementation would _require_ a custom resolver, which might make more separation-of-concerns sense.

@naugtur I'm not sure if the webpack plugin would find passing a custom resolver into `@lavamoat/aa` useful?  
