### PR TITLE
chore(ci): validate lockfile

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: '1'
+
 jobs:
   test:
     name: test
@@ -11,8 +14,6 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-    env:
-      FORCE_COLOR: 1
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -33,52 +34,17 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-    strategy:
-      matrix:
-        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - name: Upgrade npm # for workspace support
-        run: npm i -g npm@9 # npm@9 supports our supported Node.js versions
       - name: Install Dependencies
         uses: bahmutov/npm-install@d476752204653fb5cce6c09db0eaf220761f5d9e # v1.8.37
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts
-      - name: Lint
-        run: npm run lint
-
-  validate-lockfile:
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 1
-    strategy:
-      matrix:
-        node-version: [18.x]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - name: Upgrade npm # for workspace support
-        run: npm i -g npm
-      - name: Install Dependencies
-        uses: bahmutov/npm-install@d476752204653fb5cce6c09db0eaf220761f5d9e # v1.8.37
-        with:
-          useRollingCache: true
-          install-command: npm ci --foreground-scripts
-      # if this command fails, then there's a mismatch between package-lock.json
-      # and one or more workspace package.json files
+      - name: Lint Sources
+        run: npm run lint:eslint
+      - name: Lint Dependencies
+        run: npm run lint:deps
       - name: Validate Lockfile
         run: npm ls

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -55,3 +55,30 @@ jobs:
           install-command: npm ci --foreground-scripts
       - name: Lint
         run: npm run lint
+
+  validate-lockfile:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Upgrade npm # for workspace support
+        run: npm i -g npm
+      - name: Install Dependencies
+        uses: bahmutov/npm-install@d476752204653fb5cce6c09db0eaf220761f5d9e # v1.8.37
+        with:
+          useRollingCache: true
+          install-command: npm ci --foreground-scripts
+      # if this command fails, then there's a mismatch between package-lock.json
+      # and one or more workspace package.json files
+      - name: Validate Lockfile
+        run: npm ls


### PR DESCRIPTION
`npm ci` installs based on `package-lock.json` only, which can become out-of-date (somehow) with respect to a `package.json`.  If `npm ls` after an `npm ci` fails with a non-zero exit code, this is why.