### PR TITLE
chore(eslint): increase target langugage from es2020 to es2021

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,13 +18,13 @@
  * The minimum EcmaScript runtime environment to support
  * @see {@link https://eslint.org/docs/latest/use/configure/language-options#specifying-environments}
  */
-const ECMASCRIPT_ENV = 'es2020'
+const ECMASCRIPT_ENV = 'es2021'
 
 /**
  * The minimum EcmaScript language version to support
  * @see {@link https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options}
  */
-const ECMASCRIPT_VERSION = 2020
+const ECMASCRIPT_VERSION = 2021
 
 /**
  * The minimum supported version of Node.js


### PR DESCRIPTION
This breaks out the es version bump from #753 into a separate commit.

- Change eslint config `parserOptions.ecmaVersion` to `2021`
- Set eslint config `env.es2021`
- Unset eslint config `env.es2020`

### Related
- Lifted from #753 (https://github.com/LavaMoat/LavaMoat/pull/753#discussion_r1491586426) 

#### Blocked by
- [x] #1022 