### PR TITLE
fix(deps): Align and integrity-check cdn resources in perf trials

### DIFF
--- a/packages/perf/trials/bify-simple/chart.html
+++ b/packages/perf/trials/bify-simple/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/bify-simple/chart.html
+++ b/packages/perf/trials/bify-simple/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/increment/chart.html
+++ b/packages/perf/trials/increment/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/increment/chart.html
+++ b/packages/perf/trials/increment/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/pull-stream/chart.html
+++ b/packages/perf/trials/pull-stream/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/pull-stream/chart.html
+++ b/packages/perf/trials/pull-stream/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/secp256k1-mixedAdd/chart.html
+++ b/packages/perf/trials/secp256k1-mixedAdd/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/secp256k1-mixedAdd/chart.html
+++ b/packages/perf/trials/secp256k1-mixedAdd/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/secp256k1-newBN/chart.html
+++ b/packages/perf/trials/secp256k1-newBN/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/secp256k1-newBN/chart.html
+++ b/packages/perf/trials/secp256k1-newBN/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/terser/chart.html
+++ b/packages/perf/trials/terser/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/terser/chart.html
+++ b/packages/perf/trials/terser/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>

--- a/packages/perf/trials/wallet/chart.html
+++ b/packages/perf/trials/wallet/chart.html
@@ -9,7 +9,9 @@
       type="text/css"
     />
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js"
+      integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"
+      crossorigin="anonymous"
       charset="utf-8"
     ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>

--- a/packages/perf/trials/wallet/chart.html
+++ b/packages/perf/trials/wallet/chart.html
@@ -5,6 +5,8 @@
     <title>chart-csv</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.css"
+      integrity="sha384-ztqQYuF0ztQOO26+6hbRTtSQ6HGLosUJRQI9kx0L9OpJiESTtsiriiQNqwBIBl9a"
+      crossorigin="anonymous"
       rel="stylesheet"
       type="text/css"
     />
@@ -14,7 +16,11 @@
       crossorigin="anonymous"
       charset="utf-8"
     ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.20/c3.min.js"
+      integrity="sha384-xOzJ6ocROuPNeY/PUgXyXgiPyvvePCiWVkKXro4Lb1gWoGJOtrJw+zrpf3NBx1B5"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body onload="run()">
     <div id="graph"></div>


### PR DESCRIPTION
- chore: add [`integrity`](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) and [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attributes to js and stylesheets loaded from external CDN
- fix(deps): bump d3 from v3 to v5 (latest supported by c3)

c3 is unmaintained and if updating d3 for the perf trials further is actually desired, it would probably have to be replaced with something else, like [`billboard.js`](https://github.com/naver/billboard.js)

- Replaces #917 