### PR TITLE
refactor: normalise root tsconfig references paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,23 +2,23 @@
   "extends": "@tsconfig/node16/tsconfig.json",
   "files": [],
   "compilerOptions": {
-    "allowJs": true
+    "allowJs": true,
   },
   "references": [
     {
-      "path": "packages/allow-scripts"
+      "path": "./packages/allow-scripts",
     },
     {
-      "path": "packages/aa"
+      "path": "./packages/aa",
     },
     {
-      "path": "packages/core"
+      "path": "./packages/core",
     },
     {
-      "path": "packages/laverna"
+      "path": "./packages/laverna",
     },
     {
-      "path": "packages/tofu"
-    }
-  ]
+      "path": "./packages/tofu",
+    },
+  ],
 }


### PR DESCRIPTION
Normalise root tsconfig _references_ paths to prefix `./`
like we do with remaining `packages/*` tsconfig files

Before (cmd+click on path)

<img width="468" alt="Screenshot 2024-02-07 at 3 21 34 pm" src="https://github.com/LavaMoat/LavaMoat/assets/1881059/09188602-17d6-4596-91c8-85ef1a0574a6">

After

<img width="471" alt="Screenshot 2024-02-07 at 3 22 24 pm" src="https://github.com/LavaMoat/LavaMoat/assets/1881059/9a1bb3c5-4f68-4dfc-bcfd-4f525ecc64e6">

<img width="463" alt="Screenshot 2024-02-07 at 3 22 39 pm" src="https://github.com/LavaMoat/LavaMoat/assets/1881059/f2589ce2-08a1-43bb-af9c-e9e084257fbe">
