### PR TITLE
chore(ci): fail if any VCS files changed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,8 +15,17 @@ jobs:
       matrix:
         node-version: [16.x, 18.x, 20.x]
     steps:
-      - name: Checkout
+      - name: Checkout (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      # fetch-depth: 0 looks like it has a perf impact, so let's not do that if we don't have to.
+      # see https://github.com/actions/checkout/blob/main/README.md#usage
+      - name: Checkout (Push)
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0 # needed for dirty check
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
@@ -31,6 +40,8 @@ jobs:
           install-command: npm ci --foreground-scripts
       - name: Test
         run: npm test
+      - name: Dirty Check
+        run: node ./scripts/dirty-check.js
 
   lint:
     runs-on: ubuntu-latest

--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -12,9 +12,45 @@
     },
     "@babel/code-frame>@babel/highlight": {
       "packages": {
-        "@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
+        "@babel/code-frame>@babel/highlight>chalk": true,
         "@babel/code-frame>@babel/highlight>js-tokens": true,
-        "@babel/code-frame>chalk": true
+        "lavamoat-core>@babel/types>@babel/helper-validator-identifier": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
+        "@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
+        "@babel/code-frame>@babel/highlight>chalk>supports-color": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
+      "packages": {
+        "@babel/code-frame>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight>chalk>supports-color": {
+      "builtin": {
+        "os.release": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.versions.node.split": true
+      },
+      "packages": {
+        "@babel/code-frame>@babel/highlight>chalk>supports-color>has-flag": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
       }
     },
     "@babel/code-frame>chalk": {
@@ -89,10 +125,10 @@
       },
       "packages": {
         "@lavamoat/lavapack>combine-source-map": true,
-        "@lavamoat/lavapack>convert-source-map": true,
         "@lavamoat/lavapack>espree": true,
         "@lavamoat/lavapack>umd": true,
         "browserify>JSONStream": true,
+        "convert-source-map": true,
         "json-stable-stringify": true,
         "lavamoat-core": true,
         "readable-stream": true,
@@ -129,18 +165,6 @@
       },
       "packages": {
         "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true
-      }
-    },
-    "@lavamoat/lavapack>convert-source-map": {
-      "builtin": {
-        "fs.readFileSync": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "value": true
       }
     },
     "@lavamoat/lavapack>espree": {
@@ -287,11 +311,16 @@
       "packages": {
         "browserify>browser-pack>safe-buffer": true,
         "browserify>browser-pack>through2>readable-stream>isarray": true,
+        "browserify>browser-pack>through2>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>browser-pack>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>browser-pack>safe-buffer": true
       }
     },
     "browserify>cached-path-relative": {
@@ -349,9 +378,9 @@
       "packages": {
         "browserify>deps-sort>through2>readable-stream>isarray": true,
         "browserify>deps-sort>through2>readable-stream>safe-buffer": true,
+        "browserify>deps-sort>through2>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -359,6 +388,11 @@
     "browserify>deps-sort>through2>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>deps-sort>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>deps-sort>through2>readable-stream>safe-buffer": true
       }
     },
     "browserify>duplexer2": {
@@ -383,9 +417,9 @@
       "packages": {
         "browserify>duplexer2>readable-stream>isarray": true,
         "browserify>duplexer2>readable-stream>safe-buffer": true,
+        "browserify>duplexer2>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -393,6 +427,11 @@
     "browserify>duplexer2>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>duplexer2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>duplexer2>readable-stream>safe-buffer": true
       }
     },
     "browserify>glob>path-is-absolute": {
@@ -449,9 +488,9 @@
       "packages": {
         "browserify>insert-module-globals>through2>readable-stream>isarray": true,
         "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true,
+        "browserify>insert-module-globals>through2>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -459,6 +498,11 @@
     "browserify>insert-module-globals>through2>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>insert-module-globals>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true
       }
     },
     "browserify>insert-module-globals>undeclared-identifiers": {
@@ -512,9 +556,9 @@
       "packages": {
         "browserify>labeled-stream-splicer>stream-splicer>readable-stream>isarray": true,
         "browserify>labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true,
+        "browserify>labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -522,6 +566,11 @@
     "browserify>labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true
       }
     },
     "browserify>module-deps": {
@@ -592,9 +641,9 @@
       "packages": {
         "browserify>module-deps>readable-stream>isarray": true,
         "browserify>module-deps>readable-stream>safe-buffer": true,
+        "browserify>module-deps>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -602,6 +651,11 @@
     "browserify>module-deps>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>module-deps>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>module-deps>readable-stream>safe-buffer": true
       }
     },
     "browserify>module-deps>stream-combiner2": {
@@ -627,9 +681,9 @@
       "packages": {
         "browserify>module-deps>stream-combiner2>readable-stream>isarray": true,
         "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true,
+        "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -637,6 +691,11 @@
     "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true
       }
     },
     "browserify>module-deps>through2": {
@@ -694,9 +753,9 @@
       "packages": {
         "browserify>read-only-stream>readable-stream>isarray": true,
         "browserify>read-only-stream>readable-stream>safe-buffer": true,
+        "browserify>read-only-stream>readable-stream>string_decoder": true,
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -704,6 +763,11 @@
     "browserify>read-only-stream>readable-stream>safe-buffer": {
       "builtin": {
         "buffer": true
+      }
+    },
+    "browserify>read-only-stream>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>read-only-stream>readable-stream>safe-buffer": true
       }
     },
     "browserify>readable-stream": {
@@ -724,8 +788,8 @@
         "browserify>readable-stream>core-util-is": true,
         "browserify>readable-stream>isarray": true,
         "browserify>readable-stream>process-nextick-args": true,
-        "browserify>readable-stream>safe-buffer": true,
         "browserify>string_decoder": true,
+        "browserify>string_decoder>safe-buffer": true,
         "duplexify>inherits": true,
         "readable-stream>util-deprecate": true
       }
@@ -738,11 +802,6 @@
     "browserify>readable-stream>process-nextick-args": {
       "globals": {
         "process": true
-      }
-    },
-    "browserify>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
       }
     },
     "browserify>resolve": {
@@ -873,6 +932,14 @@
         "Buffer": true
       }
     },
+    "convert-source-map": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "value": true
+      }
+    },
     "duplexify": {
       "globals": {
         "Buffer": true,
@@ -962,9 +1029,17 @@
       },
       "globals": {
         "__dirname": true,
+        "ast": true,
         "console.error": true,
         "console.warn": true,
-        "define": true
+        "content": true,
+        "define": true,
+        "file": true,
+        "importMap": true,
+        "moduleInitializer": true,
+        "packageName": true,
+        "specifier": true,
+        "type": true
       },
       "packages": {
         "json-stable-stringify": true,
@@ -1089,8 +1164,8 @@
         "process": true
       },
       "packages": {
-        "@babel/code-frame>chalk>supports-color": true,
-        "lavamoat-core>lavamoat-tofu>@babel/traverse>debug>ms": true
+        "lavamoat-core>lavamoat-tofu>@babel/traverse>debug>ms": true,
+        "source-map-explorer>chalk>supports-color": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/types": {
@@ -1099,9 +1174,9 @@
         "process.env.BABEL_TYPES_8_BREAKING": true
       },
       "packages": {
-        "@babel/code-frame>@babel/highlight>@babel/helper-validator-identifier": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types>to-fast-properties": true
+        "lavamoat-core>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat-core>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat-core>@babel/types>to-fast-properties": true
       }
     },
     "lavamoat-core>merge-deep": {
@@ -1182,14 +1257,42 @@
         "process.stdout": true
       },
       "packages": {
-        "browserify>string_decoder": true,
         "duplexify>inherits": true,
+        "readable-stream>string_decoder": true,
         "readable-stream>util-deprecate": true
+      }
+    },
+    "readable-stream>string_decoder": {
+      "packages": {
+        "readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "readable-stream>string_decoder>safe-buffer": {
+      "builtin": {
+        "buffer": true
       }
     },
     "readable-stream>util-deprecate": {
       "builtin": {
         "util.deprecate": true
+      }
+    },
+    "source-map-explorer>chalk>supports-color": {
+      "builtin": {
+        "os.release": true,
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true
+      },
+      "packages": {
+        "source-map-explorer>chalk>supports-color>has-flag": true
+      }
+    },
+    "source-map-explorer>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
       }
     },
     "through2": {

--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -1047,6 +1047,17 @@
         "lavamoat-core>merge-deep": true
       }
     },
+    "lavamoat-core>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BABEL_TYPES_8_BREAKING": true
+      },
+      "packages": {
+        "lavamoat-core>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat-core>@babel/types>@babel/helper-validator-identifier": true,
+        "lavamoat-core>@babel/types>to-fast-properties": true
+      }
+    },
     "lavamoat-core>lavamoat-tofu": {
       "globals": {
         "console.log": true
@@ -1062,6 +1073,7 @@
       },
       "packages": {
         "@babel/code-frame": true,
+        "lavamoat-core>@babel/types": true,
         "lavamoat-core>lavamoat-tofu>@babel/parser": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
@@ -1069,8 +1081,7 @@
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>debug": true,
-        "lavamoat-core>lavamoat-tofu>@babel/traverse>globals": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>lavamoat-tofu>@babel/traverse>globals": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator": {
@@ -1079,10 +1090,10 @@
         "console.warn": true
       },
       "packages": {
+        "lavamoat-core>@babel/types": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator>@jridgewell/gen-mapping": true,
         "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator>@jridgewell/trace-mapping": true,
-        "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator>jsesc": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator>jsesc": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/generator>@jridgewell/gen-mapping": {
@@ -1128,25 +1139,25 @@
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
       "packages": {
-        "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>@babel/types": true,
+        "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-function-name>@babel/template": {
       "packages": {
         "@babel/code-frame": true,
-        "lavamoat-core>lavamoat-tofu>@babel/parser": true,
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>@babel/types": true,
+        "lavamoat-core>lavamoat-tofu>@babel/parser": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
       "packages": {
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>@babel/types": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
       "packages": {
-        "lavamoat-core>lavamoat-tofu>@babel/types": true
+        "lavamoat-core>@babel/types": true
       }
     },
     "lavamoat-core>lavamoat-tofu>@babel/traverse>debug": {
@@ -1166,17 +1177,6 @@
       "packages": {
         "lavamoat-core>lavamoat-tofu>@babel/traverse>debug>ms": true,
         "source-map-explorer>chalk>supports-color": true
-      }
-    },
-    "lavamoat-core>lavamoat-tofu>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BABEL_TYPES_8_BREAKING": true
-      },
-      "packages": {
-        "lavamoat-core>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat-core>@babel/types>@babel/helper-validator-identifier": true,
-        "lavamoat-core>@babel/types>to-fast-properties": true
       }
     },
     "lavamoat-core>merge-deep": {

--- a/packages/node/test/prepare.js
+++ b/packages/node/test/prepare.js
@@ -39,6 +39,7 @@ const COREPACK_BIN = path.resolve(
 
 /**
  * Blast `node_modules` in `cwd`
+ *
  * @param {string} cwd - Project dir
  * @returns {Promise<void>}
  */
@@ -48,7 +49,8 @@ async function clean(cwd) {
 }
 
 /**
- * Resolves a module's installation path (_not_ entry point) from some other directory.
+ * Resolves a module's installation path (_not_ entry point) from some other
+ * directory.
  *
  * @param {string} cwd - Some other directory
  * @param {string} moduleId - Module to resolve
@@ -65,6 +67,7 @@ function resolveDependencyFrom(cwd, moduleId) {
 /**
  * Some native packages may not ship binaries for Apple silicon, so we have to
  * rebuild them
+ *
  * @param {string} cwd
  */
 async function setupAppleSilicon(cwd) {
@@ -85,6 +88,7 @@ async function setupAppleSilicon(cwd) {
 /**
  * Install a project's deps via a package manager, run the `setup` script, then
  * execute `lavamoat` on the `index.js` file.
+ *
  * @param {string} cwd - Project dir
  * @returns {Promise<void>}
  */

--- a/scripts/dirty-check.js
+++ b/scripts/dirty-check.js
@@ -1,0 +1,75 @@
+// @ts-check
+
+/**
+ * This script is intended to be run in a GitHub Actions workflow to check if
+ * test execution changed any files under version control. If so, the script
+ * will exit with a non-zero exit code and print an "error" to the GitHub
+ * Actions log for each changed file.
+ *
+ * This is not a shell script because portability.
+ *
+ * @example
+ *
+ * ```yaml
+ * on: [push, pull_request]
+ * jobs:
+ *   test:
+ *     runs-on: ubuntu-latest
+ *   steps:
+ *     - run: your stuff
+ *     - run: node ./scripts/dirty-check.js
+ * ```
+ *
+ * @packageDocumentation
+ * @see
+ * {@link https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions}
+ */
+
+const { promisify } = require('node:util')
+const execFile = promisify(require('node:child_process').execFile)
+
+/**
+ * Asks `git` if any files changed and exits with a non-zero exit code if so.
+ *
+ * @returns {Promise<void>}
+ * @todo We could determine what lines changed in what file so the file would be
+ *   annotated with the error, but it requires some extra parsing of `git diff`
+ *   output.
+ */
+async function main() {
+  await execFile('git', ['add', '.'])
+  const diffResultPromise = execFile(
+    'git',
+    ['diff', '--staged', '-b', '--quiet'],
+    { encoding: 'utf8' },
+  )
+
+  try {
+    await diffResultPromise
+    console.log('::notice::No dirty files detected')
+  } catch (e) {
+    if (e.code !== 1 || e.killed || e.stderr !== '') {
+      throw e
+    }
+    // something changed, and we should fail the build
+    process.exitCode = 1
+
+    console.log(
+      '::error,title=Dirty File::Working area contains unexpected changes; see job log for diff'
+    )
+    const { stdout } = await execFile(
+      'git',
+      ['diff', '--staged', '-b'],
+      { encoding: 'utf8' },
+    )
+    console.log(stdout)
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    // last resort
+    console.log(`::error::${err}`)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
This adds a script to determine if any files under version control changed, which should be run post-test-suites.

In the check summary, it will display the file(s) changed and provide references to the lines changed. Unfortunately, it will _not_ tell you _why_ the lines changed; you'll have to put on your Sherlock Holmes hat and figure it out.

![image](https://github.com/LavaMoat/LavaMoat/assets/924465/ced24923-56d1-4f03-99a6-4f300fc7e6ca)

Closes #721 