### PR TITLE
chore(browserify,lavapack): remove extraneous stale gitHead from package.json

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -60,7 +60,6 @@
     "timeout": "2m",
     "concurrency": 1
   },
-  "gitHead": "28a238fc4c3d55650bd2ba9a3603b1f275567286",
   "lavamoat": {
     "allowScripts": {
       "keccak": false

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -50,6 +50,5 @@
       "test/*.spec.js"
     ],
     "timeout": "30s"
-  },
-  "gitHead": "28a238fc4c3d55650bd2ba9a3603b1f275567286"
+  }
 }


### PR DESCRIPTION
The `gitHead` field should be filled by registry and not be present in sources. This removes stale entries from `lavamoat-browserify` and `lavapack`.