### PR TITLE
chore(allow-scripts): pin yargs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17748,7 +17748,7 @@
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "4.0.3",
         "npm-normalize-package-bin": "^3.0.0",
-        "yargs": "^17.7.2"
+        "yargs": "17.7.2"
       },
       "bin": {
         "allow-scripts": "src/cli.js"
@@ -17774,7 +17774,8 @@
     },
     "packages/allow-scripts/node_modules/yargs": {
       "version": "17.7.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -43,7 +43,7 @@
     "@npmcli/run-script": "^6.0.0",
     "bin-links": "4.0.3",
     "npm-normalize-package-bin": "^3.0.0",
-    "yargs": "^17.7.2"
+    "yargs": "17.7.2"
   },
   "devDependencies": {
     "@types/npmcli__promise-spawn": "6.0.3"


### PR DESCRIPTION
For whatever reason, renovate was trying to downgrade yargs, and that is broken.