### PR TITLE
chore: add an auto-labeler bot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,93 @@
+'pkg:@lavamoat/aa':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/aa/**'
+
+'pkg:@lavamoat/allow-scripts':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/allow-scripts/**'
+
+'pkg:lavamoat-browserify':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/browserify/**'
+
+'pkg:lavamoat-core':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/core/**'
+
+'pkg:lavamoat-perf':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/perf/**'
+
+'pkg:@lavamoat/preinstall-always-fail':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/preinstall-always-fail/**'
+
+'pkg:survey':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/survey/**'
+
+'pkg:lavamoat-tofu':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/tofu/**'
+
+'pkg:lavamoat-viz':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/viz/**'
+
+'pkg:@lavamoat/webpack':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/webpack/**'
+
+'pkg:@lavamoat/lavapack':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/lavapack/**'
+
+'pkg:@lavamoat/yarn-plugin-allow-scripts':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/yarn-plugin-allow-scripts/**'
+
+'dependencies':
+  - changed-files:
+      - any-glob-to-any-file:
+          # this can't capture digest changes in workflow files
+          - 'packages/*/package.json'
+          - './package?(-lock).json'
+
+'chore':
+  - changed-files:
+      - any-glob-to-any-file:
+          # general config-related stuff
+          - '.github/**'
+          - '.husky/**'
+          - '**/.*' # all dotfiles
+          - '**/.config/**'
+          - '**/*.config.*'
+          - '*release-please*'
+          - '**/tsconfig*.json'
+
+          # adhoc scripts
+          - '**/scripts/**'
+
+          # test-related
+          - 'packages/*/test/**'
+          - 'packages/*/*.spec.{?([mc])js,ts}'
+
+'documentation':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - '!**/snapshots/**'
+          - '**/docs/**'
+          - '**/example?(s)/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5


### PR DESCRIPTION
This adds an autolabeler from GitHub: https://github.com/actions/labeler

I put a bunch of stuff in the config file which made sense to me, anyway.

This will create a handful of new labels prefixed with `pkg:` corresponding to each workspace.

Closes #817