### PR TITLE
perf(core): optimize RegExp allocation and compilation in sourceTransforms

### DIFF
--- a/packages/core/src/sourceTransforms.js
+++ b/packages/core/src/sourceTransforms.js
@@ -12,12 +12,12 @@ function applySourceTransforms(source) {
   ])
 }
 
+const DIRECT_EVAL_REPLACE_FN = (_, p1) => '(0,eval)' + p1
 function evadeDirectEvalExpressions(source) {
-  /* eslint-disable-next-line prefer-regex-literals */
-  const someDirectEvalPattern = new RegExp('\\beval(\\s*\\()', 'g')
-
-  const replaceFn = (_, p1) => `(0,eval)${p1}`
-  return source.replace(someDirectEvalPattern, replaceFn)
+  return source.replace(
+    /\beval(\s*\()/g,
+    DIRECT_EVAL_REPLACE_FN
+  )
 }
 
 module.exports = {


### PR DESCRIPTION
Resource-usage optimization targeting regex-transforms in core.

- Switching to literal means static compilation instead of dynamically` compiling expression at runtime
- Moving allocation to outer scope to possibly reduce redundant allocations
- Switching from template string to concatenation in replace function gives measurable runtime difference in local benchmarks


#### Related
- Broken out from: #867 
- Motivation: https://github.com/MetaMask/metamask-extension/issues/21006

---

Co-Authored by: David Murdoch <187813+davidmurdoch@users.noreply.github.com>