### PR TITLE
chore(pre-commit): test:prep on package-lock.json change

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     ],
     "!((package-lock|policy)*).json": [
       "prettier --write"
+    ],
+    "package-lock.json": [
+      "npm run test:prep"
     ]
   },
   "prettier": {


### PR DESCRIPTION
Changes in `package-lock.json` often result in fixture policy changes.

This runs test:prep as part of git pre-commit hook if lockfile is changed.

#### Related
- #721 
- #825 