### PR TITLE
test(windows-compat): tofu

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -70,6 +70,7 @@ jobs:
       TEST_WORKSPACES: >-
         --workspace=packages/lavapack
         --workspace=packages/preinstall-always-fail
+        --workspace=packages/tofu
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 
+const { EOL } = require('node:os')
 const test = require('ava')
 const deepEqual = require('deep-equal')
 const { inspectGlobals } = require('../src/index')
@@ -9,7 +10,7 @@ test('fnToCodeBlock utility works', (t) => {
     1 + 2 + 3
   })
 
-  t.is(src, '(() => {\n    1 + 2 + 3\n  })()')
+  t.is(src, `(() => {${EOL}    1 + 2 + 3${EOL}  })()`)
 })
 
 testInspect(


### PR DESCRIPTION
This is part of introducing cross-OS testing for LavaMoat. It the tests for `tofu` to pass on Windows.
#### Based on
- [x] #691 
  - [Diff](https://github.com/legobeat/LavaMoat/compare/ci-win-mac...legobeat:LavaMoat:win-compat-tofu)


#### Related
- #1002
- #1004

#### Changes
- chore(ci): Enable Windows-compatability tests for `tofu`
- fix(tofu): Fix tests of tofu to run on Windows