### PR TITLE
chore(deps): downgrade @types/node from 20 to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2118,12 +2118,6 @@
         "node": ">=v14"
       }
     },
-    "node_modules/@commitlint/load/node_modules/@types/node": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
-      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5205,11 +5199,6 @@
       "engines": {
         "node": ">=12 <14 || 14.2 - 14.9 || >14.10.0"
       }
-    },
-    "node_modules/@yarnpkg/pnp/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
     "node_modules/@yarnpkg/shell": {
       "version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23048,10 +23048,6 @@
         "@yarnpkg/core": "3.5.1",
         "clipanion": "3.2.1"
       },
-      "devDependencies": {
-        "@types/node": "20.11.5",
-        "typescript": "5.2.2"
-      },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@commitlint/cli": "17.8.1",
         "@commitlint/config-conventional": "17.8.1",
         "@tsconfig/node16": "16.1.1",
-        "@types/node": "20.11.5",
+        "@types/node": "18.19.8",
         "@types/yargs": "17.0.32",
         "@typescript-eslint/eslint-plugin": "6.8.0",
         "@typescript-eslint/parser": "6.8.0",
@@ -3518,9 +3518,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
-      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@commitlint/cli": "17.8.1",
     "@commitlint/config-conventional": "17.8.1",
     "@tsconfig/node16": "16.1.1",
-    "@types/node": "20.11.5",
+    "@types/node": "18.19.8",
     "@types/yargs": "17.0.32",
     "@typescript-eslint/eslint-plugin": "6.8.0",
     "@typescript-eslint/parser": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "typescript": "5.2.2"
   },
   "overrides": {
+    "@types/node": "$@types/node",
     "ses": "$ses",
     "type-fest": "$type-fest",
     "util": "0.12.5"

--- a/packages/yarn-plugin-allow-scripts/package.json
+++ b/packages/yarn-plugin-allow-scripts/package.json
@@ -24,9 +24,5 @@
     "@yarnpkg/cli": "3.5.1",
     "@yarnpkg/core": "3.5.1",
     "clipanion": "3.2.1"
-  },
-  "devDependencies": {
-    "@types/node": "20.11.5",
-    "typescript": "5.2.2"
   }
 }


### PR DESCRIPTION
Drop typings package to align with lowest supported major Node.js version.


#### Depends on
- [ ] #875