### PR TITLE
fix(tofu): make lavamoat-core a peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22787,11 +22787,13 @@
         "type-fest": "4.7.1"
       },
       "devDependencies": {
-        "deep-equal": "2.2.3",
-        "lavamoat-core": "^15.0.0"
+        "deep-equal": "2.2.3"
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+      },
+      "peerDependencies": {
+        "lavamoat-core": "^15.0.0"
       }
     },
     "packages/viz": {

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -17,12 +17,16 @@
     "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
   },
   "main": "src/index.js",
+  "types": "./types/index.d.ts",
   "directories": {
     "test": "test"
   },
   "scripts": {
     "lint:deps": "depcheck",
     "test": "ava"
+  },
+  "peerDependencies": {
+    "lavamoat-core": "^15.0.0"
   },
   "dependencies": {
     "@babel/parser": "7.23.6",
@@ -32,14 +36,12 @@
     "type-fest": "4.7.1"
   },
   "devDependencies": {
-    "deep-equal": "2.2.3",
-    "lavamoat-core": "^15.0.0"
+    "deep-equal": "2.2.3"
   },
   "ava": {
     "files": [
       "test/*.spec.js"
     ],
     "timeout": "30s"
-  },
-  "types": "./types/index.d.ts"
+  }
 }


### PR DESCRIPTION
`lavamoat-core` was a dev dep of `lavamoat-tofu`, but the former depends directly on the latter.  this creates a cycle, which is bad.

This makes `lavamoat-core` a peer dep of `lavamoat-tofu`, which avoids the cycle.