### PR TITLE
chore(browserify): sync exampleApp fixture policy

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -26,7 +26,7 @@
     "lint:deps": "depcheck",
     "test": "npm run test:prep && npm run test:ava",
     "test:ava": "ava",
-    "test:prep": "cross-env WRITE_AUTO_POLICY=1 node ./test/fixtures/secureBundling/run.js"
+    "test:prep": "cross-env WRITE_AUTO_POLICY=1 node ./test/fixtures/secureBundling/run.js && cross-env WRITE_AUTO_POLICY=1 node ./test/fixtures/secureBundling/build.js >/dev/null"
   },
   "dependencies": {
     "@lavamoat/aa": "^4.0.1",

--- a/packages/browserify/test/fixtures/exampleApp/policy.json
+++ b/packages/browserify/test/fixtures/exampleApp/policy.json
@@ -24,16 +24,6 @@
         "setTimeout": true
       }
     },
-    "browserify>string_decoder": {
-      "packages": {
-        "browserify>util>safe-buffer": true
-      }
-    },
-    "browserify>util>safe-buffer": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
     "keccak": {
       "packages": {
         "browserify>buffer": true,
@@ -47,8 +37,18 @@
         "browserify>events": true,
         "browserify>inherits": true,
         "browserify>process": true,
-        "browserify>string_decoder": true,
+        "keccak>readable-stream>string_decoder": true,
         "keccak>readable-stream>util-deprecate": true
+      }
+    },
+    "keccak>readable-stream>string_decoder": {
+      "packages": {
+        "keccak>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "keccak>readable-stream>string_decoder>safe-buffer": {
+      "packages": {
+        "browserify>buffer": true
       }
     },
     "keccak>readable-stream>util-deprecate": {


### PR DESCRIPTION
It seems like the fixture file `test/fixtures/exampleApp/policy.json` has not been updated for quite a while.

This adds regeneration of it to the `test:prep` script (which I intend to refactor to make portable and nicer separately), and commits the result of running that.