### PR TITLE
chore(ci): do not auto-rebase onto main

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,6 @@
     'group:definitelyTyped', // groups all `@types/*` packages together
     'helpers:pinGitHubActionDigests', // pins SHAs of GitHub actions
     ':enableVulnerabilityAlerts', // enables GitHub vulnerability alerts
-    ':rebaseStalePrs', // automatically rebase stale PRs against main
     ':semanticCommits', // use semantic commits
     'group:linters', // group lint-related packages together
   ],


### PR DESCRIPTION
Renovate was configured to automatically rebase all its PRs onto `main` whenever `main` gets pushed to.  This causes a lot of workflows to get dumped into the CI queue.

This disables that behavior.  I am not sure if it will still automatically attempt to resolve conflicts if things get _too_ out-of-date, but we will see.