### PR TITLE
chore(ci): fix labelbot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,6 +88,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.md'
-          - '!**/snapshots/**'
           - '**/docs/**'
           - '**/example?(s)/**'
+      - all-globs-to-all-files:
+          - '!**/snapshots/**/*.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,4 @@
+name: LabelBot
 on:
   - pull_request_target
 
@@ -10,4 +11,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      - name: Label PRs
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5


### PR DESCRIPTION
This was misconfigured such that everything would be labeled `documentation`, which is bad.