### PR TITLE
feat(lavapack): check syntax of a module independently of browserify's own check

### DIFF
--- a/packages/lavapack/src/pack.js
+++ b/packages/lavapack/src/pack.js
@@ -307,12 +307,22 @@ function extractSourceMaps(sourceCode) {
   return { code, maps }
 }
 
+function assertValidJS(code) {
+  try {
+    new Function(code)
+  } catch (err) {
+    throw new Error(`Invalid JavaScript: ${err.message}`)
+  }
+}
+
 function wrapInModuleInitializer(
   moduleData,
   sourceMeta,
   sourcePathForModule,
   bundleWithPrecompiledModules
 ) {
+  // additional layer of syntax checking independent of browserify
+  assertValidJS(sourceMeta.code)
   const filename = encodeURI(String(moduleData.file))
   let moduleWrapperSource
   if (bundleWithPrecompiledModules) {

--- a/packages/lavapack/test/index.spec.js
+++ b/packages/lavapack/test/index.spec.js
@@ -79,6 +79,45 @@ test('sourcemap test', async (t) => {
   t.pass('no error thrown')
 })
 
+test('detect invalid module', (t) => {
+  t.plan(2)
+  const packStream = pack({
+    raw: true,
+    includePrelude: false,
+    devMode: true,
+    bundleWithPrecompiledModules: true,
+  })
+  t.throws(
+    () => {
+      packStream.write({
+        id: '2',
+        sourceFile: 'log.js',
+        source: '>>invalid code<<',
+        deps: {},
+      })
+    },
+    { message: "Invalid JavaScript: Unexpected token '>>'" }
+  )
+
+  const packStream2 = pack({
+    raw: true,
+    includePrelude: true,
+    devMode: true,
+    bundleWithPrecompiledModules: false,
+  })
+  t.throws(
+    () => {
+      packStream2.write({
+        id: '2',
+        sourceFile: 'log.js',
+        source: '>>invalid code<<',
+        deps: {},
+      })
+    },
+    { message: "Invalid JavaScript: Unexpected token '>>'" }
+  )
+})
+
 function deferred() {
   const result = {}
   result.promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
browserify does its own checking at a different time, but this is a better spot and seems to be throwing more informative errors.