### PR TITLE
feat(core): ESM support in policy generation

### DIFF
--- a/packages/core/src/parseForPolicy.js
+++ b/packages/core/src/parseForPolicy.js
@@ -54,7 +54,7 @@ async function parseForPolicy({
  * @callback ResolveFn
  * @param {string} requestedName
  * @param {string} parentAddress
- * @returns {string | undefined}
+ * @returns {string | null}
  */
 
 /**

--- a/packages/core/test/generatePolicy.spec.js
+++ b/packages/core/test/generatePolicy.spec.js
@@ -142,6 +142,54 @@ test('generatePolicy - config ignores newer intrinsics', async (t) => {
   )
 })
 
+test('generatePolicy - CJS should flag import/export as global', async (t) => {
+  const config = await createConfigForTest(function () {
+    globalThis.import
+    globalThis.export
+    require('node:util')
+  })
+
+  t.deepEqual(
+    config,
+    {
+      resources: {
+        test: {
+          globals: {
+            import: true,
+            export: true,
+          },
+        },
+      },
+    },
+    'config matches expected'
+  )
+})
+
+test('generatePolicy - ESM should flag require/module/exports as global', async (t) => {
+  const config = await createConfigForTest(`
+  require('node:util');
+  let e = exports
+  let m = module.exports
+  export const foo = 'bar';
+`)
+
+  t.deepEqual(
+    config,
+    {
+      resources: {
+        test: {
+          globals: {
+            require: true,
+            exports: true,
+            'module.exports': true,
+          },
+        },
+      },
+    },
+    'config matches expected'
+  )
+})
+
 // we no longer throw an error, we log a warning
 // test('generatePolicy - primordial modification', async (t) => {
 //   try {

--- a/packages/node/src/parseForPolicy.js
+++ b/packages/node/src/parseForPolicy.js
@@ -326,7 +326,7 @@ function parseModule(moduleSrc, filename = '<unknown file>') {
     // transformFromAstAsync
     ast = parse(moduleSrc, {
       // esm support
-      sourceType: 'module',
+      sourceType: 'unambiguous',
       // someone must have been doing this
       allowReturnOutsideFunction: true,
       // plugins: [


### PR DESCRIPTION
This adds ESM support to the policy generator.

## TODO

- [x] add ~~scenarios~~ test project(s). only policy gen will be tested since the runtime cannot execute ESM
- [x] handle CJS/ESM disagreements about allowed global variable names