### PR TITLE
chore(ci): fix labeler again

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -87,8 +87,9 @@
 'documentation':
   - changed-files:
       - any-glob-to-any-file:
+          # note: this will include snapshot *.md files.
+          # someone is welcome to figure out how to exclude these, but I give up
           - '**/*.md'
           - '**/docs/**'
           - '**/example?(s)/**'
-      - all-globs-to-all-files:
-          - '!**/snapshots/**/*.md'
+


### PR DESCRIPTION
Apparently we need the "all" top-level property here, which seems to fail config validation.

**(trying to avoid everything getting tagged `documentation`)**