### PR TITLE
windows-compat: aa, allow-scripts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,10 +68,13 @@ jobs:
     env:
       FORCE_COLOR: 1
       TEST_WORKSPACES: >-
+        --workspace=packages/aa
+        --workspace=packages/allow-scripts
         --workspace=packages/core
         --workspace=packages/lavapack
         --workspace=packages/preinstall-always-fail
         --workspace=packages/tofu
+        --workspace=packages/yarn-plugin-allow-scripts
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -11897,7 +11897,9 @@
       "license": "ISC"
     },
     "node_modules/inline-source-map": {
-      "version": "0.6.2",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.3.tgz",
+      "integrity": "sha512-1aVsPEsJWMJq/pdMU61CDlm1URcW702MTB4w9/zUjMus6H/Py8o7g68Pr9D4I6QluWGt/KdmswuRhaA05xVR1w==",
       "license": "MIT",
       "dependencies": {
         "source-map": "~0.5.3"

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -269,7 +269,7 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
   // files should never be associated with a package directory across a package boundary (as tested via the presense of "node_modules" in the path)
   if (relativeToPackageDir.includes('node_modules')) {
     throw new Error(
-      `LavaMoat - Encountered unknown package directory for file "${modulePath}"`
+      `LavaMoat - Encountered unknown package directory "${relativeToPackageDir}" for file "${modulePath}"`
     )
   }
   return packageName

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -11,7 +11,7 @@ function normalizeEntries(map) {
   return [...map.entries()]
     .sort()
     .map(([packagePath, canonicalName]) => [
-      path.relative(__dirname, packagePath),
+      path.normalize(path.relative(__dirname, packagePath)),
       canonicalName,
     ])
 }

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "lint:deps": "depcheck",
     "test": "npm run test:run",
-    "test:prep": "for d in ./test/projects/*/ ; do (cd \"$d\" && ../../../src/cli.js auto --experimental-bins); done",
+    "test:prep": "test/prepare.sh",
     "test:run": "ava"
   },
   "dependencies": {

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "lint:deps": "depcheck",
     "test": "npm run test:run",
-    "test:prep": "test/prepare.sh",
+    "test:prep": "node test/prepare.js",
     "test:run": "ava"
   },
   "dependencies": {

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -31,7 +31,9 @@ test('cli - auto command', (t) => {
   )
 
   // forward error output for debugging
-  t.log(result.stderr.toString('utf-8'))
+  if (result.stderr) {
+    t.log(result.stderr.toString('utf-8'))
+  }
 
   // get the package.json
   const packageJsonContents = JSON.parse(
@@ -63,7 +65,9 @@ test('cli - auto command with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  t.log(result.stderr.toString('utf-8'))
+  if (result.stderr) {
+    t.log(result.stderr.toString('utf-8'))
+  }
 
   // get the package.json
   const packageJsonContents = JSON.parse(
@@ -138,7 +142,9 @@ test('cli - run command - good dep at the root with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  t.log(result.stderr.toString('utf-8'))
+  if (result.stderr) {
+    t.log(result.stderr.toString('utf-8'))
+  }
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
@@ -190,8 +196,8 @@ test('cli - run command - good dep as a sub dep', (t) => {
   )
 
   // uncomment to forward error output for debugging
-  t.log(result.stdout.toString('utf-8'))
-  t.log(result.stderr.toString('utf-8'))
+  // t.log(result.stdout.toString('utf-8'))
+  // t.log(result.stderr.toString('utf-8'))
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -21,7 +21,28 @@ test('cli - auto command', (t) => {
   fs.rmSync(path.join(projectRoot, PACKAGE_JSON), { force: true })
 
   // npm init -y
-  spawnSync('npm', ['init', '-y'], realisticEnvOptions(projectRoot))
+  let initResult = spawnSync(
+    'npm',
+    ['init', '-y'],
+    realisticEnvOptions(projectRoot)
+  )
+
+  // forward error output for debugging
+  if (typeof initResult.stderr !== 'undefined') {
+    t.log(initResult.stderr.toString('utf-8'))
+  } else {
+    t.fail(
+      `Failed calling 'npm init -y': ${JSON.stringify(
+        {
+          projectRoot,
+          options: realisticEnvOptions(projectRoot),
+          initResult,
+        },
+        undefined,
+        2
+      )}`
+    )
+  }
 
   // run the auto command
   let result = spawnSync(
@@ -31,8 +52,20 @@ test('cli - auto command', (t) => {
   )
 
   // forward error output for debugging
-  if (result.stderr) {
+  if (typeof result.stderr !== 'undefined') {
     t.log(result.stderr.toString('utf-8'))
+  } else {
+    t.fail(
+      `Failed calling '${ALLOW_SCRIPTS_BIN} auto': ${JSON.stringify(
+        {
+          projectRoot,
+          options: realisticEnvOptions(projectRoot),
+          result,
+        },
+        undefined,
+        2
+      )}`
+    )
   }
 
   // get the package.json
@@ -65,8 +98,20 @@ test('cli - auto command with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  if (result.stderr) {
+  if (typeof result.stderr !== 'undefined') {
     t.log(result.stderr.toString('utf-8'))
+  } else {
+    t.fail(
+      `Failed calling '${ALLOW_SCRIPTS_BIN} auto --experimental-bins': ${JSON.stringify(
+        {
+          projectRoot,
+          options: realisticEnvOptions(projectRoot),
+          result,
+        },
+        undefined,
+        2
+      )}`
+    )
   }
 
   // get the package.json
@@ -105,7 +150,21 @@ test('cli - run command - good dep at the root', (t) => {
   )
 
   // forward error output for debugging
-  t.log(result.stderr.toString('utf-8'))
+  if (typeof result.stderr !== 'undefined') {
+    t.log(result.stderr.toString('utf-8'))
+  } else {
+    t.fail(
+      `Failed calling '${ALLOW_SCRIPTS_BIN} run': ${JSON.stringify(
+        {
+          projectRoot,
+          options: realisticEnvOptions(projectRoot),
+          result,
+        },
+        undefined,
+        2
+      )}`
+    )
+  }
 
   // assert the output
   t.deepEqual(result.stdout.toString().split('\n'), [
@@ -142,8 +201,20 @@ test('cli - run command - good dep at the root with experimental bins', (t) => {
   )
 
   // forward error output for debugging
-  if (result.stderr) {
+  if (typeof result.stderr !== 'undefined') {
     t.log(result.stderr.toString('utf-8'))
+  } else {
+    t.fail(
+      `Failed calling '${ALLOW_SCRIPTS_BIN} run --experimental-bins': ${JSON.stringify(
+        {
+          projectRoot,
+          options: realisticEnvOptions(projectRoot),
+          result,
+        },
+        undefined,
+        2
+      )}`
+    )
   }
 
   // assert the output

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -5,7 +5,14 @@ const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 const { pathToFileURL } = require('node:url')
 
-const NPM_CMD = os.platform() === 'win32' ? 'npm.cmd' : 'npm'
+const isWindows = os.platform() === 'win32'
+const NPM_CMD = isWindows ? 'npm.cmd' : 'npm'
+/* eslint-disable ava/no-skip-test */
+const skipOnWindows =
+  isWindows
+    ? (description, ...args) =>
+        test.skip('[no Windows support] ' + description, ...args)
+    : test
 
 /**
  * For fat fingers
@@ -14,25 +21,22 @@ const PACKAGE_JSON = 'package.json'
 
 /**
  * Execute allow-scripts binaries with the given arguments
- * @param {any} t ava test object
+ *
+ * @param {any} t Ava test object
  * @param {string[]} args Arguments to pass
  * @param {string} cwd Working directory to execute command from
- * @returns {{stderr: string, stdout: string, status: number}} Process result
+ * @returns {{ stderr: string; stdout: string; status: number }} Process result
  */
 const run = (t, args, cwd) => {
   // Path to the allow-scripts executable
   const ALLOW_SCRIPTS_BIN = require.resolve('../src/cli')
   const options = realisticEnvOptions(cwd)
-  const result = spawnSync(
-    'node',
-    [
-      ALLOW_SCRIPTS_BIN,
-      ...args,
-    ],
-    options,
-  )
+  const result = spawnSync('node', [ALLOW_SCRIPTS_BIN, ...args], options)
 
-  if (typeof result.stderr === 'undefined' || typeof result.status !== 'number') {
+  if (
+    typeof result.stderr === 'undefined' ||
+    typeof result.status !== 'number'
+  ) {
     t.fail(
       `Failed calling 'node ${ALLOW_SCRIPTS_BIN} ${args.join(' ')}': ${JSON.stringify(
         {
@@ -55,7 +59,6 @@ const run = (t, args, cwd) => {
     stdout: result.stdout,
   }
 }
-
 
 test('cli - auto command', (t) => {
   // set up the directories
@@ -109,7 +112,7 @@ test('cli - auto command', (t) => {
   })
 })
 
-test('cli - auto command with experimental bins', (t) => {
+skipOnWindows('cli - auto command with experimental bins', (t) => {
   // set up the directories
   let projectRoot = path.join(__dirname, 'projects', '1')
 
@@ -173,43 +176,46 @@ test('cli - run command - good dep at the root', (t) => {
   // with
   // "preinstall": "touch /tmp/$( date '+%Y-%m-%d_%H-%M-%S' )"
 })
-test('cli - run command - good dep at the root with experimental bins', (t) => {
-  // set up the directories
-  let projectRoot = path.join(__dirname, 'projects', '2')
+skipOnWindows(
+  'cli - run command - good dep at the root with experimental bins',
+  (t) => {
+    // set up the directories
+    let projectRoot = path.join(__dirname, 'projects', '2')
 
-  // clean up from a previous run
-  // the force option is only here to stop rm complaining if target is missing
-  fs.rmSync(path.join(projectRoot, 'node_modules', '.bin'), {
-    recursive: true,
-    force: true,
-  })
+    // clean up from a previous run
+    // the force option is only here to stop rm complaining if target is missing
+    fs.rmSync(path.join(projectRoot, 'node_modules', '.bin'), {
+      recursive: true,
+      force: true,
+    })
 
-  // run the "run" command
-  const result = run(t, ['run', '--experimental-bins'], projectRoot)
+    // run the "run" command
+    const result = run(t, ['run', '--experimental-bins'], projectRoot)
 
-  // assert the output
-  t.deepEqual(result.stdout.toString().split('\n'), [
-    'installing bin scripts',
-    '- good - from package: good_dep',
-    'running lifecycle scripts for event "preinstall"',
-    '- good_dep',
-    'running lifecycle scripts for event "install"',
-    'running lifecycle scripts for event "postinstall"',
-    'running lifecycle scripts for top level package',
-    '',
-  ])
+    // assert the output
+    t.deepEqual(result.stdout.toString().split('\n'), [
+      'installing bin scripts',
+      '- good - from package: good_dep',
+      'running lifecycle scripts for event "preinstall"',
+      '- good_dep',
+      'running lifecycle scripts for event "install"',
+      'running lifecycle scripts for event "postinstall"',
+      'running lifecycle scripts for top level package',
+      '',
+    ])
 
-  t.assert(
-    fs.existsSync(path.join(projectRoot, 'node_modules', '.bin', 'good')),
-    'Expected a bin script to be installed in top level node_modules'
-  )
+    t.assert(
+      fs.existsSync(path.join(projectRoot, 'node_modules', '.bin', 'good')),
+      'Expected a bin script to be installed in top level node_modules'
+    )
 
-  // note
-  // we could also test whether the preinstall script is
-  // actually executing. we did it manually by replacing
-  // with
-  // "preinstall": "touch /tmp/$( date '+%Y-%m-%d_%H-%M-%S' )"
-})
+    // note
+    // we could also test whether the preinstall script is
+    // actually executing. we did it manually by replacing
+    // with
+    // "preinstall": "touch /tmp/$( date '+%Y-%m-%d_%H-%M-%S' )"
+  }
+)
 
 test('cli - run command - good dep as a sub dep', (t) => {
   // set up the directories
@@ -244,65 +250,68 @@ test('cli - run command - good dep as a sub dep', (t) => {
   ])
 })
 
-test('cli - run command - good dep as a sub dep with experimental bins', (t) => {
-  // set up the directories
-  let projectRoot = path.join(__dirname, 'projects', '3')
+skipOnWindows(
+  'cli - run command - good dep as a sub dep with experimental bins',
+  (t) => {
+    // set up the directories
+    let projectRoot = path.join(__dirname, 'projects', '3')
 
-  // clean up from a previous run
-  // the force option is only here to stop rm complaining if target is missing
-  fs.rmSync(
-    path.join(projectRoot, 'node_modules', 'bbb', '.goodscriptworked'),
-    { force: true }
-  )
-  fs.rmSync(path.join(projectRoot, 'node_modules', '.bin'), {
-    recursive: true,
-    force: true,
-  })
-  // run the "run" command
-  const result = run(t, ['run', '--experimental-bins'], projectRoot)
+    // clean up from a previous run
+    // the force option is only here to stop rm complaining if target is missing
+    fs.rmSync(
+      path.join(projectRoot, 'node_modules', 'bbb', '.goodscriptworked'),
+      { force: true }
+    )
+    fs.rmSync(path.join(projectRoot, 'node_modules', '.bin'), {
+      recursive: true,
+      force: true,
+    })
+    // run the "run" command
+    const result = run(t, ['run', '--experimental-bins'], projectRoot)
 
-  t.assert(
-    fs.existsSync(
-      path.join(
-        projectRoot,
-        'node_modules',
-        'bbb',
-        'node_modules',
-        '.bin',
-        'good'
-      )
-    ),
-    'Expected a nested bin script to be installed in bbb/node_modules/.bin'
-  )
-  const errarr = result.stderr.toString().split('\n')
-  t.assert(
-    errarr.every((line) => !line.includes('you shall not pass')),
-    'Should not have run the parent script from the nested package postinstall'
-  )
-  t.assert(
-    errarr.some((line) => line.includes('"good": "node_modules/')),
-    'Expected to see instructions on how to enable a bin script1'
-  )
-  t.assert(
-    errarr.some((line) => line.includes('node_modules/good_dep/cli.js')),
-    'Expected to see instructions on how to enable a bin script2'
-  )
-  t.assert(
-    errarr.some((line) => line.includes('node_modules/aaa/shouldntrun.sh')),
-    'Expected to see instructions on how to enable a bin script3'
-  )
-  // assert the output
-  t.deepEqual(result.stdout.toString().split('\n'), [
-    'installing bin scripts',
-    '- good - from package: aaa',
-    'running lifecycle scripts for event "preinstall"',
-    '- bbb>good_dep',
-    'running lifecycle scripts for event "install"',
-    'running lifecycle scripts for event "postinstall"',
-    '- bbb',
-    '',
-  ])
-})
+    t.assert(
+      fs.existsSync(
+        path.join(
+          projectRoot,
+          'node_modules',
+          'bbb',
+          'node_modules',
+          '.bin',
+          'good'
+        )
+      ),
+      'Expected a nested bin script to be installed in bbb/node_modules/.bin'
+    )
+    const errarr = result.stderr.toString().split('\n')
+    t.assert(
+      errarr.every((line) => !line.includes('you shall not pass')),
+      'Should not have run the parent script from the nested package postinstall'
+    )
+    t.assert(
+      errarr.some((line) => line.includes('"good": "node_modules/')),
+      'Expected to see instructions on how to enable a bin script1'
+    )
+    t.assert(
+      errarr.some((line) => line.includes('node_modules/good_dep/cli.js')),
+      'Expected to see instructions on how to enable a bin script2'
+    )
+    t.assert(
+      errarr.some((line) => line.includes('node_modules/aaa/shouldntrun.sh')),
+      'Expected to see instructions on how to enable a bin script3'
+    )
+    // assert the output
+    t.deepEqual(result.stdout.toString().split('\n'), [
+      'installing bin scripts',
+      '- good - from package: aaa',
+      'running lifecycle scripts for event "preinstall"',
+      '- bbb>good_dep',
+      'running lifecycle scripts for event "install"',
+      'running lifecycle scripts for event "postinstall"',
+      '- bbb',
+      '',
+    ])
+  }
+)
 
 /**
  * @param {string} projectRoot

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -31,14 +31,14 @@ const run = (t, args, cwd) => {
   // Path to the allow-scripts executable
   const ALLOW_SCRIPTS_BIN = require.resolve('../src/cli')
   const options = realisticEnvOptions(cwd)
-  const result = spawnSync('node', [ALLOW_SCRIPTS_BIN, ...args], options)
+  const result = spawnSync(process.execPath, [ALLOW_SCRIPTS_BIN, ...args], options)
 
   if (
     typeof result.stderr === 'undefined' ||
     typeof result.status !== 'number'
   ) {
     t.fail(
-      `Failed calling 'node ${ALLOW_SCRIPTS_BIN} ${args.join(' ')}': ${JSON.stringify(
+      `Failed calling '${process.execPath} ${ALLOW_SCRIPTS_BIN} ${args.join(' ')}': ${JSON.stringify(
         {
           cwd,
           options,

--- a/packages/allow-scripts/test/prepare.js
+++ b/packages/allow-scripts/test/prepare.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process')
+const { readdirSync } = require('node:fs')
+const { join, normalize } = require('node:path')
+
+// Execute allow-scripts command inside each test project directory
+readdirSync(join(__dirname, '../test/projects/'), { withFileTypes: true })
+  .filter((p) => p.isDirectory())
+  .forEach((dir) => {
+    try {
+      execSync(`node ${normalize('../../../src/cli.js')} auto --experimental-bins`, {
+        cwd: join(__dirname, '../test/projects/', dir.name),
+        stdio: 'inherit',
+      })
+    } catch (e) {
+      // ignore expected error
+      if (e.status !== 1) {
+        throw e
+      }
+    }
+  })

--- a/packages/allow-scripts/test/prepare.js
+++ b/packages/allow-scripts/test/prepare.js
@@ -1,20 +1,17 @@
-const { execSync } = require('child_process')
-const { readdirSync } = require('node:fs')
+const { execSync } = require('node:child_process')
+const { existsSync, readdirSync } = require('node:fs')
 const { join, normalize } = require('node:path')
 
 // Execute allow-scripts command inside each test project directory
-readdirSync(join(__dirname, '../test/projects/'), { withFileTypes: true })
-  .filter((p) => p.isDirectory())
+const baseDir = join(__dirname, '../test/projects/')
+readdirSync(baseDir, { withFileTypes: true })
+  .filter((p) => p.isDirectory() && existsSync(join(baseDir, p.name, 'package.json')))
   .forEach((dir) => {
-    try {
-      execSync(`node ${normalize('../../../src/cli.js')} auto --experimental-bins`, {
-        cwd: join(__dirname, '../test/projects/', dir.name),
+    execSync(
+      [process.execPath, normalize('../../../src/cli.js'), 'auto', '--experimental-bins'].join(' '),
+      {
+        cwd: join(baseDir, dir.name),
         stdio: 'inherit',
-      })
-    } catch (e) {
-      // ignore expected error
-      if (e.status !== 1) {
-        throw e
       }
-    }
+    )
   })

--- a/packages/allow-scripts/test/prepare.sh
+++ b/packages/allow-scripts/test/prepare.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-for d in ./test/projects/*/
-do
-  (cd "$d" && ../../../src/cli.js auto --experimental-bins);
-done
-

--- a/packages/allow-scripts/test/prepare.sh
+++ b/packages/allow-scripts/test/prepare.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+for d in ./test/projects/*/
+do
+  (cd "$d" && ../../../src/cli.js auto --experimental-bins);
+done
+

--- a/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/cli.js
+++ b/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/cli.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const process = require('process')
+process.stdout.write('GOOD!\n')
+fs.closeSync(
+  fs.openSync('.goodscriptworked', 'as')
+)

--- a/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/cli.sh
+++ b/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/cli.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo 'GOOD!'
-touch .goodscriptworked

--- a/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/package.json
+++ b/packages/allow-scripts/test/projects/3/node_modules/bbb/node_modules/good_dep/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "bin": {
-    "good": "cli.sh"
+    "good": "cli.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/allow-scripts/test/tsconfig.json
+++ b/packages/allow-scripts/test/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "checkJs": false
   },
-  "include": ["**/*.spec.js"],
+  "include": ["**/*.js"],
   "references": [
     {
       "path": "../src/tsconfig.json"


### PR DESCRIPTION
This is part of introducing cross-OS testing for LavaMoat. It should make tests pass for `allow-scripts` except for the ones associated with the `--experimental-bins` feature (#993)

#### Based on
- [x] #691 
  - [Diff](https://github.com/legobeat/LavaMoat/compare/ci-win-mac...legobeat:LavaMoat:win-compat-allow-scripts)

#### Related
- #1003
- #1004

#### Changes
- chore(ci): Enable Windows-compat testing for `@lavamoat/aa`, `@lavamoat/allow-scripts`
  - chore(allow-scripts): Skip tests for `--experimental-bins` when running on Windows
- chore(allow-scripts): Port package shellscripts to JS
- fix(aa): Fix tests of allow-scripts to run on Windows
- fix(allow-scripts): Fix tests of allow-scripts to run on Windows
- feat(aa): Include unknown directory path in error message

#### Resolves
- #692