### PR TITLE
chore(lavapack): fix source-map version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18345,7 +18345,7 @@
       },
       "devDependencies": {
         "mississippi": "4.0.0",
-        "source-map": "0.5.7"
+        "source-map": "0.7.4"
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
@@ -18358,8 +18358,9 @@
     },
     "packages/lavapack/node_modules/source-map": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "mississippi": "4.0.0",
-    "source-map": "0.5.7"
+    "source-map": "0.7.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When the versions were pinned, for some reason it was pinned to 0.5.x instead of 0.7.x
