### PR TITLE
fix(browserify/test): result output references in error handling

### DIFF
--- a/packages/browserify/test/util.js
+++ b/packages/browserify/test/util.js
@@ -33,12 +33,12 @@ function overrideDepsWithLocalPackages(projectDir, log) {
 
   // link all of the workspaces to the temp dir project. no need to unlink
   // first; this will overwrite any already-present links
-  const res2 = spawnSync(
+  const res = spawnSync(
     'npm',
     ['install', '--ignore-scripts', ...Object.values(localPkgPaths)],
     { cwd: projectDir, encoding: 'utf8' }
   )
-  if (res2.status !== 0) {
+  if (res.status !== 0) {
     const err = res.stderr
     log({
       err,


### PR DESCRIPTION
Fixes regression in error-handling in browserify tests introduced in f4292a06c12bbed3e807cc0a2f85f42976255510 (#698) where a non-existent `res` is referred in error-handling.

Ideally cases like this would be caught by lint.