### PR TITLE
chore(core): run scenarios in ava context

### DIFF
--- a/packages/core/test/runScenarios.spec.js
+++ b/packages/core/test/runScenarios.spec.js
@@ -1,21 +1,22 @@
 const test = require('ava')
-const { loadScenarios } = require('./scenarios/index')
+const { loadScenarios } = require('./scenarios')
 const { runScenario, runAndTestScenario } = require('./util')
 
-test('Run scenarios', async (t) => {
+;(async () => {
   for await (const scenario of loadScenarios()) {
-    t.log(`Running Core Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) =>
-      runScenario({ scenario })
-    )
-  }
-})
+    test.serial(`core scenario: ${scenario.name}`, async (t) => {
+      await runAndTestScenario(t, scenario, ({ scenario }) =>
+        runScenario({ scenario })
+      )
+    })
 
-test('Run scenarios with precompiled intializer', async (t) => {
-  for await (const scenario of loadScenarios()) {
-    t.log(`Running Core Scenario: ${scenario.name}`)
-    await runAndTestScenario(t, scenario, ({ scenario }) =>
-      runScenario({ scenario, runWithPrecompiledModules: true })
+    test.serial(
+      `core scenario (precompiled initializer): ${scenario.name}`,
+      async (t) => {
+        await runAndTestScenario(t, scenario, ({ scenario }) =>
+          runScenario({ scenario, runWithPrecompiledModules: true })
+        )
+      }
     )
   }
-})
+})()


### PR DESCRIPTION
This changes the `runScenarios` test so that there's a 1:1 mapping between each scenario and an Ava test.

<details>
This requires changing the file to be `.mjs`, however.

Also: ESLint is mightily confused, and after hammering on it for a little bit, I still couldn't figure out what magic incantations I needed to get it to parse the file.

Take it or leave it!  (by that I mean: I _totally understand_ if nobody wants to merge this. I'm not sure I do!)
</details>

**UPDATE Jan 27 2025**

This change no longer requires switching any files to ESM.