### PR TITLE
chore: fix package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "lavamoat-monorepo",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lavamoat/lavamoat.git"
+  },
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -4,7 +4,7 @@
   "description": "A tool for running only the dependency lifecycle hooks specified in an allowlist.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/LavaMoat.git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git",
     "directory": "packages/allow-scripts"
   },
   "homepage": "https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts",

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -4,7 +4,7 @@
   "description": "browserify plugin for sandboxing dependencies with LavaMoat",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/browserify"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "LavaMoat kernel and utils",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/core"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -4,7 +4,7 @@
   "description": "LavaMoat packer",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/lavapack"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/node"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/LavaMoat.git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git",
     "directory": "packages/perf"
   },
   "private": true,

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/LavaMoat.git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git",
     "directory": "packages/preinstall-always-fail"
   },
   "author": "",

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -4,7 +4,7 @@
   "description": "This is the TOFU (trust-on-first-use) static analysis tool used by LavaMoat to automatically generate useable config",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/tofu"
   },
   "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/tofu/README.md",

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -4,7 +4,7 @@
   "description": "This is a dashboard for exploring a dependency graph and LavaMoat policy file",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/viz"
   },
   "homepage": "https://github.com/LavaMoat/LavaMoat/blob/main/packages/viz/README.md",
@@ -17,7 +17,7 @@
     "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
   },
   "bin": {
-    "lavamoat-viz": "./bin/index.js"
+    "lavamoat-viz": "bin/index.js"
   },
   "main": "index.js",
   "files": [

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -4,7 +4,7 @@
   "description": "LavaMoat Webpack plugin for running dependencies in Compartments without eval",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/lavamoat.git",
+    "url": "git+https://github.com/LavaMoat/lavamoat.git",
     "directory": "packages/webpack"
   },
   "homepage": "https://github.com/LavaMoat/lavamoat#readme",

--- a/packages/yarn-plugin-allow-scripts/package.json
+++ b/packages/yarn-plugin-allow-scripts/package.json
@@ -4,7 +4,7 @@
   "description": "A Yarn plugin for running `@lavamoat/allow-scripts` after install",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LavaMoat/LavaMoat.git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git",
     "directory": "packages/yarn-plugin-allow-scripts"
   },
   "license": "MIT",


### PR DESCRIPTION
This is the result of running `npm pkg fix` (npm v10+) on each workspace `package.json` file. Also adds a missing `repository` field to the root workspace `package.json`.