### PR TITLE
fail faster on dirty changes via pre-commit hook

### DIFF
--- a/.config/lint-staged.config.js
+++ b/.config/lint-staged.config.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @type {import('lint-staged').Config} */
+module.exports = {
+  '*.js': ['eslint --fix', 'prettier --write'],
+  '*.(ts|md|ya?ml|json)': ['prettier --write'],
+  '!((package-lock|policy)*).json': ['prettier --write'],
+  'packages/*/src/**/*.js|package?(-lock).json': () => [
+    'npm run test:prep',
+    'npm run test:dirty-check',
+  ],
+}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: npm test
       - name: Dirty Check
-        run: node ./scripts/dirty-check.js
+        run: npm run test:dirty-check
 
   lint:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:deps": "npm run --workspaces --if-present lint:deps",
     "lint:eslint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint:staged": "lint-staged",
+    "lint:staged": "lint-staged --config ./.config/lint-staged.config.js",
     "rebuild": "npm run --workspaces --if-present rebuild && npm run rebuild:types",
     "rebuild:types": "npm run clean:types && npm run build:types",
     "release": "npm run release:rebuild && npm run release:publish --newPkg=${npm_config_newpkg}",
@@ -81,18 +81,6 @@
       "scripts/*.spec.js"
     ],
     "timeout": "2m"
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.(ts|md|ya?ml|json)": [
-      "prettier --write"
-    ],
-    "!((package-lock|policy)*).json": [
-      "prettier --write"
-    ]
   },
   "prettier": {
     "jsdocCommentLineStrategy": "keep",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "release:rebuild": "npm run rebuild && npm run test:prep && npm run test:workspaces",
     "setup": "husky; npm run rebuild",
     "test": "npm run build && npm run test:prep && npm run test:workspaces && npm run test:scripts",
+    "test:dirty-check": "node ./scripts/dirty-check.js",
     "test:prep": "npm run --workspaces --if-present test:prep",
     "test:scripts": "ava --config scripts/ava.config.mjs",
     "test:workspaces": "npm run --workspaces --if-present test",

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -26,7 +26,7 @@
     "lint:deps": "depcheck",
     "test": "npm run test:prep && npm run test:ava",
     "test:ava": "ava --serial",
-    "test:prep": "WRITE_AUTO_POLICY=1 ./test/fixtures/secureBundling/run.sh"
+    "test:prep": "cross-env WRITE_AUTO_POLICY=1 node ./test/fixtures/secureBundling/run.js"
   },
   "dependencies": {
     "@lavamoat/aa": "^4.0.1",

--- a/packages/browserify/test/fixtures/secureBundling/run.js
+++ b/packages/browserify/test/fixtures/secureBundling/run.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+/**
+ * Preps browserify tests.
+ *
+ * Adapted from shell script (`run.sh`) for portability!
+ */
+
+const { spawnSync } = require('child_process')
+const path = require('node:path')
+
+/**
+ * Whether or not to write a new policy.
+ */
+const WRITE_AUTO_POLICY = Boolean(process.env.WRITE_AUTO_POLICY)
+
+/**
+ * Path to `browserify` workspace
+ */
+const CWD = path.join(__dirname, '..', '..')
+
+/**
+ * Path to policy
+ */
+const POLICY_PATH = path.join(__dirname, 'lavamoat', 'node', 'policy.json')
+
+/**
+ * Path to build script
+ */
+const BUILD_PATH = path.join(__dirname, 'build.js')
+
+const spawnArgs = [
+  'exec',
+  'lavamoat',
+  '--',
+  BUILD_PATH,
+  '--policyPath',
+  POLICY_PATH,
+]
+
+if (WRITE_AUTO_POLICY) {
+  spawnArgs.push('--writeAutoPolicy')
+}
+
+console.error('npm', spawnArgs.join(' '))
+
+spawnSync('npm', spawnArgs, { stdio: 'inherit', cwd: CWD })

--- a/packages/browserify/test/fixtures/secureBundling/run.sh
+++ b/packages/browserify/test/fixtures/secureBundling/run.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-if [ "$WRITE_AUTO_POLICY" = "1" ]; then
-  ../node/src/cli.js test/fixtures/secureBundling/build.js --projectRoot './' --policyPath test/fixtures/secureBundling/lavamoat/node/policy.json --writeAutoPolicy
-else
-  ../node/src/cli.js test/fixtures/secureBundling/build.js --projectRoot './' --policyPath test/fixtures/secureBundling/lavamoat/node/policy.json
-fi

--- a/packages/browserify/test/lavamoatNode.spec.js
+++ b/packages/browserify/test/lavamoatNode.spec.js
@@ -6,7 +6,7 @@ const { evalBundle } = require('./util')
 test('lavamoat-node compat - bundle works under lavamoat node', (t) => {
   let bundle
   try {
-    bundle = execSync('./test/fixtures/secureBundling/run.sh', {
+    bundle = execSync('node ./test/fixtures/secureBundling/run.js', {
       cwd: path.resolve(__dirname, '../'),
       maxBuffer: 8192 * 10000,
     })


### PR DESCRIPTION
This does three (3) things, and could probably be split up into equivalent PRs, but I'm all out of Graphite stacks:

- chore(browserify): rewrite test:prep bash script as a JS script

This is just for portability's sake.  

- chore: adapt dirty-check script to be run in local dev env

This is trickier, and I especially want @legobeat to look at it re: `--staged`

- chore: update lint-staged to run browserify policy gen

In my limited testing, these changes seem to work, but it probably wants to be tested locally.  To trigger it:

1.  Do something like change a `require('fs')` to `require('node:fs')` (or vice-versa) in `lavamoat-browserify`'s sources somewhere.  
2. Run `npm run setup` to ensure your hooks are up-to-date
3. Stage the change, then commit it
4. It _should_ cause the `test:prep` script to run and the policy file to get updated and will then dump stuff from `dirty-check.js` and fail.

Or, if there's a branch you have handy that _already_ has the problem (which would currently be surfaced in CI), just try to add a commit to that branch.  I was using fc51eea for this, assuming that it still exists.