### PR TITLE
chore: add json5 to linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@ packages/viz/dist/**/*
 packages/viz/src/example-policies/**/*
 packages/yarn-plugin-allow-scripts/bundles
 packages/*/types
+!/.github

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,28 @@
 // @ts-check
 
 /**
- * @summary The root ESLint configuration.
- * @description
- *
  * - If a workspace emits declaration files, it should contain a `.eslintrc.js`
- * which extends {@link file://./.config/eslintrc.typed-workspace.js}.
- * - A workspace _only_ needs its own `.eslintrc.js` if it needs to override this configuration.
+ *   which extends {@link file://./.config/eslintrc.typed-workspace.js}.
+ * - A workspace _only_ needs its own `.eslintrc.js` if it needs to override this
+ *   configuration.
  * - While you may be tempted, please do not use an `eslintConfig` prop in your
- * `package.json`; use `.eslintrc.js` for consistency.
+ *   `package.json`; use `.eslintrc.js` for consistency.
  * - Note: glob patterns in this file should _not_ be relative.
  *
+ * @summary The root ESLint configuration.
  * @packageDocumentation
  */
 
 /**
  * The minimum EcmaScript runtime environment to support
+ *
  * @see {@link https://eslint.org/docs/latest/use/configure/language-options#specifying-environments}
  */
 const ECMASCRIPT_ENV = 'es2021'
 
 /**
  * The minimum EcmaScript language version to support
+ *
  * @see {@link https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options}
  */
 const ECMASCRIPT_VERSION = 2021
@@ -86,6 +87,7 @@ module.exports = {
     node: {
       /**
        * For `n/no-missing-import`
+       *
        * @see {@link https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-missing-import.md}
        */
       allowModules: ['deep-equal'], // something weird about this dependency
@@ -94,10 +96,10 @@ module.exports = {
        * For `n/no-unsupported-features`.
        *
        * `eslint-plugin-n` looks in the `engines` field of the closest
-       * `package.json` to the file being linted to determine this value.  For
+       * `package.json` to the file being linted to determine this value. For
        * our workspaces, this field is present, but in some test fixtures it may
        * not be. We _do_ try to ignore test fixtures, but that is easy to
-       * accidentally override via `eslint` on the command line.  So, the safest
+       * accidentally override via `eslint` on the command line. So, the safest
        * thing is to just set it here.
        */
       version: MIN_NODE_VERSION,
@@ -126,6 +128,10 @@ module.exports = {
         'n/no-missing-import': 'off',
       },
       parser: '@typescript-eslint/parser',
+    },
+    {
+      files: ['**/tsconfig*.json', '**/*.json5', '**/*.jsonc'],
+      extends: ['plugin:jsonc/prettier'],
     },
   ],
   ignorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-ava": "14.0.0",
         "eslint-plugin-import": "2.29.1",
+        "eslint-plugin-jsonc": "2.13.0",
         "eslint-plugin-n": "16.6.2",
         "eslint-plugin-react": "7.33.2",
         "glob": "10.3.10",
@@ -9376,6 +9377,78 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.13.0.tgz",
+      "integrity": "sha512-2wWdJfpO/UbZzPDABuUVvlUQjfMJa2p2iQfYt/oWxOMpXCcjuiMUSaA02gtY/Dbu82vpaSqc+O7Xq6ECHwtIxA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "eslint-compat-utils": "^0.4.0",
+        "espree": "^9.6.1",
+        "graphemer": "^1.4.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0",
+        "synckit": "^0.6.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc/node_modules/eslint-compat-utils": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.4.1.tgz",
+      "integrity": "sha512-5N7ZaJG5pZxUeNNJfUchurLVrunD1xJvyg5kYOIVF8kg1f3ajTikmAu/5fZ9w100omNPOoMjngRszh/Q/uFGMg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/eslint-plugin-n": {
       "version": "16.6.2",
       "dev": true,
@@ -12658,6 +12731,57 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -18775,6 +18899,18 @@
     "node_modules/survey": {
       "resolved": "packages/survey",
       "link": true
+    },
+    "node_modules/synckit": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.6.2.tgz",
+      "integrity": "sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/syntax-error": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-ava": "14.0.0",
     "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-jsonc": "2.13.0",
     "eslint-plugin-n": "16.6.2",
     "eslint-plugin-react": "7.33.2",
     "glob": "10.3.10",


### PR DESCRIPTION
chore: add json5 to linter

This adds lint support for JSON5/JSONC files via [eslint-plugin-jsonc](https://npm.im/eslint-plugin-jsonc).

In addition, `tsconfig.json` files are _actually_ treated as JSONC files, regardless of the file extension (this allows us to add comments in them, if we wish; the risk of doing so having negative unintended consequences on 3rd-party tooling is pretty low, given the default `tsconfig.json` generated by `tsc init` contains comments--so it is expected--and _generally_ tools will parse `tsconfig.json` using TS' programmatic API).

The only other affected file at this time is `.github/renovate.json5`. There is currently _no_ validation of this file, and the impact of pushing an invalid config would suck and may not immediately be obvious.

The configuration of the plugin is set to mainly just assert the files are valid and not to stomp on Prettier's toes, as it will already format a valid JSON5/JSONC file.