### PR TITLE
chore: re-enable no-undef rule for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,9 +55,6 @@ module.exports = {
     // base rules; none of these are in eslint/recommended
     'no-empty': ['error', { allowEmptyCatch: true }],
 
-    // @typescript-eslint/no-unused-vars is more robust
-    'no-unused-vars': 'off',
-
     // additional errors not in n/recommended
     'n/callback-return': 'error',
     'n/handle-callback-err': 'error',
@@ -126,6 +123,8 @@ module.exports = {
       rules: {
         // eslint-plugin-n does not understand typescript imports
         'n/no-missing-import': 'off',
+        // eslint doesn't understand typescript
+        'no-unused-vars': 'off'
       },
       parser: '@typescript-eslint/parser',
     },

--- a/packages/browserify/test/generatePolicy.spec.js
+++ b/packages/browserify/test/generatePolicy.spec.js
@@ -1,5 +1,5 @@
-/* eslint-disable ava/use-t-well */
-/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars, ava/use-t-well */
+
 const test = require('ava')
 
 const { autoConfigForScenario } = require('./util')
@@ -38,6 +38,7 @@ test('generatePolicy - ignore various refs', async (t) => {
   const scenario = createScenarioFromScaffold({
     defineOne: () => {
       const js = [this]
+      // eslint-disable-next-line no-undef
       const ignored = [global, require, module, exports, arguments]
       const globalRefs = [typeof globalThis, typeof self, typeof window]
       global.xyz

--- a/packages/browserify/test/globalRef.spec.js
+++ b/packages/browserify/test/globalRef.spec.js
@@ -1,4 +1,6 @@
-/* eslint-disable no-undef */
+// eslint-disable-next-line no-unused-vars
+/* global checkThis: true, checkSelf: true, checkWindow: true, checkGlobal: true */
+
 const test = require('ava')
 const { runScenario } = require('./util')
 const {

--- a/packages/browserify/test/sourcemaps.js
+++ b/packages/browserify/test/sourcemaps.js
@@ -16,9 +16,8 @@ async function verifySourceMaps({ bundle, log = console.error.bind(console) }) {
 }
 
 async function verifyWithSourceExplorer(bundle) {
-  let result
   try {
-    result = await explore({ code: Buffer.from(bundle, 'utf8') })
+    await explore({ code: Buffer.from(bundle, 'utf8') })
   } catch (resultWithError) {
     if (resultWithError.errors) {
       resultWithError.errors.forEach((exploreError) => {
@@ -40,15 +39,12 @@ async function verifySamples(bundle, log) {
     log('SourcemapValidator - missing content of some sources...')
   }
 
-  let sampleCount = 0
-
   const buildLines = bundle.split('\n')
   const targetString = 'module.exports'
   const matchesPerLine = buildLines.map((line) => indicesOf(targetString, line))
   const errors = []
   matchesPerLine.forEach((matchIndices, lineIndex) => {
     matchIndices.forEach((matchColumn) => {
-      sampleCount += 1
       const position = { line: lineIndex + 1, column: matchColumn }
       const result = consumer.originalPositionFor(position)
       // warn if source content is missing

--- a/packages/core/lib/strict-scope-terminator.js
+++ b/packages/core/lib/strict-scope-terminator.js
@@ -24,11 +24,10 @@ const d = (strings, args) => strings.join() + args.join()
 const q = (arg) => arg
 
 /**
- * alwaysThrowHandler
- * This is an object that throws if any property is called. It's used as
- * a proxy handler which throws on any trap called.
- * It's made from a proxy with a get trap that throws. It's safe to
- * create one and share it between all Proxy handlers.
+ * AlwaysThrowHandler This is an object that throws if any property is called.
+ * It's used as a proxy handler which throws on any trap called. It's made from
+ * a proxy with a get trap that throws. It's safe to create one and share it
+ * between all Proxy handlers.
  */
 const alwaysThrowHandler = new Proxy(
   immutableObject,
@@ -42,16 +41,19 @@ const alwaysThrowHandler = new Proxy(
 )
 
 /**
- * scopeTerminatorHandler manages a strictScopeTerminator Proxy which serves as
- * the final scope boundary that will always return "undefined" in order
- * to prevent access to "start compartment globals".
+ * ScopeTerminatorHandler manages a strictScopeTerminator Proxy which serves as
+ * the final scope boundary that will always return "undefined" in order to
+ * prevent access to "start compartment globals".
+ *
  * @type {ProxyHandler}
  */
 const scopeProxyHandlerProperties = {
+  // eslint-disable-next-line no-unused-vars
   get(_shadow, _prop) {
     return undefined
   },
 
+  // eslint-disable-next-line no-unused-vars
   set(_shadow, prop, _value) {
     // We should only hit this if the has() hook returned true matches the v8
     // ReferenceError message "Uncaught ReferenceError: xyz is not defined"

--- a/packages/core/test/globals.spec.js
+++ b/packages/core/test/globals.spec.js
@@ -1,4 +1,5 @@
-/* eslint-disable no-undef, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* global abc: true, xyz, chrome */
 
 const test = require('ava')
 const { createScenarioFromScaffold, runScenario } = require('./util')

--- a/packages/lavapack/test/index.spec.js
+++ b/packages/lavapack/test/index.spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const test = require('ava')
-const { pipe, from, concat } = require('mississippi')
+const { pipe, concat } = require('mississippi')
 const { SourceMapConsumer } = require('source-map')
 const convertSourceMap = require('convert-source-map')
 const pack = require('../src')

--- a/packages/lavapack/test/sourcemaps.spec.js
+++ b/packages/lavapack/test/sourcemaps.spec.js
@@ -13,6 +13,7 @@ test.skip('sourcemaps - adjust maps for wrapper', async (t) => {
   var three = two + 1
   `
 
+  // eslint-disable-next-line no-undef
   const result = UglifyJS.minify(
     { './foo.js': fooSource },
     {
@@ -52,6 +53,7 @@ function indicesOf(substring, string) {
 // this is not perfecct - just a heuristic
 async function validateSourcemaps(t, sourceMeta) {
   const targetSlug = 'new Error'
+  // eslint-disable-next-line no-undef
   const consumer = await new SourceMapConsumer(sourceMeta.maps)
   t.true(consumer.hasContentsOfAllSources(), 'has the contents of all sources')
 

--- a/packages/laverna/test/laverna.spec.js
+++ b/packages/laverna/test/laverna.spec.js
@@ -135,6 +135,7 @@ test.beforeEach((t) => {
      * @param {import('node:child_process').SpawnOptions} opts
      * @returns {import('node:events').EventEmitter}
      */
+    // eslint-disable-next-line no-unused-vars
     (cmd, args, opts) => {
       const ee = new EventEmitter()
       setImmediate(() => {

--- a/packages/tofu/test/findGlobals.spec.js
+++ b/packages/tofu/test/findGlobals.spec.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs')
 const path = require('path')
-const assert = require('assert')
 const test = require('ava')
 const { parse } = require('../src/index')
 const { findGlobals } = require('../src/findGlobals')

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -1,4 +1,5 @@
-/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
+/* global xyz: true, zzz, a, b, c, z: true, abc: true, manifest */
 
 const { EOL } = require('node:os')
 const test = require('ava')

--- a/packages/tofu/test/inspectImports.spec.js
+++ b/packages/tofu/test/inspectImports.spec.js
@@ -41,6 +41,7 @@ testInspect(
   'cjs - include even if declared var is unused',
   {},
   () => {
+    // eslint-disable-next-line no-unused-vars
     const rfs = require('fs').readFileSync
   },
   {

--- a/packages/tofu/test/inspectPrimordialAssignments.spec.js
+++ b/packages/tofu/test/inspectPrimordialAssignments.spec.js
@@ -1,9 +1,5 @@
 const test = require('ava')
-const {
-  parse,
-  inspectPrimordialAssignments,
-  environmentTypes,
-} = require('../src/index')
+const { parse, inspectPrimordialAssignments } = require('../src/index')
 
 function inspectPrimordialAssignmentsTest(code) {
   return inspectPrimordialAssignments(parse(code))

--- a/packages/webpack/test/e2e-hack.spec.js
+++ b/packages/webpack/test/e2e-hack.spec.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 // eslint-disable-next-line ava/no-import-test-files
-const { scaffold, runScriptWithSES, runScript } = require('./scaffold.js')
+const { scaffold, runScriptWithSES } = require('./scaffold.js')
 const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
 
 test.before(async (t) => {

--- a/packages/webpack/test/scaffold.js
+++ b/packages/webpack/test/scaffold.js
@@ -2,7 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const memfs = require('memfs')
 const { toSnapshotSync } = require('memfs/lib/snapshot')
-const { createContext, Script, runInNewContext } = require('vm')
+const { createContext, runInNewContext } = require('vm')
 const { readFileSync } = require('fs')
 
 /**


### PR DESCRIPTION
~~This needs #960 to pass CI, but I cannot target a branch in a fork.~~

`no-undef` was disabled because we use a lot of undefined variables, but it's better to create lint exceptions on a line-by-line or file-by-file basis, since it can cause the problem fixed in #960.
