### PR TITLE
chore(renovate): ignore new major version of espree

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,7 @@
       matchPackageNames: [
         // Missing support for LavaMoat supported major Node.js version(s)
         'copy-webpack-plugin',
+        'espree',
 
         // ESM-only packages
         '@types/wrap-ansi',


### PR DESCRIPTION
breaks node16 compat; runtime dep of lavapack