### PR TITLE
chore(ci): only tag "chore" if all files are in the chore bucket

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,7 +67,7 @@
 
 'chore':
   - changed-files:
-      - any-glob-to-any-file:
+      - any-glob-to-all-files:
           # general config-related stuff
           - '.github/**'
           - '.husky/**'


### PR DESCRIPTION
I noticed that most PRs were getting labeled "chore", and I think this is why.  This change _should_ make it such that for something to be labeled "chore", _all_ of the files in the PR must be in the chore bucket.