### PR TITLE
feat(aa): support symlinks for workspace and devtime linking compatibility

### DIFF
--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { readFileSync } = require('node:fs')
+const { readFileSync, realpathSync, lstatSync } = require('node:fs')
 const path = require('node:path')
 const nodeResolve = require('resolve')
 
@@ -141,6 +141,14 @@ function getDependencies(packageDir, includeDevDeps) {
   return depsToWalk
 }
 
+/**
+ * @param {string} location
+ */
+function isSymlink(location) {
+  const info = lstatSync(location)
+  return info.isSymbolicLink()
+}
+
 /** @type {WalkDepTreeOpts[]} */
 let currentLevelTodos
 
@@ -174,6 +182,15 @@ function walkDependencyTreeForBestLogicalPaths({
     }
   } while (currentLevelTodos.length > 0)
 
+  for (const [
+    packageDir,
+    logicalPath,
+  ] of preferredPackageLogicalPathMap.entries()) {
+    if (isSymlink(packageDir)) {
+      const realPath = realpathSync(packageDir)
+      preferredPackageLogicalPathMap.set(realPath, logicalPath)
+    }
+  }
   return preferredPackageLogicalPathMap
 }
 

--- a/packages/aa/test/benchmark1.spec.js
+++ b/packages/aa/test/benchmark1.spec.js
@@ -1,0 +1,61 @@
+const { realpathSync, lstatSync } = require('node:fs')
+const path = require('node:path')
+const test = require('ava')
+
+function isSymlink(location) {
+  const info = lstatSync(location)
+  return info.isSymbolicLink()
+}
+
+const symlink = path.join(__dirname, './projects/4/node_modules/aaa')
+const notsymlink = path.join(__dirname, './projects/4/node_modules/bbb')
+
+const bench = (fn, name) => {
+  const t0 = performance.now()
+  for (let i = 0; i < 10000; i++) {
+    fn()
+  }
+  const t1 = performance.now()
+  return [name, t1 - t0]
+}
+
+const ratioIsBelow = (a, b, expected) => {
+  const ratio = a / b
+  return ratio < expected
+}
+
+test('[bench] isSymlink is significantly faster than realpathSync in a naive microbenchmark', (t) => {
+  const entries = [
+    bench(() => {
+      isSymlink(symlink)
+    }, 'isSymlink(symlink)'),
+    bench(() => {
+      isSymlink(notsymlink)
+    }, 'isSymlink(notsymlink)'),
+    bench(() => {
+      realpathSync(symlink)
+    }, 'realpathSync(symlink)'),
+    bench(() => {
+      realpathSync(notsymlink)
+    }, 'realpathSync(notsymlink)'),
+  ]
+
+  const results = Object.fromEntries(entries)
+  t.log({ results })
+  t.assert(
+    ratioIsBelow(
+      results['isSymlink(symlink)'],
+      results['realpathSync(symlink)'],
+      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+    ),
+    'expected isSymlink(symlink) to be much faster than realpathSync(symlink)'
+  )
+  t.assert(
+    ratioIsBelow(
+      results['isSymlink(notsymlink)'],
+      results['realpathSync(notsymlink)'],
+      0.2 // the tradeoff is worth it up until close to 1, so this number can be increased.
+    ),
+    'expected isSymlink(notsymlink) to be much faster than realpathSync(notsymlink)'
+  )
+})

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -1,19 +1,26 @@
+const resolve = require('resolve')
 const path = require('path')
 const test = require('ava')
 const { loadCanonicalNameMap } = require('../src/index.js')
-
-test('project 1', async (t) => {
-  const canonicalNameMap = await loadCanonicalNameMap({
-    rootDir: path.join(__dirname, 'projects', '1'),
-  })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
+const { Module } = require('node:module')
+/**
+ *
+ * @param {import('../src/index.js').CanonicalNameMap} map
+ */
+function normalizeEntries(map) {
+  return [...map.entries()]
     .sort()
     .map(([packagePath, canonicalName]) => [
       path.relative(__dirname, packagePath),
       canonicalName,
     ])
-  t.deepEqual(normalizedMapEntries, [
+}
+
+test('project 1', async (t) => {
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir: path.join(__dirname, 'projects', '1'),
+  })
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/1', '$root$'],
     ['projects/1/node_modules/aaa', 'aaa'],
     ['projects/1/node_modules/bbb', 'bbb'],
@@ -25,14 +32,7 @@ test('project 2', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '2'),
   })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
-    .sort()
-    .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
-      canonicalName,
-    ])
-  t.deepEqual(normalizedMapEntries, [
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/2', '$root$'],
     ['projects/2/node_modules/aaa', 'aaa'],
     ['projects/2/node_modules/bbb', 'bbb'],
@@ -45,18 +45,33 @@ test('project 3', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '3'),
   })
-  // normalize results to be relative
-  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
-    .sort()
-    .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
-      canonicalName,
-    ])
-  t.deepEqual(normalizedMapEntries, [
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
     ['projects/3', '$root$'],
     ['projects/3/node_modules/aaa', 'aaa'],
     ['projects/3/node_modules/bbb', 'bbb'],
     ['projects/3/node_modules/bbb/node_modules/good_dep', 'bbb>good_dep'],
     ['projects/3/node_modules/evil_dep', 'evil_dep'],
+  ])
+})
+
+test('custom Resolver', async (t) => {
+  const rootDir = path.join(__dirname, 'projects', '1')
+  /** @type {import('../src/index.js').Resolver} */
+  const resolver = {
+    sync: (moduleId, { basedir }) => {
+      return Module.createRequire(path.join(basedir, 'dummy.js')).resolve(
+        moduleId
+      )
+    },
+  }
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir,
+    resolve: resolver,
+  })
+  t.deepEqual(normalizeEntries(canonicalNameMap), [
+    ['projects/1', '$root$'],
+    ['projects/1/node_modules/aaa', 'aaa'],
+    ['projects/1/node_modules/bbb', 'bbb'],
+    ['projects/1/node_modules/bbb/node_modules/evil_dep', 'bbb>evil_dep'],
   ])
 })

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -54,7 +54,26 @@ test('project 3', async (t) => {
   ])
 })
 
-test('custom Resolver', async (t) => {
+test('project 4 - workspace symlink', async (t) => {
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir: path.join(__dirname, 'projects', '4', 'packages', 'stuff'),
+  })
+  // normalize results to be relative
+  const normalizedMapEntries = Array.from(canonicalNameMap.entries())
+    .sort()
+    .map(([packagePath, canonicalName]) => [
+      path.relative(__dirname, packagePath),
+      canonicalName,
+    ])
+  t.deepEqual(normalizedMapEntries, [
+    ['projects/4/node_modules/aaa', 'aaa'],
+    ['projects/4/node_modules/bbb', 'bbb'],
+    ['projects/4/packages/aaa', 'aaa'], // symlink resolved
+    ['projects/4/packages/stuff', '$root$'],
+  ])
+})
+
+test('project 1 - with custom resolver', async (t) => {
   const rootDir = path.join(__dirname, 'projects', '1')
   /** @type {import('../src/index.js').Resolver} */
   const resolver = {

--- a/packages/aa/test/projects/4/node_modules/aaa
+++ b/packages/aa/test/projects/4/node_modules/aaa
@@ -1,0 +1,1 @@
+../packages/aaa

--- a/packages/aa/test/projects/4/node_modules/bbb/package.json
+++ b/packages/aa/test/projects/4/node_modules/bbb/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bbb",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/aa/test/projects/4/package.json
+++ b/packages/aa/test/projects/4/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "4",
+  "version": "1.0.0",
+  "description": ""
+}

--- a/packages/aa/test/projects/4/packages/aaa/package.json
+++ b/packages/aa/test/projects/4/packages/aaa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aaa",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "main": "index.js",
+  "keywords": [],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/packages/aa/test/projects/4/packages/stuff/package.json
+++ b/packages/aa/test/projects/4/packages/stuff/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "aaa": "^1.0.0",
+    "bbb": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Rebased on #808 _(but now I think it should have been the other way around :see_no_evil: )_

Packages from workspace ended up as `external:../name` because we did not recognize their final location after resolving links and some of the tools that asked for canonical names for locations were using the fully resolved paths. Instead of fighting the ecosystem for consistent link behavior, I propose we throw money (RAM) at it.

What does this fix?
Our policies are bloated with entries like:
`"external:../snaps-sdk/src/ui/components/panel.ts"` 
`"external:../snaps-sdk/src/ui/components/row.ts"` 
when a package from a workspace is being depended on. 
Resolving the symlink in `../../node_modules/@metamask/snaps-sdk` to `../snaps-sdk` will help when lookups end up asking for those locations. (more precisely these would be absolute paths for the most part) 

This should also be useful for workspace support in allow-scripts, but I did not verify. (@legobeat )


Sidenote:
This solution is expensive but general.
I can imagine a solution where we go up to the package.json of the workspace and read the workspace configuration and only add duplicate entries for the workspace items. 
That would be much more performant, but would only solve for workspace and not other cases where links are created (like local folder installations or other trickery)

Both approaches are worth considering.