### PR TITLE
chore: add prettier-plugin-jsdoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "lint-staged": "^13.2.3",
         "memfs": "^4.3.0",
         "prettier": "3.0.3",
+        "prettier-plugin-jsdoc": "1.1.1",
         "type-fest": "^4.7.1",
         "typescript": "~5.2.2"
       },
@@ -2165,6 +2166,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/emscripten": {
       "version": "1.39.6",
       "license": "MIT"
@@ -2268,6 +2278,15 @@
       "version": "4.14.182",
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
@@ -2283,6 +2302,12 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.10.4",
@@ -2409,6 +2434,12 @@
     "node_modules/@types/treeify": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
+      "dev": true
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -4480,6 +4511,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/binary-searching": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
+      "integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
+      "dev": true
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "license": "MIT",
@@ -5164,6 +5201,16 @@
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
       "license": "BSD-2-Clause",
@@ -5628,6 +5675,15 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -6517,6 +6573,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "license": "MIT",
@@ -6784,6 +6853,19 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -10977,6 +11059,43 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+      "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "dev": true,
@@ -11248,6 +11367,448 @@
       "version": "1.1.1",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+      "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+      "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+      "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+      "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+      "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+      "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+      "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+      "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+      "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+      "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+      "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+      "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+      "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+      "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+      "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+      "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -13072,6 +13633,23 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-jsdoc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.1.1.tgz",
+      "integrity": "sha512-yA13k0StQ+g0RJBrmo2IldVSp3ANXlJdsNzQNhGtQ0LY7JFC+u01No/1Z9xp0ZhT4u98BXlPAc4SC0iambqy5A==",
+      "dev": true,
+      "dependencies": {
+        "binary-searching": "^2.0.5",
+        "comment-parser": "^1.4.0",
+        "mdast-util-from-markdown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -16088,6 +16666,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint-staged": "^13.2.3",
     "memfs": "^4.3.0",
     "prettier": "3.0.3",
+    "prettier-plugin-jsdoc": "1.1.1",
     "type-fest": "^4.7.1",
     "typescript": "~5.2.2"
   },
@@ -78,9 +79,13 @@
   ],
   "version": "0.0.0",
   "prettier": {
-    "singleQuote": true,
+    "jsdocCommentLineStrategy": "keep",
+    "jsdocPreferCodeFences": true,
+    "plugins": ["prettier-plugin-jsdoc"],
     "semi": false,
-    "trailingComma": "es5"
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "tsdoc": true
   },
   "ava": {
     "files": [

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -18,7 +18,10 @@ module.exports = {
 function createPerformantResolve() {
   /**
    * @param {string} self
-   * @returns {(readFileSync: (file: string) => (string|{toString(): string}), pkgfile: string) => Record<string,unknown>}
+   * @returns {(
+   *   readFileSync: (file: string) => string | { toString(): string },
+   *   pkgfile: string
+   * ) => Record<string, unknown>}
    */
   const readPackageWithout = (self) => (readFileSync, pkgfile) => {
     // avoid loading the package.json we're just trying to resolve
@@ -74,7 +77,7 @@ async function loadCanonicalNameMap({ rootDir, includeDevDeps, resolve }) {
  * @param {Resolver} resolve
  * @param {string} depName
  * @param {string} packageDir
- * @returns {string|undefined}
+ * @returns {string | undefined}
  */
 function wrappedResolveSync(resolve, depName, packageDir) {
   const depRelativePackageJsonPath = path.join(depName, 'package.json')
@@ -226,7 +229,7 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
 /**
  * @param {CanonicalNameMap} canonicalNameMap
  * @param {string} modulePath
- * @returns {string|undefined}
+ * @returns {string | undefined}
  */
 function getPackageDirForModulePath(canonicalNameMap, modulePath) {
   // find which of these directories the module is in
@@ -242,7 +245,8 @@ function getPackageDirForModulePath(canonicalNameMap, modulePath) {
 }
 
 /**
- * for comparing string lengths
+ * For comparing string lengths
+ *
  * @param {string} a
  * @param {string} b
  * @returns {string}
@@ -252,10 +256,11 @@ function takeLongest(a, b) {
 }
 
 /**
- * for package logical path names
+ * For package logical path names
+ *
  * @param {string} a
  * @param {string} b
- * @returns {0|1|-1}
+ * @returns {0 | 1 | -1}
  */
 function comparePreferredPackageName(a, b) {
   // prefer shorter package names
@@ -275,10 +280,11 @@ function comparePreferredPackageName(a, b) {
 }
 
 /**
- * for comparing package logical path arrays (shorter is better)
+ * For comparing package logical path arrays (shorter is better)
+ *
  * @param {string[]} [aPath]
  * @param {string[]} [bPath]
- * @returns {0|1|-1}
+ * @returns {0 | 1 | -1}
  */
 function comparePackageLogicalPaths(aPath, bPath) {
   // undefined is not preferred
@@ -317,7 +323,7 @@ function comparePackageLogicalPaths(aPath, bPath) {
 
 /**
  * @typedef Resolver
- * @property {(path: string, opts: {basedir: string}) => string} sync
+ * @property {(path: string, opts: { basedir: string }) => string} sync
  */
 
 /**
@@ -328,15 +334,15 @@ function comparePackageLogicalPaths(aPath, bPath) {
  */
 
 /**
- * @internal
  * @typedef WalkDepTreeOpts
  * @property {string} packageDir
  * @property {string[]} [logicalPath]
  * @property {boolean} [includeDevDeps]
  * @property {Set<string>} [visited]
  * @property {Resolver} [resolve]
+ * @internal
  */
 
 /**
- * @typedef {Map<string, string> & {rootDir: string}} CanonicalNameMap
+ * @typedef {Map<string, string> & { rootDir: string }} CanonicalNameMap
  */

--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -20,6 +20,7 @@ const setup = require('./setup')
 
 /**
  * Individual package info
+ *
  * @typedef {Object} PkgInfo
  * @property {string} canonicalName
  * @property {string} path
@@ -28,6 +29,7 @@ const setup = require('./setup')
 
 /**
  * Individual bin link info
+ *
  * @typedef {Object} BinInfo
  * @property {string} canonicalName
  * @property {boolean} isDirect
@@ -35,31 +37,33 @@ const setup = require('./setup')
  * @property {string} path
  * @property {string} link
  * @property {string} fullLinkPath
- **/
-
-/**
- * Configuration for a type of scripts policies
- * @typedef {Object} ScriptsConfig
- * @property {Record<string,any>} allowConfig
- * @property {Map<string,[PkgInfo]>} packagesWithScripts
- * @property {Array<string>} allowedPatterns
- * @property {Array<string>} disallowedPatterns
- * @property {Array<string>} missingPolicies
- * @property {Array<string>} excessPolicies
  */
 
 /**
- * @typedef {Map<string,BinInfo[]>} BinCandidates
+ * Configuration for a type of scripts policies
+ *
+ * @typedef {Object} ScriptsConfig
+ * @property {Record<string, any>} allowConfig
+ * @property {Map<string, [PkgInfo]>} packagesWithScripts
+ * @property {string[]} allowedPatterns
+ * @property {string[]} disallowedPatterns
+ * @property {string[]} missingPolicies
+ * @property {string[]} excessPolicies
+ */
+
+/**
+ * @typedef {Map<string, BinInfo[]>} BinCandidates
  */
 
 /**
  * Configuration for a type of bins policies
+ *
  * @typedef {Object} BinsConfig
- * @property {Record<string,any>} allowConfig
+ * @property {Record<string, any>} allowConfig
  * @property {BinCandidates} binCandidates
- * @property {Array<BinInfo>} allowedBins
- * @property {Array<BinInfo>} firewalledBins
- * @property {Array<string>} excessPolicies
+ * @property {BinInfo[]} allowedBins
+ * @property {BinInfo[]} firewalledBins
+ * @property {string[]} excessPolicies
  * @property {boolean} somePoliciesAreMissing
  */
 
@@ -72,7 +76,6 @@ module.exports = {
 }
 
 /**
- *
  * @param {GetOptionsForBinOpts} param0
  */
 async function getOptionsForBin({ rootDir, name }) {
@@ -212,7 +215,6 @@ async function printPackagesList({ rootDir }) {
 }
 
 /**
- *
  * @param {PrintMissingPoliciesIfAnyOpts} param0
  */
 function printMissingPoliciesIfAny({
@@ -231,10 +233,9 @@ function printMissingPoliciesIfAny({
 // internals
 
 /**
- *
  * @param {Object} arg
  * @param {string} arg.event
- * @param {Array<PkgInfo>} arg.packages
+ * @param {PkgInfo[]} arg.packages
  */
 async function runAllScriptsForEvent({ event, packages }) {
   for (const { canonicalName, path, scripts } of packages) {
@@ -245,7 +246,7 @@ async function runAllScriptsForEvent({ event, packages }) {
   }
 }
 /**
- * @param {Array<BinInfo>} allowedBins
+ * @param {BinInfo[]} allowedBins
  * @returns {Promise<void>}
  */
 async function installBinScripts(allowedBins) {
@@ -256,8 +257,9 @@ async function installBinScripts(allowedBins) {
 }
 /**
  * Points all bins on the list to whichbin.js cli app from allow-scripts
- * @param {Array<BinInfo>} firewalledBins
- * @param {string} link - absolute path to the whichbin.js script
+ *
+ * @param {BinInfo[]} firewalledBins
+ * @param {string} link - Absolute path to the whichbin.js script
  * @returns {Promise<void>}
  */
 async function installBinFirewall(firewalledBins, link) {
@@ -296,7 +298,7 @@ const bannedBins = new Set(['node', 'npm', 'yarn', 'pnpm'])
  * @param {BinCandidates} binCandidates
  */
 function prepareBinScriptsPolicy(binCandidates) {
-  /** @type {Record<string,string>} */
+  /** @type {Record<string, string>} */
   const policy = {}
   // pick direct dependencies without conflicts and enable them by default unless colliding with bannedBins
   for (const [bin, infos] of binCandidates.entries()) {
@@ -382,7 +384,6 @@ function printPackagesByScriptConfiguration({
 }
 
 /**
- *
  * @param {SavePackageConfigurationsOpts} param0
  * @returns {Promise<void>}
  */
@@ -405,7 +406,6 @@ async function savePackageConfigurations({
 }
 
 /**
- *
  * @param {Object} args
  * @param {string} args.rootDir
  * @returns {Promise<PkgConfs>}
@@ -453,7 +453,13 @@ async function loadAllPackageConfigurations({ rootDir }) {
     )
 
     if (lifeCycleScripts.length) {
-      /** @type {{canonicalName: string, path: string, scripts: LavamoatPackageJson['scripts']}[]} */
+      /**
+       * @type {{
+       *   canonicalName: string
+       *   path: string
+       *   scripts: LavamoatPackageJson['scripts']
+       * }[]}
+       */
       const collection = packagesWithScriptsLifecycle.get(canonicalName) || []
       collection.push({
         canonicalName,
@@ -513,9 +519,14 @@ async function loadAllPackageConfigurations({ rootDir }) {
 }
 
 /**
- * Adds helpful redundancy to the config object thus producing a full ScriptsConfig type
- * @param {import('type-fest').SetRequired<Partial<ScriptsConfig>, 'packagesWithScripts'>} config
- * @return {ScriptsConfig}
+ * Adds helpful redundancy to the config object thus producing a full
+ * ScriptsConfig type
+ *
+ * @param {import('type-fest').SetRequired<
+ *   Partial<ScriptsConfig>,
+ *   'packagesWithScripts'
+ * >} config
+ * @returns {ScriptsConfig}
  */
 function indexLifecycleConfiguration(config) {
   config.allowConfig = config.allowConfig || {}
@@ -542,9 +553,14 @@ function indexLifecycleConfiguration(config) {
 }
 
 /**
- * Adds helpful redundancy to the config object thus producing a full {@link BinsConfig} type
- * @param {import('type-fest').SetRequired<Partial<BinsConfig>, 'binCandidates'>} config
- * @return {BinsConfig}
+ * Adds helpful redundancy to the config object thus producing a full
+ * {@link BinsConfig} type
+ *
+ * @param {import('type-fest').SetRequired<
+ *   Partial<BinsConfig>,
+ *   'binCandidates'
+ * >} config
+ * @returns {BinsConfig}
  */
 function indexBinsConfiguration(config) {
   // only autogenerate the initial config. A better heuristic would be to detect if any scripts from direct dependencies are missing
@@ -573,11 +589,10 @@ function indexBinsConfiguration(config) {
 }
 
 /**
- *
  * @template T
  * @template U
  * @param {(value: T) => U} getterFn
- * @returns {(a: T, b: T) => 1|-1|0}
+ * @returns {(a: T, b: T) => 1 | -1 | 0}
  */
 function sortBy(getterFn) {
   return (a, b) => {
@@ -600,7 +615,6 @@ function sortBy(getterFn) {
  */
 
 /**
- *
  * @typedef SavePackageConfigurationsOpts
  * @property {string} rootDir
  * @property {PkgConfs} conf
@@ -610,7 +624,6 @@ function sortBy(getterFn) {
  * @typedef GetOptionsForBinOpts
  * @property {string} rootDir
  * @property {string} name
- *
  */
 
 /**
@@ -631,20 +644,20 @@ function sortBy(getterFn) {
 /**
  * @typedef PrintMissingPoliciesIfAnyOpts
  * @property {string[]} [missingPolicies]
- * @property {Map<string,unknown[]>} [packagesWithScripts]
+ * @property {Map<string, unknown[]>} [packagesWithScripts]
  */
 
 /**
  * @typedef PkgLavamoatConfig
- * @property {Record<string,any>} [allowScripts]
- * @property {Record<string,any>} [allowBins]
- * @property {Record<string,any>} [allowConfig]
- * @property {Record<string,any>} [allowedPatterns]
- * @property {Record<string,any>} [disallowedPatterns]
- * @property {Record<string,any>} [missingPolicies]
- * @property {Record<string,any>} [excessPolicies]
+ * @property {Record<string, any>} [allowScripts]
+ * @property {Record<string, any>} [allowBins]
+ * @property {Record<string, any>} [allowConfig]
+ * @property {Record<string, any>} [allowedPatterns]
+ * @property {Record<string, any>} [disallowedPatterns]
+ * @property {Record<string, any>} [missingPolicies]
+ * @property {Record<string, any>} [excessPolicies]
  */
 
 /**
- * @typedef {import('type-fest').PackageJson & {lavamoat: PkgLavamoatConfig}} LavamoatPackageJson
+ * @typedef {import('type-fest').PackageJson & { lavamoat: PkgLavamoatConfig }} LavamoatPackageJson
  */

--- a/packages/allow-scripts/src/linker.js
+++ b/packages/allow-scripts/src/linker.js
@@ -3,15 +3,22 @@
 
 const binTarget = require('bin-links/lib/bin-target.js')
 const isWindows = require('bin-links/lib/is-windows.js')
-const linkBin = isWindows ? require('bin-links/lib/shim-bin.js') : require('bin-links/lib/link-bin.js')
-
+const linkBin = isWindows
+  ? require('bin-links/lib/shim-bin.js')
+  : require('bin-links/lib/link-bin.js')
 
 const { dirname, resolve, relative } = require('path')
 
 /**
  * @param {LinkBinOpts} opts
  */
-const linkBinRelative = ({ path, bin, link, top = undefined, force = true }) => {
+const linkBinRelative = ({
+  path,
+  bin,
+  link,
+  top = undefined,
+  force = true,
+}) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
   const absFrom = resolve(path, link)
@@ -22,7 +29,13 @@ const linkBinRelative = ({ path, bin, link, top = undefined, force = true }) => 
 /**
  * @param {LinkBinOpts} opts
  */
-const linkBinAbsolute = ({ path, bin, link, top = undefined, force = true }) => {
+const linkBinAbsolute = ({
+  path,
+  bin,
+  link,
+  top = undefined,
+  force = true,
+}) => {
   const target = binTarget({ path, top })
   const to = resolve(target, bin)
   const absFrom = link

--- a/packages/allow-scripts/src/setup.js
+++ b/packages/allow-scripts/src/setup.js
@@ -36,7 +36,6 @@ module.exports = {
 }
 
 /**
- *
  * @param {string} filename
  * @returns {string}
  */
@@ -46,7 +45,6 @@ function addInstallParentDir(filename) {
 }
 
 /**
- *
  * @param {string} entry
  * @param {string} file
  * @returns {boolean}
@@ -61,7 +59,6 @@ function isEntryPresent(entry, file) {
 }
 
 /**
- *
  * @param {WriteRcFileContentOpts} param0
  */
 function writeRcFileContent({ file, entry }) {
@@ -83,7 +80,6 @@ function writeRcFileContent({ file, entry }) {
 let binsBlockedMemo
 
 /**
- *
  * @param {AreBinsBlockedOpts} args
  * @returns {boolean}
  */
@@ -198,5 +194,5 @@ function editPackageJson() {
 
 /**
  * @typedef AreBinsBlockedOpts
- * @property {boolean} [noMemoization] turn off memoization, make a fresh lookup
+ * @property {boolean} [noMemoization] Turn off memoization, make a fresh lookup
  */

--- a/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/bin-target.d.ts
@@ -1,12 +1,12 @@
 declare module 'bin-links/lib/bin-target.js' {
   namespace binTarget {
     interface BinTargetOptions {
-      top?: string;
-      path: string;
+      top?: string
+      path: string
     }
   }
 
-  function binTarget(opts: binTarget.BinTargetOptions): string;
+  function binTarget(opts: binTarget.BinTargetOptions): string
 
-  export = binTarget;
+  export = binTarget
 }

--- a/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/link-bin.d.ts
@@ -1,15 +1,15 @@
 declare module 'bin-links/lib/link-bin.js' {
   namespace linkBin {
     interface LinkBinOptions {
-      path: string;
-      from: string;
-      to: string;
-      absFrom: string;
-      force: boolean;
+      path: string
+      from: string
+      to: string
+      absFrom: string
+      force: boolean
     }
   }
 
-  function linkBin(opts: linkBin.LinkBinOptions): Promise<boolean>;
+  function linkBin(opts: linkBin.LinkBinOptions): Promise<boolean>
 
-  export = linkBin;
+  export = linkBin
 }

--- a/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
+++ b/packages/allow-scripts/src/types/bin-links/shim-bin.d.ts
@@ -1,15 +1,15 @@
 declare module 'bin-links/lib/shim-bin.js' {
   namespace shimBin {
     interface ShimBinOptions {
-      path: string;
-      from: string;
-      to: string;
-      absFrom: string;
-      force: boolean;
+      path: string
+      from: string
+      to: string
+      absFrom: string
+      force: boolean
     }
   }
 
-  function shimBin(opts: shimBin.ShimBinOptions): Promise<boolean>;
+  function shimBin(opts: shimBin.ShimBinOptions): Promise<boolean>
 
-  export = shimBin;
+  export = shimBin
 }

--- a/packages/allow-scripts/src/types/npmcli__run-script.d.ts
+++ b/packages/allow-scripts/src/types/npmcli__run-script.d.ts
@@ -16,7 +16,7 @@ declare module '@npmcli/run-script' {
   }
 
   function npmRunScript(
-    opts: npmRunScript.RunScriptOptions,
+    opts: npmRunScript.RunScriptOptions
   ): ReturnType<typeof PromiseSpawn>
 
   export = npmRunScript

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -35,11 +35,16 @@ function endowmentsToolkit({
   }
 
   /**
-   * Creates an object populated with only the deep properties specified in the packagePolicy
+   * Creates an object populated with only the deep properties specified in the
+   * packagePolicy
+   *
    * @param {object} sourceRef - Object from which to copy properties
-   * @param {LMPolicy.PackagePolicy} packagePolicy - LavaMoat policy item representing a package
-   * @param {object} unwrapTo - For getters and setters, when the this-value is unwrapFrom, is replaced as unwrapTo
-   * @param {object} unwrapFrom - For getters and setters, the this-value to replace (default: targetRef)
+   * @param {LMPolicy.PackagePolicy} packagePolicy - LavaMoat policy item
+   *   representing a package
+   * @param {object} unwrapTo - For getters and setters, when the this-value is
+   *   unwrapFrom, is replaced as unwrapTo
+   * @param {object} unwrapFrom - For getters and setters, the this-value to
+   *   replace (default: targetRef)
    * @returns {object} - The targetRef
    */
   function getEndowmentsForConfig(
@@ -95,7 +100,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {object} sourceRef
    * @param {string[]} paths
    * @param {object} unwrapTo
@@ -140,7 +144,7 @@ function endowmentsToolkit({
 
   /**
    * @template T
-   * @param {T|null} value
+   * @param {T | null} value
    * @returns {value is null}
    */
   function isEmpty(value) {
@@ -148,7 +152,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {string} visitedPath
    * @param {string[]} pathParts
    * @param {string[]} explicitlyBanned
@@ -279,9 +282,8 @@ function endowmentsToolkit({
     Reflect.defineProperty(targetRef, nextPart, newPropDesc)
 
     /**
-     *
      * @param {TypedPropertyDescriptor<any>} sourcePropDesc
-     * @returns {{sourceValue: any, sourceWritable: boolean|undefined}}
+     * @returns {{ sourceValue: any; sourceWritable: boolean | undefined }}
      */
     function getSourceValue(sourcePropDesc) {
       // determine the source value, this coerces getters to values
@@ -304,7 +306,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {PropertyDescriptor} propDesc
    * @param {object} unwrapFromCompartmentGlobalThis
    * @param {object} unwrapToGlobalThis
@@ -330,7 +331,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {PropertyDescriptor} sourcePropDesc
    * @param {object} unwrapFromGlobalThis
    * @param {object} unwrapToGlobalThis
@@ -396,7 +396,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {PropertyDescriptor} propDesc
    * @param {object} unwrapFromCompartmentGlobalThis
    * @param {object} unwrapToGlobalThis
@@ -429,13 +428,12 @@ function endowmentsToolkit({
   }
 
   /**
-   *
-   * @param {object|null} target
+   * @param {object | null} target
    * @param {PropertyKey} key
-   * @returns {{prop: PropertyDescriptor|null, receiver: object|null}}
+   * @returns {{ prop: PropertyDescriptor | null; receiver: object | null }}
    */
   function getPropertyDescriptorDeep(target, key) {
-    /** @type {object|null} */
+    /** @type {object | null} */
     let receiver = target
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -461,7 +459,6 @@ function endowmentsToolkit({
   }
 
   /**
-   *
    * @param {object} globalRef
    * @param {Record<PropertyKey, any>} target
    * @param {string[]} globalThisRefs
@@ -538,8 +535,9 @@ function endowmentsToolkit({
   }
 
   /**
-   * util for getting the prototype chain as an array
-   * includes the provided value in the result
+   * Util for getting the prototype chain as an array includes the provided
+   * value in the result
+   *
    * @param {any} value
    * @returns {any[]}
    */
@@ -563,8 +561,8 @@ function endowmentsToolkit({
 function defaultCreateFunctionWrapper(sourceValue, unwrapTest, unwrapTo) {
   /**
    * @param {...any[]} args
-   * @this {object}
    * @returns {any}
+   * @this {object}
    */
   const newValue = function (...args) {
     if (new.target) {

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -23,7 +23,6 @@ const rootSlug = '$root$'
 module.exports = { rootSlug, createModuleInspector, getDefaultPaths }
 
 /**
- *
  * @param {ModuleInspectorOptions} opts
  * @returns {ModuleInspector}
  */
@@ -108,7 +107,6 @@ function createModuleInspector(opts) {
   }
 
   /**
-   *
    * @param {AST} ast
    * @returns {ast is import('@babel/parser').ParseResult<import('@babel/types').File>}
    */
@@ -117,7 +115,6 @@ function createModuleInspector(opts) {
   }
 
   /**
-   *
    * @param {import('./moduleRecord').LavamoatModuleRecord} moduleRecord
    * @param {ModuleInspectorOptions} opts
    */
@@ -158,8 +155,8 @@ function createModuleInspector(opts) {
     }
     // get ast (parse or use cached)
     /**
-     * @todo - Put this in `LavamoatModuleRecord` instead
      * @type {AST}
+     * @todo - Put this in `LavamoatModuleRecord` instead
      */
     const ast =
       moduleRecord.ast ||
@@ -190,7 +187,6 @@ function createModuleInspector(opts) {
   }
 
   /**
-   *
    * @param {AST} ast
    * @param {import('./moduleRecord').LavamoatModuleRecord} moduleRecord
    * @param {boolean} includeDebugInfo
@@ -249,7 +245,6 @@ function createModuleInspector(opts) {
   }
 
   /**
-   *
    * @param {AST} ast
    * @param {import('./moduleRecord').LavamoatModuleRecord} moduleRecord
    * @param {string} packageName
@@ -283,7 +278,6 @@ function createModuleInspector(opts) {
   }
 
   /**
-   *
    * @param {AST} ast
    * @param {import('./moduleRecord').LavamoatModuleRecord} moduleRecord
    * @param {string} packageName
@@ -326,7 +320,10 @@ function createModuleInspector(opts) {
   function generatePolicy({ policyOverride, includeDebugInfo = false }) {
     /** @type {import('./schema').Resources} */
     const resources = {}
-    /** @type {import('./schema').LavaMoatPolicyDebug | import('./schema').LavaMoatPolicy} */
+    /**
+     * @type {import('./schema').LavaMoatPolicyDebug
+     *   | import('./schema').LavaMoatPolicy}
+     */
     const policy = { resources }
     packageToModules.forEach((packageModules, packageName) => {
       // the policy fields for each package
@@ -416,8 +413,16 @@ function createModuleInspector(opts) {
 }
 
 /**
- *
- * @param {{packageModules: Record<string,import('./moduleRecord').LavamoatModuleRecord>, moduleIdToModuleRecord: Map<string,import('./moduleRecord').LavamoatModuleRecord>}} opts
+ * @param {{
+ *   packageModules: Record<
+ *     string,
+ *     import('./moduleRecord').LavamoatModuleRecord
+ *   >
+ *   moduleIdToModuleRecord: Map<
+ *     string,
+ *     import('./moduleRecord').LavamoatModuleRecord
+ *   >
+ * }} opts
  * @returns
  */
 function aggregateDeps({ packageModules, moduleIdToModuleRecord }) {
@@ -454,8 +459,9 @@ function aggregateDeps({ packageModules, moduleIdToModuleRecord }) {
 }
 
 /**
- * For when you encounter a `requestedName` that was not inspected, likely because
- * resolution was skipped for that module
+ * For when you encounter a `requestedName` that was not inspected, likely
+ * because resolution was skipped for that module
+ *
  * @param {string} requestedName
  * @returns {string}
  */
@@ -474,7 +480,6 @@ function guessPackageName(requestedName) {
 }
 
 /**
- *
  * @param {string} policyName
  * @returns
  */
@@ -492,8 +497,11 @@ function getDefaultPaths(policyName) {
 
 /**
  * @callback GeneratePolicyFn
- * @param {Partial<ModuleInspectorOptions> & {policyOverride?: import('./schema').LavaMoatPolicyOverrides}} opts
- * @returns {import('./schema').LavaMoatPolicy | import('./schema').LavaMoatPolicyDebug}
+ * @param {Partial<ModuleInspectorOptions> & {
+ *   policyOverride?: import('./schema').LavaMoatPolicyOverrides
+ * }} opts
+ * @returns {import('./schema').LavaMoatPolicy
+ *   | import('./schema').LavaMoatPolicyDebug}
  */
 
 /**
@@ -519,5 +527,6 @@ function getDefaultPaths(policyName) {
  */
 
 /**
- * @typedef {import('@babel/parser').ParseResult<import('@babel/types').File> | import('@babel/types').File} AST
+ * @typedef {import('@babel/parser').ParseResult<import('@babel/types').File>
+ *   | import('@babel/types').File} AST
  */

--- a/packages/core/src/loadPolicy.js
+++ b/packages/core/src/loadPolicy.js
@@ -10,7 +10,7 @@ module.exports = { loadPolicy, loadPolicyAndApplyOverrides }
  * Reads a policy file from disk, if present
  *
  * @param {PolicyOpts} opts
- * @returns {Promise<import('./schema').LavaMoatPolicy|undefined>}
+ * @returns {Promise<import('./schema').LavaMoatPolicy | undefined>}
  */
 async function readPolicyFile({ debugMode, policyPath }) {
   if (debugMode) {
@@ -31,9 +31,12 @@ async function readPolicyFile({ debugMode, policyPath }) {
 /**
  * Loads a policy from disk, returning a default empty policy if not found.
  *
- * @todo Because there is no validation taking place, the resulting value could be literally anything `JSON.parse()` could return. Also note that this returns a `LavaMoatPolicy` when we could be asking for a `LavaMoatPolicyOverrides`; make your type assertions accordingly!
  * @param {PolicyOpts} opts
  * @returns {Promise<import('./schema').LavaMoatPolicy>}
+ * @todo Because there is no validation taking place, the resulting value could
+ *   be literally anything `JSON.parse()` could return. Also note that this
+ *   returns a `LavaMoatPolicy` when we could be asking for a
+ *   `LavaMoatPolicyOverrides`; make your type assertions accordingly!
  */
 async function loadPolicy({ debugMode, policyPath }) {
   /** @type {import('./schema').LavaMoatPolicy} */
@@ -56,7 +59,7 @@ async function loadPolicy({ debugMode, policyPath }) {
  *
  * If overrides exist, writes the overrides _back_ into the policy file.
  *
- * @param {PolicyOpts & {policyOverridePath: string}} opts
+ * @param {PolicyOpts & { policyOverridePath: string }} opts
  * @returns {Promise<import('./schema').LavaMoatPolicy>}
  */
 async function loadPolicyAndApplyOverrides({
@@ -67,7 +70,7 @@ async function loadPolicyAndApplyOverrides({
   const policy = await loadPolicy({ debugMode, policyPath })
 
   const policyOverride =
-    /** @type {import('./schema').LavaMoatPolicyOverrides|undefined} */ (
+    /** @type {import('./schema').LavaMoatPolicyOverrides | undefined} */ (
       await readPolicyFile({ debugMode, policyPath: policyOverridePath })
     )
 

--- a/packages/core/src/makeGeneralUtils.js
+++ b/packages/core/src/makeGeneralUtils.js
@@ -1,7 +1,8 @@
 module.exports = makeGeneralUtils
 
 /**
- * @deprecated - inlined in endowmentsToolkit (see core/src/endowmentsToolkit.js)
+ * @deprecated - Inlined in endowmentsToolkit (see
+ *   core/src/endowmentsToolkit.js)
  */
 function makeGeneralUtils() {
   return {

--- a/packages/core/src/moduleRecord.js
+++ b/packages/core/src/moduleRecord.js
@@ -2,7 +2,6 @@
 
 class LavamoatModuleRecord {
   /**
-   *
    * @param {LavamoatModuleRecordOptions} opts
    */
   constructor({
@@ -32,12 +31,13 @@ module.exports = { LavamoatModuleRecord }
  * @typedef LavamoatModuleRecordOptions
  * @property {string} specifier
  * @property {string} file
- * @property {'builtin'|'native'|'js'} type
+ * @property {'builtin' | 'native' | 'js'} type
  * @property {string} packageName
  * @property {string} [content]
  * @property {Record<string, string>} [importMap]
  * @property {import('@babel/types').File} [ast]
  * @property {(...args: any[]) => any} [moduleInitializer]
  * @todo `moduleInitializer` probably needs narrowing
+ *
  * @todo `@babel/types` should be a prod dep
  */

--- a/packages/core/src/parseForPolicy.js
+++ b/packages/core/src/parseForPolicy.js
@@ -7,7 +7,7 @@ module.exports = { parseForPolicy }
 
 /**
  * @param {ParseForPolicyOpts} opts
- * @returns {Promise<import('./schema').LavaMoatPolicy>} policy object
+ * @returns {Promise<import('./schema').LavaMoatPolicy>} Policy object
  */
 async function parseForPolicy({
   moduleSpecifier,
@@ -54,7 +54,7 @@ async function parseForPolicy({
  * @callback ResolveFn
  * @param {string} requestedName
  * @param {string} parentAddress
- * @returns {string|undefined}
+ * @returns {string | undefined}
  */
 
 /**
@@ -70,7 +70,6 @@ async function parseForPolicy({
  */
 
 /**
- *
  * @param {ParseForPolicyOpts} opts
- * @returns {Promise<import('./schema').LavaMoatPolicySchema>} policy object
+ * @returns {Promise<import('./schema').LavaMoatPolicySchema>} Policy object
  */

--- a/packages/core/src/schema/lavamoat-policy.v0-0-1.schema.ts
+++ b/packages/core/src/schema/lavamoat-policy.v0-0-1.schema.ts
@@ -22,13 +22,13 @@ export interface PartialLavaMoatPolicy {
 export interface DebugInfo {
   /**
    * @todo This is an array of `@babel/parser`'s `ParseError`. To use it
-   * directly we'd need to add `@babel/parser` as a production dependency of
-   * `lavamoat-tofu`, and I don't want to do that right now.
+   *   directly we'd need to add `@babel/parser` as a production dependency of
+   *   `lavamoat-tofu`, and I don't want to do that right now.
    */
   parseErrors?: { code: string; reasonCode: string }[]
   moduleRecord: Omit<LavamoatModuleRecord, 'ast'>
   /**
-   * @todo move these types into lavamoat-tofu
+   * @todo Move these types into lavamoat-tofu
    */
   sesCompat: SesCompat
   globals: Record<string, boolean>
@@ -79,21 +79,24 @@ export interface ResourcePolicy {
 }
 
 /**
- * Globals (including properties using dot notation) accessible to the module; `true` to allow and `false` to deny
+ * Globals (including properties using dot notation) accessible to the module;
+ * `true` to allow and `false` to deny
  */
 export interface GlobalPolicy {
   [k: string]: boolean
 }
 
 /**
- * Node.js builtins (including properties using dot notation); `true` to allow and `false` to deny
+ * Node.js builtins (including properties using dot notation); `true` to allow
+ * and `false` to deny
  */
 export interface BuiltinPolicy {
   [k: string]: boolean
 }
 
 /**
- * Additional external packages (in their entirety) accessible to the module; `true` to allow and `false` to deny
+ * Additional external packages (in their entirety) accessible to the module;
+ * `true` to allow and `false` to deny
  */
 export interface PackagePolicy {
   [k: string]: boolean

--- a/packages/core/src/walk.js
+++ b/packages/core/src/walk.js
@@ -43,7 +43,9 @@ async function walk({
  * @param {import('./parseForPolicy').ImportHookFn} options.importHook
  * @param {import('./parseForPolicy').ShouldImportFn} [options.shouldImport]
  * @param {Set<string>} [options.visitedSpecifiers]
- * @returns {AsyncIterableIterator<import('./moduleRecord').LavamoatModuleRecord>}
+ * @returns {AsyncIterableIterator<
+ *   import('./moduleRecord').LavamoatModuleRecord
+ * >}
  */
 // NOTE: i think this is depth first in a way that doesnt take advantage of concurrency
 async function* eachNodeInTree({

--- a/packages/tofu/src/ses-whitelist.js
+++ b/packages/tofu/src/ses-whitelist.js
@@ -1,18 +1,14 @@
 // modified from https://github.com/Agoric/SES-shim/blob/aefefbfcbe53f5b4520542bfb4da14dd68f13ec6/packages/ses/src/whitelist.js
 
 /**
- * @fileoverview Exports {@code whitelist}, a recursively defined
- * JSON record enumerating all intrinsics and their properties
- * according to ECMA specs.
- *
+ * @file Exports {@code whitelist}, a recursively defined JSON record
+ *   enumerating all intrinsics and their properties according to ECMA specs.
  * @author JF Paradis
  */
 
 /**
  * <p>Each JSON record enumerates the disposition of the properties on
- *    some corresponding intrinsic object.
- *
- * <p>All records are made of key-value pairs where the key
+ *    some corresponding intrinsic object.<p>All records are made of key-value pairs where the key
  *    is the property to process, and the value is the associated
  *    dispositions a.k.a. the "permit". Those permits can be:
  * <ul>
@@ -34,9 +30,7 @@
  *     whitelisted and that next record represents the disposition of
  *     the object which is its value. For example, {@code "Object"}
  *     leads to another record explaining what properties {@code
- *     "Object"} may have and how each such property should be treated.
- *
- * <p>Notes:
+ *     "Object"} may have and how each such property should be treated.<p>Notes:
  * <li>"**proto**" is used to refer to "__proto__" without creating
  *     an actual prototype.
  * <li>"ObjectPrototype" is the default "**proto**" (when not specified).

--- a/packages/webpack/src/buildtime/aa.js
+++ b/packages/webpack/src/buildtime/aa.js
@@ -18,7 +18,7 @@ const lookUp = (needle, haystack) => {
 
 /**
  * @param {Set<string>} neededIds
- * @param {Array<string>} policyIds
+ * @param {string[]} policyIds
  */
 const crossReference = (neededIds, policyIds) => {
   // Policy generator skips packages that don't use anything, so it's ok for policy to be missing.
@@ -34,7 +34,7 @@ const crossReference = (neededIds, policyIds) => {
   if (missingIds.length > 0) {
     diag.rawDebug(
       1,
-      `Policy is missing the following resources: ${missingIds.join(', ')}`,
+      `Policy is missing the following resources: ${missingIds.join(', ')}`
     )
   }
 }
@@ -62,7 +62,7 @@ exports.generateIdentifierLookup = ({
   const usedIdentifiers = Object.keys(policy.resources)
   usedIdentifiers.unshift(ROOT_IDENTIFIER)
   const usedIdentifiersIndex = Object.fromEntries(
-    usedIdentifiers.map((id, index) => [id, index]),
+    usedIdentifiers.map((id, index) => [id, index])
   )
   // choose the implementation - to translate from AA to numbers or not
   let translate
@@ -78,7 +78,7 @@ exports.generateIdentifierLookup = ({
 
   const pathLookup = pathsToIdentifiers(paths)
   const identifiersWithKnownPaths = new Set(
-    Object.values(pathLookup).map((pl) => pl.aa),
+    Object.values(pathLookup).map((pl) => pl.aa)
   )
 
   crossReference(identifiersWithKnownPaths, usedIdentifiers)
@@ -91,7 +91,7 @@ exports.generateIdentifierLookup = ({
       }
       acc[key].push(moduleId)
       return acc
-    }, {}),
+    }, {})
   )
 
   const translateResource = (resource) => ({
@@ -102,7 +102,7 @@ exports.generateIdentifierLookup = ({
         Object.entries(resource.packages).map(([id, value]) => [
           translate(id),
           value,
-        ]),
+        ])
       ),
   })
 
@@ -130,7 +130,7 @@ exports.generateIdentifierLookup = ({
             .map(([id, resource]) => [
               translate(id),
               translateResource(resource),
-            ]),
+            ])
         ),
       }
       return translatedPolicy

--- a/packages/webpack/src/buildtime/assemble.js
+++ b/packages/webpack/src/buildtime/assemble.js
@@ -1,4 +1,4 @@
-const {readFileSync} = require('fs')
+const { readFileSync } = require('fs')
 
 function removeMultilineComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, '')

--- a/packages/webpack/src/buildtime/diagnostics.js
+++ b/packages/webpack/src/buildtime/diagnostics.js
@@ -7,7 +7,6 @@ module.exports = {
     return level
   },
   /**
-   *
    * @param {number} verbosity
    * @param {function} cb
    */
@@ -17,7 +16,6 @@ module.exports = {
     }
   },
   /**
-   *
    * @param {number} verbosity
    * @param {any} content
    */

--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-/** @typedef {import("webpack").Generator} Generator */
-/** @typedef {import("webpack").NormalModule} NormalModule */
-/** @typedef {import("webpack").sources.Source} Source */
+/** @typedef {import('webpack').Generator} Generator */
+/** @typedef {import('webpack').NormalModule} NormalModule */
+/** @typedef {import('webpack').sources.Source} Source */
 
 const path = require('path')
 const {
@@ -20,7 +20,6 @@ const EXCLUDE_LOADER = path.join(__dirname, '../excludeLoader.js')
 // TODO: processing requirements needs to be a tiny bit more clever yet.
 // Look in JavascriptModulesPlugin for how it decides if module and exports are unused.
 /**
- *
  * @param {Set<string>} requirements
  * @param {NormalModule} module
  * @returns
@@ -57,7 +56,6 @@ function processRequirements(requirements, module) {
   return runtimeKit
 }
 
-
 // Use a weakset to mark generatorInstance as wrapped,
 // this is to avoid wrapping the same instance twice
 const wrappedGeneratorInstances = new WeakSet()
@@ -86,9 +84,8 @@ exports.wrapGeneratorMaker = ({
     }
     const originalGenerate = generatorInstance.generate
     /**
-     *
      * @param {NormalModule} module
-     * @param {*} options - GeneratorOptions type not exported fromw ebpack
+     * @param {any} options - GeneratorOptions type not exported fromw ebpack
      * @returns {Source}
      */
     generatorInstance.generate = function (module, options) {
@@ -97,7 +94,7 @@ exports.wrapGeneratorMaker = ({
         options,
       })
 
-      const originalGeneratedSource =originalGenerate.apply(this, arguments)
+      const originalGeneratedSource = originalGenerate.apply(this, arguments)
 
       // bail out if we're dealing with a subcompilation from a plugin and such - they may run too early
       if (!PROGRESS.done('pathsProcessed')) {
@@ -106,9 +103,12 @@ exports.wrapGeneratorMaker = ({
 
       // skip doing anything if marked as excluded by the excludeLoader,
       // only accept exclude loader from config, not inline.
-      // Inline loader definition uses a `!` character as a loader separator. 
+      // Inline loader definition uses a `!` character as a loader separator.
       // Defining what to exclude should only be possible in the config.
-      if (module.loaders.some(({ loader }) => loader === EXCLUDE_LOADER) && !module.rawRequest.includes('!')) {
+      if (
+        module.loaders.some(({ loader }) => loader === EXCLUDE_LOADER) &&
+        !module.rawRequest.includes('!')
+      ) {
         excludes.push(module.rawRequest)
         diag.rawDebug(3, `skipped wrapping ${module.rawRequest}`)
         return originalGeneratedSource
@@ -132,7 +132,7 @@ exports.wrapGeneratorMaker = ({
             console.warn(
               'Attempted to set strict mode on module',
               module.rawRequest,
-              Error().stack,
+              Error().stack
             )
           },
         })
@@ -168,11 +168,7 @@ exports.wrapGeneratorMaker = ({
       if (sourceChanged) {
         return new ConcatSource(before, source, after)
       } else {
-        return new ConcatSource(
-          before,
-          originalGeneratedSource,
-          after,
-        )
+        return new ConcatSource(before, originalGeneratedSource, after)
       }
     }
     wrappedGeneratorInstances.add(generatorInstance)

--- a/packages/webpack/src/buildtime/progress.js
+++ b/packages/webpack/src/buildtime/progress.js
@@ -3,10 +3,15 @@ const diag = require('./diagnostics')
 
 /**
  * @typedef {object} ProgressAPI
- * @property {(expectedStep: string) => boolean} is - checks if current progress matches expectedStep
- * @property {(expectedStep: string) => boolean} done - checks if expectedStep was already reported.
- * @property {(expectedStep: string) => void} assertDone - throws if expectedStep was not already reported.
- * @property {(step: string) => void} report - moves progress forward if step passed is the next step. no-op if current step (reporting progress is idempotent)
+ * @property {(expectedStep: string) => boolean} is - Checks if current progress
+ *   matches expectedStep
+ * @property {(expectedStep: string) => boolean} done - Checks if expectedStep
+ *   was already reported.
+ * @property {(expectedStep: string) => void} assertDone - Throws if
+ *   expectedStep was not already reported.
+ * @property {(step: string) => void} report - Moves progress forward if step
+ *   passed is the next step. no-op if current step (reporting progress is
+ *   idempotent)
  */
 
 /**
@@ -41,7 +46,7 @@ module.exports = function progress({ steps }) {
       throw Error(
         `LavaMoatPlugin Plugin: Progress reported '${step}' but the next step was expected to be '${
           steps[currentStep + 1]
-        }'`,
+        }'`
       )
     } else {
       diag.rawDebug(1, `\n> progress ${steps[currentStep]}->${step}`)
@@ -64,7 +69,7 @@ module.exports = function progress({ steps }) {
       return
     }
     throw Error(
-      `LavaMoatPlugin Plugin: Expected '${query}' to be done, but we're at '${steps[currentStep]}'`,
+      `LavaMoatPlugin Plugin: Expected '${query}' to be done, but we're at '${steps[currentStep]}'`
     )
   }
   return API

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -10,15 +10,22 @@ const q = JSON.stringify
  * @property {string[] | Set<string>} runtimeKit
  * @property {string} evalKitFunctionName
  * @property {boolean} [runChecks]
- *
  */
 
-const { NAME_globalThis, NAME_scopeTerminator, NAME_runtimeHandler } = require('../ENUM.json')
+const {
+  NAME_globalThis,
+  NAME_scopeTerminator,
+  NAME_runtimeHandler,
+} = require('../ENUM.json')
 
 /**
- *
  * @param {WrappingInput} params
- * @returns {{before: string, after: string, source: string, sourceChanged: boolean}}
+ * @returns {{
+ *   before: string
+ *   after: string
+ *   source: string
+ *   sourceChanged: boolean
+ * }}
  */
 exports.wrapper = function wrapper({
   source,
@@ -49,9 +56,9 @@ exports.wrapper = function wrapper({
       }
     }
     }
-}).call(${evalKitFunctionName}(${q(id)}, { ${Array.from(
-  runtimeKit,
-).join(',')}}))()`
+}).call(${evalKitFunctionName}(${q(id)}, { ${Array.from(runtimeKit).join(
+    ','
+  )}}))()`
   if (runChecks) {
     validateSource(before + sesCompatibleSource + after)
   }
@@ -72,11 +79,15 @@ function validateSource(source) {
   } catch (e) {
     if (e !== validityFlag) {
       diag.run(1, () => {
-        fs.writeFileSync(validityFlag + '.js', source+`
+        fs.writeFileSync(
+          validityFlag + '.js',
+          source +
+            `
 /*
 ${e}
 */
-        `)
+        `
+        )
       })
       throw Error(validityFlag + 'wrapped module is not valid JS\n' + e)
     }

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -53,7 +53,7 @@ const lockdownDefaults = {
 
 class LavaMoatPlugin {
   /**
-   * @param {import("./types.js").LavaMoatPluginOptions} [options]
+   * @param {import('./types.js').LavaMoatPluginOptions} [options]
    */
   constructor(options = { policy: {} }) {
     if (!options.lockdown) {
@@ -64,7 +64,7 @@ class LavaMoatPlugin {
     diag.level = options.diagnosticsVerbosity || 0
   }
   /**
-   * @param {import("webpack").Compiler} compiler the compiler instance
+   * @param {import('webpack').Compiler} compiler The compiler instance
    * @returns {void}
    */
   apply(compiler) {

--- a/packages/webpack/src/runtime/runtime.d.ts
+++ b/packages/webpack/src/runtime/runtime.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="ses" />
 
-declare const LAVAMOAT: import('../types.js').RuntimeNamespace;
+declare const LAVAMOAT: import('../types.js').RuntimeNamespace

--- a/packages/webpack/src/types.js
+++ b/packages/webpack/src/types.js
@@ -1,37 +1,49 @@
 /**
  * @typedef {Object} Policy
- * @property {Record<string,object>} resources
+ * @property {Record<string, object>} resources
  */
 
 /**
  * @typedef {Object} LavaMoatPluginOptions
- * @property {boolean} [runChecks] - check resulting code with wrapping for correctness
- * @property {boolean} [readableResourceIds] - should resourceIds be readable or turned into numbers - defaults to (mode==='development')
- * @property {boolean} [HtmlWebpackPluginInterop] - add a script tag to the html output for lockdown.js if HtmlWebpackPlugin is in use
- * @property {number} [diagnosticsVerbosity] - a number representing diagnostics output verbosity, the larger the more overwhelming
+ * @property {boolean} [runChecks] - Check resulting code with wrapping for
+ *   correctness
+ * @property {boolean} [readableResourceIds] - Should resourceIds be readable or
+ *   turned into numbers - defaults to (mode==='development')
+ * @property {boolean} [HtmlWebpackPluginInterop] - Add a script tag to the html
+ *   output for lockdown.js if HtmlWebpackPlugin is in use
+ * @property {number} [diagnosticsVerbosity] - A number representing diagnostics
+ *   output verbosity, the larger the more overwhelming
  * @property {Object} policy - LavaMoat policy
- * @property {Object} [lockdown] - options to pass to lockdown
+ * @property {Object} [lockdown] - Options to pass to lockdown
  */
 
 /**
- * @callback GetEndowmentsForConfig Creates an object populated with only the deep properties specified in the packagePolicy
+ * @callback GetEndowmentsForConfig Creates an object populated with only the
+ *   deep properties specified in the packagePolicy
  * @param {object} sourceRef - Object from which to copy properties
  * @param {object} packagePolicy - LavaMoat policy item representing a package
- * @param {object} unwrapTo - For getters and setters, when the this-value is unwrapFrom, is replaced as unwrapTo
- * @param {object} unwrapFrom - For getters and setters, the this-value to replace (default: targetRef)
- * @return {object} - The targetRef
- *
+ * @param {object} unwrapTo - For getters and setters, when the this-value is
+ *   unwrapFrom, is replaced as unwrapTo
+ * @param {object} unwrapFrom - For getters and setters, the this-value to
+ *   replace (default: targetRef)
+ * @returns {object} - The targetRef
  */
 
 /**
  * @typedef {Object} EndowmentsToolkit
  * @property {GetEndowmentsForConfig} getEndowmentsForConfig
- * @property {(...args: any[]) => unknown} makeMinimalViewOfRef - Creates a minimal view of a reference (e.g. a global) that only exposes the properties specified in the packagePolicy
- * @property {(...args: any[]) => unknown} copyValueAtPath - Copies a value at a specific path from the source reference to the target reference
+ * @property {(...args: any[]) => unknown} makeMinimalViewOfRef - Creates a
+ *   minimal view of a reference (e.g. a global) that only exposes the
+ *   properties specified in the packagePolicy
+ * @property {(...args: any[]) => unknown} copyValueAtPath - Copies a value at a
+ *   specific path from the source reference to the target reference
  * @property {(...args: any[]) => unknown} applyGetSetPropDescTransforms
  * @property {(...args: any[]) => unknown} applyEndowmentPropDescTransforms
- * @property {(...args: any[]) => unknown} copyWrappedGlobals - Copies wrapped globals from a global reference to a target object with wrapping
- * @property {(...args: any[]) => unknown} createFunctionWrapper - conditionally binds a function - used to ensure functions (like fetch) get called on the this they expect
+ * @property {(...args: any[]) => unknown} copyWrappedGlobals - Copies wrapped
+ *   globals from a global reference to a target object with wrapping
+ * @property {(...args: any[]) => unknown} createFunctionWrapper - Conditionally
+ *   binds a function - used to ensure functions (like fetch) get called on the
+ *   this they expect
  */
 
 /**
@@ -41,14 +53,19 @@
 
 /**
  * @typedef {Object} RuntimeNamespace
- * @property {string} root - key used to indicate the root resource
- * @property {Array<[string, string[]]>} idmap - mapping from resourceIds to moduleIds
- * @property {string[]} unenforceable - List of module ids that are impossible to handle for import policy enforcement
- * @property {LavaMoatPluginOptions} options - plugin options
+ * @property {string} root - Key used to indicate the root resource
+ * @property {[string, string[]][]} idmap - Mapping from resourceIds to
+ *   moduleIds
+ * @property {string[]} unenforceable - List of module ids that are impossible
+ *   to handle for import policy enforcement
+ * @property {LavaMoatPluginOptions} options - Plugin options
  * @property {Policy} policy - LavaMoat policy
- * @property {Record<string, string>} ENUM - short names for items to minimize bundle size withotu losing readability
- * @property {EndowmentsToolkitFactory} endowmentsToolkit - a function that returns endowmentsToolkit
- * @property {(...args: any[]) => unknown} defaultExport - the function that will be surfaced to the wrapper as `__webpack_require__._LM_`
+ * @property {Record<string, string>} ENUM - Short names for items to minimize
+ *   bundle size withotu losing readability
+ * @property {EndowmentsToolkitFactory} endowmentsToolkit - A function that
+ *   returns endowmentsToolkit
+ * @property {(...args: any[]) => unknown} defaultExport - The function that
+ *   will be surfaced to the wrapper as `__webpack_require__._LM_`
  */
 
 module.exports = {}


### PR DESCRIPTION
This adds [prettier-plugin-jsdoc](https://npm.im/prettier-plugin-jsdoc) which formats all of our docstrings nicely. We have a lot of docstrings, so they should be nice!

The second commit reformats all `.js` and `.ts` files in `packages/*/src`, so you can see its effect.  