### PR TITLE
chore(ci): update labelbot docs glob

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,7 +88,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.md'
-          - '**/docs/**'
+          - 'docs/**'
           - '**/example?(s)/**'
       - all-globs-to-all-files:
           - '!**/snapshots/**/*.md'


### PR DESCRIPTION
Since root repo docs only living in root dir