### PR TITLE
fix(allow-scripts): add corepack to bannedBins

### DIFF
--- a/packages/allow-scripts/src/index.js
+++ b/packages/allow-scripts/src/index.js
@@ -292,7 +292,7 @@ async function runScript({ path, event }) {
   })
 }
 
-const bannedBins = new Set(['node', 'npm', 'yarn', 'pnpm'])
+const bannedBins = new Set(['corepack', 'node', 'npm', 'pnpm', 'yarn'])
 
 /**
  * @param {BinCandidates} binCandidates


### PR DESCRIPTION
Part of Node.js bundled package manager management tooling.

https://nodejs.org/api/corepack.html

https://www.npmjs.com/package/corepack

