### PR TITLE
chore(ci): auto-assign PR author

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -1,0 +1,15 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@ebd30f10fb56e46eb0759a14951f36991426fed0 # v2.1.0
+


### PR DESCRIPTION
This adds an action to automatically assign (if possible) a PR to the author of that PR. I use this extensively for myself, and it is especially helpful when viewing a list of PRs and filtering them.

The action will not assign a bot to a PR and it will not assign anyone to PRs that already have users assigned.