### PR TITLE
fix(core): update LavamoatModuleRecord

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21852,6 +21852,7 @@
       "version": "15.1.1",
       "license": "MIT",
       "dependencies": {
+        "@babel/types": "7.23.6",
         "json-stable-stringify": "1.1.1",
         "lavamoat-tofu": "^7.1.0",
         "merge-deep": "3.0.3",
@@ -21864,6 +21865,19 @@
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+      }
+    },
+    "packages/core/node_modules/@babel/types": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "packages/lavapack": {

--- a/packages/core/.depcheckrc.yml
+++ b/packages/core/.depcheckrc.yml
@@ -13,3 +13,4 @@ ignores:
   - 'one'
   # types
   - '@types/json-stable-stringify'
+  - '@babel/types'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "test:ses": "diff -q ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js"
   },
   "dependencies": {
+    "@babel/types": "7.23.6",
     "json-stable-stringify": "1.1.1",
     "lavamoat-tofu": "^7.1.0",
     "merge-deep": "3.0.3",

--- a/packages/core/src/moduleRecord.js
+++ b/packages/core/src/moduleRecord.js
@@ -1,8 +1,76 @@
 // @ts-check
 
+/**
+ * A module record
+ *
+ * @template {any[]} [InitArgs=unknown[]] - Arguments for
+ *   {@link LavamoatModuleRecord.moduleInitializer}. Default is `unknown[]`
+ */
 class LavamoatModuleRecord {
   /**
-   * @param {LavamoatModuleRecordOptions} opts
+   * Module specifier
+   *
+   * @type {string}
+   */
+  specifier
+
+  /**
+   * A filepath if {@link type} is `js`; otherwise the same value as
+   * {@link specifier}
+   *
+   * @type {string}
+   */
+  file
+
+  /**
+   * The type of module
+   *
+   * @type {ModuleRecordType}
+   */
+  type
+
+  /**
+   * The containing package name if {@link type} is `js`; otherwise the same
+   * value as {@link specifier}
+   *
+   * @type {string}
+   */
+  packageName
+
+  /**
+   * Content of module (source code)
+   *
+   * Only applicable if {@link type} is `js`.
+   *
+   * @type {string | undefined}
+   */
+  content
+
+  /**
+   * Map of specifiers to resolved filepaths or specifiers
+   *
+   * @type {Record<string, string>}
+   */
+  importMap
+
+  /**
+   * Parsed AST, if any
+   *
+   * @type {import('@babel/types').File | undefined}
+   */
+  ast
+
+  /**
+   * Module initializer function
+   *
+   * @type {ModuleInitializer<InitArgs> | undefined}
+   */
+  moduleInitializer
+
+  /**
+   * Assigns properties!
+   *
+   * @param {LavamoatModuleRecordOptions<InitArgs>} opts
    */
   constructor({
     specifier,
@@ -28,16 +96,35 @@ class LavamoatModuleRecord {
 module.exports = { LavamoatModuleRecord }
 
 /**
- * @typedef LavamoatModuleRecordOptions
- * @property {string} specifier
- * @property {string} file
- * @property {'builtin' | 'native' | 'js'} type
- * @property {string} packageName
- * @property {string} [content]
- * @property {Record<string, string>} [importMap]
- * @property {import('@babel/types').File} [ast]
- * @property {(...args: any[]) => any} [moduleInitializer]
- * @todo `moduleInitializer` probably needs narrowing
+ * Options for {@link LavamoatModuleRecord} constructor.
  *
- * @todo `@babel/types` should be a prod dep
+ * @template {any[]} [InitArgs=unknown[]] - Arguments for
+ *   {@link LavamoatModuleRecordOptions.moduleInitializer}. Default is
+ *   `unknown[]`
+ * @typedef LavamoatModuleRecordOptions
+ * @property {string} specifier - Module specifier
+ * @property {string} file - Path to module file (or specifier)
+ * @property {ModuleRecordType} type - Module type
+ * @property {string} packageName - Package containing module (or specifier)
+ * @property {string} [content] - Content of module (source)
+ * @property {Record<string, string>} [importMap] - Import map
+ * @property {import('@babel/types').File} [ast] - Parsed AST
+ * @property {ModuleInitializer<InitArgs>} [moduleInitializer] - Module
+ *   initializer function
+ */
+
+/**
+ * Possible value of {@link LavamoatModuleRecord.type}.
+ *
+ * _Note:_ `js` means "source code", **not** "JavaScript source code"
+ *
+ * @typedef {'builtin' | 'native' | 'js'} ModuleRecordType
+ */
+
+/**
+ * Module initializer function; provides non-global variables to module scope
+ *
+ * @template {any[]} [InitArgs=unknown[]] - Arguments for the function. Default
+ *   is `unknown[]`
+ * @typedef {(...args: InitArgs) => void} ModuleInitializer
  */


### PR DESCRIPTION
- add missing `@babel/types` dep

This adds an optional `InitArgs` type argument that different implementations can use to define the arguments to the module initializer function.  For Node.js, that might be the type of `[module, require, exports, __dirname, __filename]` and for browserify/webpack, that's something else.

@kumavis @naugtur I'm not sure if my descriptions are correct; please let me know.



