### PR TITLE
windows-compat: core

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       FORCE_COLOR: 1
       TEST_WORKSPACES: >-
+        --workspace=packages/core
         --workspace=packages/lavapack
         --workspace=packages/preinstall-always-fail
         --workspace=packages/tofu

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "lib:ses": "cp ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js",
     "lint:deps": "depcheck",
     "test": "ava && npm run test:ses",
-    "test:ses": "diff -q ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js"
+    "test:ses": "diff -wq ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js"
   },
   "dependencies": {
     "@babel/types": "7.23.9",

--- a/packages/core/src/loadPolicy.js
+++ b/packages/core/src/loadPolicy.js
@@ -17,15 +17,31 @@ function readPolicyFileSync({ debugMode, policyPath }) {
   if (debugMode) {
     console.warn(`Lavamoat looking for policy at '${policyPath}'`)
   }
+  /** @type string */
+  let rawPolicy
   try {
-    const rawPolicy = readFileSync(policyPath, 'utf8')
-    return JSON.parse(rawPolicy)
+    rawPolicy = readFileSync(policyPath, 'utf8')
   } catch (err) {
     if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ENOENT') {
       throw err
     } else if (debugMode) {
       console.warn(`Lavamoat could not find policy at '${policyPath}'`)
     }
+    return
+  }
+  try {
+    return JSON.parse(rawPolicy)
+  } catch (/** @type any */ error) {
+    if (debugMode) {
+      console.warn({
+        error: error?.message || error,
+        policyPath,
+        rawPolicy,
+      })
+    }
+    throw new Error(
+      `Lavamoat could not parse policy at '${policyPath}': ${/** @type {NodeJS.ErrnoException} */ (error).message}`
+    )
   }
 }
 

--- a/packages/core/test/generatePolicy.spec.js
+++ b/packages/core/test/generatePolicy.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef, @typescript-eslint/no-unused-vars, no-unused-expressions, no-extend-native */
+const { EOL } = require('node:os')
 const test = require('ava')
 
 const { createConfigForTest } = require('./util')
@@ -42,7 +43,7 @@ test('generatePolicy - config with debugInfo', async (t) => {
         file: testModuleFile,
         type: 'js',
         // this is brittle
-        content: '(function () {\n      location.href\n    })()',
+        content: `(function () {${EOL}      location.href${EOL}    })()`,
         importMap: {},
         packageName: 'test',
         moduleInitializer: undefined,


### PR DESCRIPTION
This is part of introducing cross-OS testing for LavaMoat. It the tests for `lavamoat-core` to pass on Windows.

#### Based on
- [x] #691 
  - [Diff](https://github.com/legobeat/LavaMoat/compare/ci-win-mac...legobeat:LavaMoat:win-compat-core)


#### Related
- #1003
- #1002

#### Changes
- chore(ci): Enable Windows-compatibility tests for `lavamoat-core`
- fix(core): Fix tests of core to run on Windows
- feat(core): include attempted path in error message when parsing JSON of policy fails