### PR TITLE
normalize test logging

### DIFF
--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -31,7 +31,7 @@ test('cli - auto command', (t) => {
   )
 
   // forward error output for debugging
-  console.error(result.stderr.toString('utf-8'))
+  t.log(result.stderr.toString('utf-8'))
 
   // get the package.json
   const packageJsonContents = JSON.parse(
@@ -63,7 +63,7 @@ test('cli - auto command with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  console.error(result.stderr.toString('utf-8'))
+  t.log(result.stderr.toString('utf-8'))
 
   // get the package.json
   const packageJsonContents = JSON.parse(
@@ -101,7 +101,7 @@ test('cli - run command - good dep at the root', (t) => {
   )
 
   // forward error output for debugging
-  console.error(result.stderr.toString('utf-8'))
+  t.log(result.stderr.toString('utf-8'))
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
@@ -138,7 +138,7 @@ test('cli - run command - good dep at the root with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  console.error(result.stderr.toString('utf-8'))
+  t.log(result.stderr.toString('utf-8'))
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
@@ -190,8 +190,8 @@ test('cli - run command - good dep as a sub dep', (t) => {
   )
 
   // uncomment to forward error output for debugging
-  console.error(result.stdout.toString('utf-8'))
-  console.error(result.stderr.toString('utf-8'))
+  t.log(result.stdout.toString('utf-8'))
+  t.log(result.stderr.toString('utf-8'))
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
@@ -227,8 +227,8 @@ test('cli - run command - good dep as a sub dep with experimental bins', (t) => 
   )
 
   // uncomment to forward error output for debugging
-  // console.error(result.stdout.toString('utf-8'))
-  // console.error(result.stderr.toString('utf-8'))
+  // t.log(result.stdout.toString('utf-8'))
+  // t.log(result.stderr.toString('utf-8'))
 
   t.assert(
     fs.existsSync(

--- a/packages/browserify/test/basic.spec.js
+++ b/packages/browserify/test/basic.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable ava/use-t-well */
 const test = require('ava')
 
 const {
@@ -30,8 +31,12 @@ test('basic - browserify bundle doesnt inject global in deps', async (t) => {
       module.exports = global
     },
   })
-  await autoConfigForScenario({ scenario })
-  const { bundleForScenario } = await createBundleForScenario({ scenario })
+  const log = t.log.bind(t)
+  await autoConfigForScenario({ scenario, log })
+  const { bundleForScenario } = await createBundleForScenario({
+    scenario,
+    log,
+  })
   const hasGlobalInjection = bundleForScenario.includes(
     'typeof global !== \\"undefined\\" ? global :'
   )
@@ -48,8 +53,12 @@ test('basic - lavamoat policy and bundle', async (t) => {
       module.exports = () => location.href
     },
   })
-  await autoConfigForScenario({ scenario })
-  const { bundleForScenario } = await createBundleForScenario({ scenario })
+  const log = t.log.bind(t)
+  await autoConfigForScenario({ scenario, log })
+  const { bundleForScenario } = await createBundleForScenario({
+    scenario,
+    log,
+  })
 
   t.true(
     bundleForScenario.includes('"location.href":true'),
@@ -74,8 +83,12 @@ test('basic - lavamoat bundle without prelude', async (t) => {
     opts: { includePrelude: false },
   })
 
-  await autoConfigForScenario({ scenario })
-  const { bundleForScenario } = await createBundleForScenario({ scenario })
+  const log = t.log.bind(t)
+  await autoConfigForScenario({ scenario, log })
+  const { bundleForScenario } = await createBundleForScenario({
+    scenario,
+    log,
+  })
 
   let didCallLoadBundle = false
   const testGlobal = {

--- a/packages/browserify/test/factor.spec.js
+++ b/packages/browserify/test/factor.spec.js
@@ -150,8 +150,12 @@ test.skip('package factor bundle', async (t) => {
     type: 'factor',
   }
 
+  // eslint-disable-next-line ava/use-t-well
+  const log = t.log.bind(t)
+
   const { bundleForScenario: rawOutput } = await createBundleForScenario({
     scenario,
+    log,
   })
   const vinylBundles = JSON.parse(rawOutput)
 
@@ -165,10 +169,12 @@ test.skip('package factor bundle', async (t) => {
   const testResult1 = await runScenario({
     scenario,
     bundle: vinylBundles['common.js'] + vinylBundles['src/1.js'],
+    log,
   })
   const testResult2 = await runScenario({
     scenario,
     bundle: vinylBundles['common.js'] + vinylBundles['src/2.js'],
+    log,
   })
 
   t.is(testResult1, 60)

--- a/packages/browserify/test/generatePolicy.spec.js
+++ b/packages/browserify/test/generatePolicy.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable ava/use-t-well */
 /* eslint-disable no-undef */
 const test = require('ava')
 
@@ -9,7 +10,7 @@ test('generatePolicy - empty policy', async (t) => {
     defineEntry: () => {},
     defaultPolicy: false,
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, { resources: {} }, 'policy matches expected')
 })
 
@@ -21,7 +22,7 @@ test('generatePolicy - basic policy', async (t) => {
     defaultPolicy: false,
   })
 
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {
       one: {
@@ -43,7 +44,7 @@ test('generatePolicy - ignore various refs', async (t) => {
     },
     defaultPolicy: false,
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {
       one: {
@@ -63,7 +64,7 @@ test('generatePolicy - policy ignores global refs', async (t) => {
     },
     defaultPolicy: false,
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {
       one: {
@@ -85,7 +86,7 @@ test('generatePolicy - policy ignores global refs when properties are not access
     },
     defaultPolicy: false,
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {},
   })
@@ -101,7 +102,7 @@ test('generatePolicy - policy ignores global refs accessed with allowlist items'
       resources: {},
     },
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {},
   })
@@ -129,7 +130,7 @@ test('generatePolicy - policy endows "process" properly', async (t) => {
       },
     },
   })
-  const policy = await autoConfigForScenario({ scenario })
+  const policy = await autoConfigForScenario({ scenario, log: t.log.bind(t) })
   t.deepEqual(policy, {
     resources: {
       one: {

--- a/packages/browserify/test/policy.spec.js
+++ b/packages/browserify/test/policy.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable ava/use-t-well */
 const test = require('ava')
 const fs = require('fs')
 const path = require('path')
@@ -20,7 +21,10 @@ test('policy - default policy path is generated with autoconfig if path is not s
     },
     contextName: 'browserify',
   })
-  const { policyDir } = await prepareBrowserifyScenarioOnDisk({ scenario })
+  const { policyDir } = await prepareBrowserifyScenarioOnDisk({
+    scenario,
+    log: t.log.bind(t),
+  })
   const expectedPath = path.join(policyDir, 'policy.json')
 
   t.false(fs.existsSync(expectedPath), 'Policy file does not yet exist')
@@ -62,7 +66,10 @@ test('Policy - Applies writeAutoPolicyDebug plugin option and dumps module objec
       writeAutoPolicyDebug: true,
     },
   })
-  const { policyDir } = await prepareBrowserifyScenarioOnDisk({ scenario })
+  const { policyDir } = await prepareBrowserifyScenarioOnDisk({
+    scenario,
+    log: t.log.bind(t),
+  })
   const expectedPath = path.join(policyDir, 'policy-debug.json')
 
   t.false(fs.existsSync(expectedPath), 'Module data does not yet exist')
@@ -80,6 +87,7 @@ test('Policy - watchify listens for policy file changes', async (t) => {
   })
   const { projectDir, policyDir } = await prepareBrowserifyScenarioOnDisk({
     scenario,
+    log: t.log.bind(t),
   })
   await runBrowserify({ scenario })
 

--- a/packages/browserify/test/runScenarios.spec.js
+++ b/packages/browserify/test/runScenarios.spec.js
@@ -5,9 +5,10 @@ const { runAndTestScenario } = require('lavamoat-core/test/util')
 
 test('Run scenarios with precompiled modules', async (t) => {
   for await (const scenario of loadScenarios()) {
-    console.log(`Running Browserify Scenario: ${scenario.name}`)
+    t.log(`Running Browserify Scenario: ${scenario.name}`)
     await runAndTestScenario(t, scenario, ({ scenario }) =>
-      runScenario({ scenario })
+      // eslint-disable-next-line ava/use-t-well
+      runScenario({ scenario, log: t.log.bind(t) })
     )
   }
 })

--- a/packages/browserify/test/sourcemaps.js
+++ b/packages/browserify/test/sourcemaps.js
@@ -6,11 +6,11 @@ const { codeFrameColumns } = require('@babel/code-frame')
 
 module.exports = { verifySourceMaps }
 
-async function verifySourceMaps({ bundle }) {
+async function verifySourceMaps({ bundle, log = console.error.bind(console) }) {
   // basic sanity checking
   validate(bundle)
   // our custom sample checking
-  await verifySamples(bundle)
+  await verifySamples(bundle, log)
   // generate a sourcemap explorer because its stricter than some other validations
   await verifyWithSourceExplorer(bundle)
 }
@@ -31,13 +31,13 @@ async function verifyWithSourceExplorer(bundle) {
   }
 }
 
-async function verifySamples(bundle) {
+async function verifySamples(bundle, log) {
   const sourcemap = extractSourceMap(bundle).toObject()
   const consumer = await new SourceMapConsumer(sourcemap)
 
   const hasContentsOfAllSources = consumer.hasContentsOfAllSources()
   if (!hasContentsOfAllSources) {
-    console.warn('SourcemapValidator - missing content of some sources...')
+    log('SourcemapValidator - missing content of some sources...')
   }
 
   let sampleCount = 0

--- a/packages/core/test/runScenarios.spec.js
+++ b/packages/core/test/runScenarios.spec.js
@@ -4,7 +4,7 @@ const { runScenario, runAndTestScenario } = require('./util')
 
 test('Run scenarios', async (t) => {
   for await (const scenario of loadScenarios()) {
-    console.log(`Running Core Scenario: ${scenario.name}`)
+    t.log(`Running Core Scenario: ${scenario.name}`)
     await runAndTestScenario(t, scenario, ({ scenario }) =>
       runScenario({ scenario })
     )
@@ -13,7 +13,7 @@ test('Run scenarios', async (t) => {
 
 test('Run scenarios with precompiled intializer', async (t) => {
   for await (const scenario of loadScenarios()) {
-    console.log(`Running Core Scenario: ${scenario.name}`)
+    t.log(`Running Core Scenario: ${scenario.name}`)
     await runAndTestScenario(t, scenario, ({ scenario }) =>
       runScenario({ scenario, runWithPrecompiledModules: true })
     )

--- a/packages/core/test/scenarios/autogen.js
+++ b/packages/core/test/scenarios/autogen.js
@@ -4,7 +4,7 @@ const {
 } = require('../util.js')
 
 module.exports = [
-  async () => {
+  async (log = console.error.bind(console)) => {
     const scenario = createScenarioFromScaffold({
       name: 'autogen - react-devtools-core hasOwnProperty',
       defineOne: () => {
@@ -20,7 +20,7 @@ module.exports = [
       },
       expectedResult: true,
     })
-    await autoConfigForScenario({ scenario })
+    await autoConfigForScenario({ scenario, log })
     return scenario
   },
 ]

--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -15,7 +15,7 @@ const one = () => {
 }
 
 module.exports = [
-  async () => {
+  async (log = console.error.bind(console)) => {
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is scuttled to work',
       defineOne: one,
@@ -39,10 +39,10 @@ module.exports = [
         },
       },
     })
-    await autoConfigForScenario({ scenario })
+    await autoConfigForScenario({ scenario, log })
     return scenario
   },
-  async () => {
+  async (log = console.error.bind(console)) => {
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is too scuttled to work',
       defineOne: one,
@@ -60,7 +60,7 @@ module.exports = [
       expectedFailureMessageRegex:
         /SES_UNHANDLED_REJECTION|inaccessible under scuttling mode./,
     })
-    await autoConfigForScenario({ scenario })
+    await autoConfigForScenario({ scenario, log })
     return scenario
   },
 ]

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -386,20 +386,31 @@ async function runScenario({ scenario, runWithPrecompiledModules = false }) {
 }
 
 /**
- * The subset of the `fs/promises` module that is used by `prepareScenarioOnDisk`.
+ * The subset of the `fs/promises` module that is used by
+ * `prepareScenarioOnDisk`.
+ *
  * @typedef FsPromiseApi
- * @property {(dir: string, opts?: import('node:fs').MakeDirectoryOptions & {recursive: true}) => Promise<string|undefined>} mkdir
+ * @property {(
+ *   dir: string,
+ *   opts?: import('node:fs').MakeDirectoryOptions & { recursive: true }
+ * ) => Promise<string | undefined>} mkdir
  * @property {(filepath: string, data: any) => Promise<void>} writeFile
  */
 
 /**
- * Prepares a scenario on disk by writing files based on the provided scenario object.
+ * Prepares a scenario on disk by writing files based on the provided scenario
+ * object.
+ *
  * @param {Object} options - The options for preparing the scenario.
- * @param {FsPromiseApi} [options.fs] - The file system module to use (default: `node:fs/promises`).
- * @param {Object} options.scenario - The scenario object containing the files to write.
- * @param {string} [options.policyName='policies'] - The name of the policy directory (default: 'policies').
+ * @param {FsPromiseApi} [options.fs] - The file system module to use (default:
+ *   `node:fs/promises`).
+ * @param {Object} options.scenario - The scenario object containing the files
+ *   to write.
+ * @param {string} [options.policyName='policies'] - The name of the policy
+ *   directory (default: 'policies'). Default is `'policies'`
  * @param {string} [options.projectDir] - The project directory path.
- * @returns {Promise<{projectDir: string, policyDir: string}>} - An object containing the project directory path and the policy directory path.
+ * @returns {Promise<{ projectDir: string; policyDir: string }>} - An object
+ *   containing the project directory path and the policy directory path.
  */
 async function prepareScenarioOnDisk({
   fs = require('node:fs/promises'),
@@ -569,7 +580,7 @@ function functionToString(func) {
 async function runAndTestScenario(t, scenario, platformRunScenario) {
   let result, err
   try {
-    result = await platformRunScenario({ scenario })
+    result = await platformRunScenario({ scenario, log: t.log.bind(t) })
   } catch (e) {
     err = e
   }

--- a/packages/lavapack/test/index.spec.js
+++ b/packages/lavapack/test/index.spec.js
@@ -58,7 +58,7 @@ test('sourcemap test', async (t) => {
 
   const bundleBuffer = await promise
   const bundleString = bundleBuffer.toString()
-  console.log(bundleString)
+  t.log(bundleString)
   fs.writeFileSync('./bundle.js', bundleBuffer)
 
   const converter = convertSourceMap.fromSource(bundleString)
@@ -72,7 +72,7 @@ test('sourcemap test', async (t) => {
       column: 0,
     })
     const bundleLine = bundleString.split('\n')[bundleStartPos.line - 1]
-    console.log(`${sourceFile}:\n${bundleLine}`)
+    t.log(`${sourceFile}:\n${bundleLine}`)
   })
 
   consumer.destroy()

--- a/packages/lavapack/test/sourcemaps.spec.js
+++ b/packages/lavapack/test/sourcemaps.spec.js
@@ -66,9 +66,9 @@ async function validateSourcemaps(t, sourceMeta) {
         const result = consumer.originalPositionFor(position)
         if (!result.source) {
           t.fail(`missing source for position: ${JSON.stringify(position)}`)
-          console.warn('=======')
-          console.warn(contentForPosition(sourceLines, position))
-          console.warn('=======')
+          t.log('=======')
+          t.log(contentForPosition(sourceLines, position))
+          t.log('=======')
           return
         }
         const sourceContent = consumer.sourceContentFor(result.source)

--- a/packages/node/test/runScenarios.spec.js
+++ b/packages/node/test/runScenarios.spec.js
@@ -13,7 +13,7 @@ test('Run scenarios', async (t) => {
     ) {
       continue
     }
-    console.log(`Running Node Scenario: ${scenario.name}`)
+    t.log(`Running Node Scenario: ${scenario.name}`)
     await runAndTestScenario(t, scenario, ({ scenario }) =>
       runScenario({ scenario })
     )

--- a/packages/tofu/test/inspectEsmImports.spec.js
+++ b/packages/tofu/test/inspectEsmImports.spec.js
@@ -60,8 +60,8 @@ function testInspect(label, opts, fn, expectedResultObj) {
     // for debugging
     if (!deepEqual(resultSorted, expectedSorted)) {
       label, opts, ast, source
-      console.log(resultSorted)
-      console.log(expectedSorted)
+      t.log(resultSorted)
+      t.log(expectedSorted)
       // eslint-disable-next-line no-debugger
       debugger
     }

--- a/packages/tofu/test/inspectImports.spec.js
+++ b/packages/tofu/test/inspectImports.spec.js
@@ -133,8 +133,8 @@ function testInspect(label, opts, fn, expectedResultObj) {
     // for debugging
     if (!deepEqual(resultSorted, expectedSorted)) {
       label, opts
-      console.log(resultSorted)
-      console.log(expectedSorted)
+      t.log(resultSorted)
+      t.log(expectedSorted)
       // eslint-disable-next-line no-debugger
       debugger
     }


### PR DESCRIPTION
This was bugging me.  It's tough to visually parse the output of tests, especially when we're running scenarios.  I went through and changed all of the console logging coming out of tests and test harnesses to use Ava's facilities to do so, which logs in a more consistent and readable manner.

Examples. Before:

```
  ✔ waysToRun › use lavamoat-run-command (439ms)
  ✔ index › execute - resolutions (424ms)
  ✔ envConfig › envConfig - intrinsic prototype mutating package running in unfrozen realm does not pollute other package intrinsics (442ms)
  ✔ index › execute - keccak with native modules (424ms)
  ✔ envConfig › envConfig - module.exports from the same Realm as its Compartment (443ms)
Running Node Scenario: security - prevent intrinsic modification
  ✔ globals › globalRef - globalRef - check default containment (454ms)
  ✔ globals › globals - has only the expected global circular refs (459ms)
Running Node Scenario: security - limit platform API
Running Node Scenario: basic - bundle works
Running Node Scenario: basic - npm buffer toLocaleString support
Running Node Scenario: basic - Function constructor for constructing constructor functions
Running Node Scenario: config - dunder proto not allowed in globals path
Running Node Scenario: config - disable access to package
Running Node Scenario: config - config validation fails: invalid "resources" key
Running Node Scenario: config - config validation fails: invalid "packages" key
Running Node Scenario: config - config validation fails: invalid "globals" key
Running Node Scenario: config - config validation fails: invalid "globals" value
Running Node Scenario: config - config validation passes - everything valid
Running Node Scenario: endowments - Date.now works in root and non-root
Running Node Scenario: exportsDefense - readOnly restrictions have override workaround fix - updates the property correctly
```

after (note the order):

```
  ✔ waysToRun › use lavamoat-run-command (416ms)
  ✔ runScenarios › Run scenarios (5.5s)
    ℹ Running Node Scenario: autogen - react-devtools-core hasOwnProperty
    ℹ Running Node Scenario: security - prevent intrinsic modification
    ℹ Running Node Scenario: security - limit platform API
    ℹ Running Node Scenario: basic - bundle works
    ℹ Running Node Scenario: basic - npm buffer toLocaleString support
    ℹ Running Node Scenario: basic - Function constructor for constructing constructor functions
    ℹ Running Node Scenario: config - dunder proto not allowed in globals path
    ℹ Running Node Scenario: config - disable access to package
    ℹ Running Node Scenario: config - config validation fails: invalid "resources" key
    ℹ Running Node Scenario: config - config validation fails: invalid "packages" key
    ℹ Running Node Scenario: config - config validation fails: invalid "globals" key
    ℹ Running Node Scenario: config - config validation fails: invalid "globals" value
    ℹ Running Node Scenario: config - config validation passes - everything valid
    ℹ Running Node Scenario: endowments - Date.now works in root and non-root
    ℹ Running Node Scenario: exportsDefense - readOnly restrictions have override workaround fix - updates the property correctly
```

Importantly, because Ava runs tests in child processes/workers, using `console` directly means the output is printed nondeterministically.  Using Ava's `t.log()`, the output is now nested beneath the test in question, and is always in order.
