### PR TITLE
chore: fix root package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "lint-staged": "13.2.3",
     "memfs": "4.6.0",
     "prettier": "3.0.3",
-    "prettier-plugin-pkg": "0.18.0",
     "prettier-plugin-jsdoc": "1.1.1",
+    "prettier-plugin-pkg": "0.18.0",
     "type-fest": "4.7.1",
     "typescript": "5.2.2"
   },
@@ -93,17 +93,13 @@
   "prettier": {
     "jsdocCommentLineStrategy": "keep",
     "jsdocPreferCodeFences": true,
-    "plugins": ["prettier-plugin-jsdoc", "prettier-plugin-pkg"],
+    "plugins": [
+      "prettier-plugin-jsdoc",
+      "prettier-plugin-pkg"
+    ],
     "semi": false,
     "singleQuote": true,
     "trailingComma": "es5",
     "tsdoc": true
-  },
-  "ava": {
-    "files": [
-      "packages/*/test/*.spec.js",
-      "scripts/*.spec.js"
-    ],
-    "timeout": "2m"
   }
 }


### PR DESCRIPTION
Follow-up to
- https://github.com/LavaMoat/LavaMoat/pull/819

Run `npm pkg fix` on our root `package.json` file
- removes dupe `ava` config we introduced by mistake in https://github.com/LavaMoat/LavaMoat/commit/d175256524f1d82ca9b2a79f8b475a9c2886a42f

Then also format the file (after save/commit)
- simply fixes alphabetical ordering of `"prettier-plugin-pkg": "0.18.0"`