### PR TITLE
chore: enable save-exact

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-scripts = true
+save-exact = true


### PR DESCRIPTION
This changes our npm config to always use exact versions when adding new packages, which aligns with Renovate's behavior.