### PR TITLE
feat(tofu): add ESM support

### DIFF
--- a/packages/tofu/src/findGlobals.js
+++ b/packages/tofu/src/findGlobals.js
@@ -15,6 +15,17 @@ const nonReferenceIdentifiers = [
   'RestElement',
 ]
 
+const importExportSpecifierTypes = new Set(
+  /** @type {const} */ ([
+    'ImportSpecifier',
+    'ImportDefaultSpecifier',
+    'ImportNamespaceSpecifier',
+    'ExportSpecifier',
+    'ExportDefaultSpecifier',
+    'MetaProperty',
+  ])
+)
+
 module.exports = { findGlobals }
 
 /**
@@ -37,6 +48,12 @@ function findGlobals(ast) {
       if (nonReferenceIdentifiers.includes(parentType)) {
         return
       }
+
+      // toss out esm imports/exports
+      if (importExportSpecifierTypes.has(parentType)) {
+        return
+      }
+
       if (parentType === 'VariableDeclarator' && path.parent.id === path.node) {
         return
       }

--- a/packages/tofu/src/findGlobals.js
+++ b/packages/tofu/src/findGlobals.js
@@ -3,37 +3,36 @@
 const { default: traverse } = require('@babel/traverse')
 const { isInFunctionDeclaration, isMemberLikeExpression } = require('./util')
 
-const nonReferenceIdentifiers = [
+/**
+ * Types which are not references to globals
+ */
+const nonReferenceIdentifiers = new Set([
+  'ArrayPatten',
+  'BreakStatement',
+  'CatchClause',
+  'ClassMethod',
+  'ContinueStatement',
+  'ExportDefaultSpecifier',
+  'ExportSpecifier',
   'FunctionDeclaration',
   'FunctionExpression',
-  'ClassMethod',
+  'ImportDefaultSpecifier',
+  'ImportNamespaceSpecifier',
+  'ImportSpecifier',
   'LabeledStatement',
-  'BreakStatement',
-  'ContinueStatement',
-  'CatchClause',
-  'ArrayPatten',
+  'MetaProperty',
   'RestElement',
-]
-
-const importExportSpecifierTypes = new Set(
-  /** @type {const} */ ([
-    'ImportSpecifier',
-    'ImportDefaultSpecifier',
-    'ImportNamespaceSpecifier',
-    'ExportSpecifier',
-    'ExportDefaultSpecifier',
-    'MetaProperty',
-  ])
-)
+])
 
 module.exports = { findGlobals }
 
 /**
- * @typedef {import('@babel/traverse').NodePath<import('@babel/types').Identifier|import('@babel/types').ThisExpression>} IdentifierOrThisExpressionNodePath
+ * @typedef {import('@babel/traverse').NodePath<
+ *   import('@babel/types').Identifier | import('@babel/types').ThisExpression
+ * >} IdentifierOrThisExpressionNodePath
  */
 
 /**
- *
  * @param {import('@babel/types').Node} ast
  * @returns {Map<string, IdentifierOrThisExpressionNodePath[]>}
  */
@@ -45,12 +44,7 @@ function findGlobals(ast) {
     Identifier: (path) => {
       // skip if not being used as reference
       const parentType = path.parent.type
-      if (nonReferenceIdentifiers.includes(parentType)) {
-        return
-      }
-
-      // toss out esm imports/exports
-      if (importExportSpecifierTypes.has(parentType)) {
+      if (nonReferenceIdentifiers.has(parentType)) {
         return
       }
 
@@ -104,7 +98,6 @@ function findGlobals(ast) {
   return globals
 
   /**
-   *
    * @param {IdentifierOrThisExpressionNodePath} path
    * @param {string} [name]
    */

--- a/packages/tofu/src/index.js
+++ b/packages/tofu/src/index.js
@@ -2,7 +2,7 @@ const { parse } = require('@babel/parser')
 const { default: traverse } = require('@babel/traverse')
 const {
   inspectGlobals,
-  inspectImports,
+  inspectRequires,
   inspectEsmImports,
   inspectDynamicRequires,
 } = require('./inspectSource')
@@ -15,7 +15,9 @@ const utils = require('./util')
 
 module.exports = {
   inspectGlobals,
-  inspectImports,
+  /** @deprecated - Use {@link inspectRequires} */
+  inspectImports: inspectRequires,
+  inspectRequires,
   inspectEsmImports,
   inspectDynamicRequires,
   utils,

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -282,6 +282,7 @@ function inspectDynamicRequires(ast) {
  * @returns {{ cjsImports: string[] }}
  */
 function inspectRequires(ast, packagesToInspect, deep = true) {
+  /** @type {string[][]} */
   const cjsImports = []
   const requireCalls = findAllCallsToRequire(ast)
   requireCalls.forEach((path) => {

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -176,14 +176,22 @@ function inspectGlobals(
  * modules.
  *
  * @param {import('@babel/types').Node} ast
- * @param {string[]} [packagesToInspect]
- * @returns {{ esmImports: string[] }}
+ * @param {string[]} [packagesToInspect] - List of module IDs to look for; if
+ *   omitted, will inspect all imports
+ * @returns {string[]} - List of imported identifiers
  */
 function inspectEsmImports(ast, packagesToInspect) {
   const pkgsToInspect = new Set(packagesToInspect)
+
   /** @type {Set<string>} */
   const esmImports = new Set()
 
+  /**
+   * @param {import('@babel/traverse').NodePath<
+   *   | import('@babel/types').ImportDeclaration
+   *   | import('@babel/types').ExportNamedDeclaration
+   * >} path
+   */
   const handleNodePath = (path) => {
     const importSource = path.node.source?.value
 
@@ -203,7 +211,7 @@ function inspectEsmImports(ast, packagesToInspect) {
     ImportDeclaration: handleNodePath,
   })
 
-  return { esmImports: [...esmImports] }
+  return [...esmImports]
 }
 
 /**

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -16,7 +16,7 @@ const {
 
 module.exports = {
   inspectGlobals,
-  inspectImports: inspectRequires,
+  inspectRequires,
   inspectEsmImports,
   inspectDynamicRequires,
 }

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -197,8 +197,8 @@ function inspectEsmImports(ast, packagesToInspect) {
 
     if (
       importSource &&
-      ((packagesToInspect && pkgsToInspect.has(importSource)) ||
-        !packagesToInspect)
+      ((pkgsToInspect.size && pkgsToInspect.has(importSource)) ||
+        !pkgsToInspect.size)
     ) {
       esmImports.add(importSource)
     }

--- a/packages/tofu/src/util.js
+++ b/packages/tofu/src/util.js
@@ -17,14 +17,15 @@ module.exports = {
 
 /**
  * @typedef MemberExpressionNesting
- * @property {import("./inspectPrimordialAssignments").NonComputedMemberLikeExpression[]} memberExpressions
- * @property {import("./inspectPrimordialAssignments").MemberLikeExpression} parentOfMembershipChain
- * @property {import("./inspectPrimordialAssignments").MemberLikeExpression|import("@babel/types").LVal} topmostMember
+ * @property {import('./inspectPrimordialAssignments').NonComputedMemberLikeExpression[]} memberExpressions
+ * @property {import('./inspectPrimordialAssignments').MemberLikeExpression} parentOfMembershipChain
+ * @property {import('./inspectPrimordialAssignments').MemberLikeExpression
+ *   | import('@babel/types').LVal} topmostMember
  */
 
 /**
- * @param {import("@babel/types").Node} identifierNode
- * @param {import("@babel/types").Node[]} parents
+ * @param {import('@babel/types').Node} identifierNode
+ * @param {import('@babel/types').Node[]} parents
  * @returns
  */
 function getMemberExpressionNesting(identifierNode, parents) {
@@ -32,7 +33,7 @@ function getMemberExpressionNesting(identifierNode, parents) {
   const parentsOnly = parents.slice(0, -1)
   // find unbroken membership chain closest to identifier
   const memberExpressions = getTailmostMatchingChain(
-    /** @type {import("./inspectPrimordialAssignments").NonComputedMemberLikeExpression[]} */ (
+    /** @type {import('./inspectPrimordialAssignments').NonComputedMemberLikeExpression[]} */ (
       parentsOnly
     ),
     isNonComputedMemberLikeExpression
@@ -52,8 +53,7 @@ function getMemberExpressionNesting(identifierNode, parents) {
 }
 
 /**
- *
- * @param {import("./inspectPrimordialAssignments").MemberLikeExpression[]} memberExpressions
+ * @param {import('./inspectPrimordialAssignments').MemberLikeExpression[]} memberExpressions
  * @returns {string[]}
  */
 function getPathFromMemberExpressionChain(memberExpressions) {
@@ -64,8 +64,7 @@ function getPathFromMemberExpressionChain(memberExpressions) {
 }
 
 /**
- *
- * @param {import("@babel/types").Node} node
+ * @param {import('@babel/types').Node} node
  * @returns {string}
  */
 function getNameFromNode(node) {
@@ -83,8 +82,7 @@ function getNameFromNode(node) {
 }
 
 /**
- *
- * @param {import("@babel/types").Node} node
+ * @param {import('@babel/types').Node} node
  * @returns {node is import("./inspectPrimordialAssignments").MemberLikeExpression}
  */
 function isMemberLikeExpression(node) {
@@ -94,8 +92,7 @@ function isMemberLikeExpression(node) {
 }
 
 /**
- *
- * @param {import("./inspectPrimordialAssignments").MemberLikeExpression} node
+ * @param {import('./inspectPrimordialAssignments').MemberLikeExpression} node
  * @returns {node is import("./inspectPrimordialAssignments").NonComputedMemberLikeExpression}
  */
 function isNonComputedMemberLikeExpression(node) {
@@ -103,14 +100,13 @@ function isNonComputedMemberLikeExpression(node) {
 }
 
 /**
- *
- * @param {import("@babel/types").LVal} identifierNode
- * @param {import("@babel/types").Node[]} parents
+ * @param {import('@babel/types').LVal} identifierNode
+ * @param {import('@babel/types').Node[]} parents
  * @returns {boolean}
  */
 function isUndefinedCheck(identifierNode, parents) {
   const parentExpression =
-    /** @type {import("@babel/types").UnaryExpression} */ (
+    /** @type {import('@babel/types').UnaryExpression} */ (
       parents[parents.length - 2]
     )
   const isTypeof =
@@ -134,7 +130,8 @@ function getTailmostMatchingChain(items, matcher) {
 }
 
 /**
- * if array contains 'x' and 'x.y' just keep 'x'
+ * If array contains 'x' and 'x.y' just keep 'x'
+ *
  * @param {Map<string, import('lavamoat-core').GlobalPolicyValue>} globalsConfig
  * @returns
  */
@@ -163,7 +160,8 @@ function reduceToTopmostApiCalls(globalsConfig) {
 }
 
 /**
- * if array contains 'x' and 'x.y' just keep 'x'
+ * If array contains 'x' and 'x.y' just keep 'x'
+ *
  * @param {string[]} keyPathStrings
  * @returns {string[]}
  */
@@ -194,7 +192,8 @@ function reduceToTopmostApiCallsFromStrings(keyPathStrings) {
 }
 
 /**
- * add variable to results, if not already set
+ * Add variable to results, if not already set
+ *
  * @param {Map<string, import('lavamoat-core').GlobalPolicyValue>} globalsConfig
  * @param {string} identifierPath
  * @param {import('lavamoat-core').GlobalPolicyValue} identifierUse
@@ -208,6 +207,7 @@ function addGlobalUsage(globalsConfig, identifierPath, identifierUse) {
 
 /**
  * Merge two global policy configs (as `Map`s) together
+ *
  * @param {Map<string, import('lavamoat-core').GlobalPolicyValue>} configA
  * @param {Map<string, import('lavamoat-core').GlobalPolicyValue>} configB
  * @returns
@@ -233,7 +233,7 @@ function objToMap(obj) {
 /**
  * @template V
  * @param {Map<PropertyKey, V>} map
- * @returns {{[k: string]: V}}if array contains 'x' and 'x.y' just keep 'x'
+ * @returns {{ [k: string]: V }} If array contains 'x' and 'x.y' just keep 'x'
  */
 function mapToObj(map) {
   return Object.fromEntries(map)
@@ -242,8 +242,8 @@ function mapToObj(map) {
 /**
  * Returns an array of a `NodePath`'s parent nodes (to the root)
  *
- * @param {import('@babel/traverse').NodePath<any>|null} nodePath
- * @returns {import("@babel/types").Node[]}
+ * @param {import('@babel/traverse').NodePath<any> | null} nodePath
+ * @returns {import('@babel/types').Node[]}
  */
 function getParents(nodePath) {
   /** @type {import('@babel/types').Node[]} */
@@ -260,9 +260,10 @@ function getParents(nodePath) {
 }
 
 /**
- * Determines if this `Node` is a descendant of a `FunctionDeclaration` or `FunctionExpression`.
+ * Determines if this `Node` is a descendant of a `FunctionDeclaration` or
+ * `FunctionExpression`.
  *
- * @param {import('@babel/traverse').NodePath<any>} path
+ * @param {import('@babel/traverse').NodePath<any>} nodePath
  * @returns {boolean}
  */
 function isInFunctionDeclaration(nodePath) {

--- a/packages/tofu/src/util.js
+++ b/packages/tofu/src/util.js
@@ -240,12 +240,13 @@ function mapToObj(map) {
 }
 
 /**
+ * Returns an array of a `NodePath`'s parent nodes (to the root)
  *
  * @param {import('@babel/traverse').NodePath<any>|null} nodePath
  * @returns {import("@babel/types").Node[]}
  */
 function getParents(nodePath) {
-  /** @type {import("@babel/types").Node[]} */
+  /** @type {import('@babel/types').Node[]} */
   const parents = []
   let target = nodePath
   while (target) {
@@ -259,14 +260,19 @@ function getParents(nodePath) {
 }
 
 /**
+ * Determines if this `Node` is a descendant of a `FunctionDeclaration` or `FunctionExpression`.
  *
  * @param {import('@babel/traverse').NodePath<any>} path
  * @returns {boolean}
  */
-function isInFunctionDeclaration(path) {
-  return getParents(path.parentPath).some(
-    (parent) =>
-      parent.type === 'FunctionDeclaration' ||
-      parent.type === 'FunctionExpression'
-  )
+function isInFunctionDeclaration(nodePath) {
+  let target = nodePath.parentPath
+  while (target) {
+    // if function declaration found, short-circuit instead of continuing
+    if (target.isFunctionDeclaration() || target.isFunctionExpression()) {
+      return true
+    }
+    target = target.parentPath
+  }
+  return false
 }

--- a/packages/tofu/test/inspectEsmImports.spec.js
+++ b/packages/tofu/test/inspectEsmImports.spec.js
@@ -29,22 +29,26 @@ testInspect(
   import defaultExport3, * as name2 from "package09";
   import "package10";
   var promise = import("package11");
+  export * as name3 from "package12";
+  export { name4 } from "package13";
+  export { default as name5 } from "package14";
+  export const foo = "bar";
 `,
   {
     esmImports: [
       'package01',
       'package02',
-      'package03.export1',
-      'package04.export2',
-      'package05.export3',
-      'package05.export4',
-      'package06/path/to/specific/un-exported/file.export5',
-      'package06/path/to/specific/un-exported/file.export6',
-      'package07.export7',
-      'package07.export8',
+      'package03',
+      'package04',
+      'package05',
+      'package06/path/to/specific/un-exported/file',
+      'package07',
       'package08',
       'package09',
-      'package09',
+      'package10',
+      'package12',
+      'package13',
+      'package14',
     ],
   }
 )

--- a/packages/tofu/test/inspectEsmImports.spec.js
+++ b/packages/tofu/test/inspectEsmImports.spec.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const deepEqual = require('deep-equal')
 const { parse, inspectEsmImports } = require('../src/index')
 
 testInspect(
@@ -8,9 +7,7 @@ testInspect(
   `
   import fs from 'fs'
 `,
-  {
-    esmImports: ['fs'],
-  }
+  ['fs']
 )
 
 // from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
@@ -34,55 +31,33 @@ testInspect(
   export { default as name5 } from "package14";
   export const foo = "bar";
 `,
-  {
-    esmImports: [
-      'package01',
-      'package02',
-      'package03',
-      'package04',
-      'package05',
-      'package06/path/to/specific/un-exported/file',
-      'package07',
-      'package08',
-      'package09',
-      'package10',
-      'package12',
-      'package13',
-      'package14',
-    ],
-  }
+  [
+    'package01',
+    'package02',
+    'package03',
+    'package04',
+    'package05',
+    'package06/path/to/specific/un-exported/file',
+    'package07',
+    'package08',
+    'package09',
+    'package10',
+    'package12',
+    'package13',
+    'package14',
+  ]
 )
 
-function testInspect(label, opts, fn, expectedResultObj) {
+function testInspect(label, opts, fn, expected) {
   test(label, (t) => {
     const source = fnToCodeBlock(fn)
     const ast = parse(source, { sourceType: 'module' })
-    const result = inspectEsmImports(ast)
-    const resultSorted = [...Object.entries(result)].sort(sortBy(0))
-    const expectedSorted = Object.entries(expectedResultObj).sort(sortBy(0))
+    const actual = inspectEsmImports(ast)
+    const sortedActual = [...actual].sort()
+    const sortedExpected = [...expected].sort()
 
-    // for debugging
-    if (!deepEqual(resultSorted, expectedSorted)) {
-      label, opts, ast, source
-      t.log(resultSorted)
-      t.log(expectedSorted)
-      // eslint-disable-next-line no-debugger
-      debugger
-    }
-
-    t.deepEqual(resultSorted, expectedSorted)
+    t.deepEqual(sortedActual, sortedExpected)
   })
-}
-
-function sortBy(key) {
-  return (a, b) => {
-    const vA = a[key]
-    const vB = b[key]
-    if (vA === vB) {
-      return 0
-    }
-    return vA > vB ? 1 : -1
-  }
 }
 
 function fnToCodeBlock(fn) {


### PR DESCRIPTION
This makes `tofu` ESM-aware.

@kumavis originally implemented most of this.  I changed it such that:

- It uses the same granularity as the CJS import detection (module level)
- It considers `export ... from` syntax (re-export)
