### PR TITLE
feat(core): turn off localeTaming in ses lockdown by default

### DIFF
--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -62,6 +62,9 @@
       stackFiltering: 'verbose',
       // prevents most common override mistake cases from tripping up users
       overrideTaming: 'severe',
+      // preserves JS locale methods
+      // prevents aliasing: toLocaleString() to toString(), etc
+      localeTaming: 'unsafe',
     }
 
     lockdown(lockdownOptions)

--- a/packages/core/src/kernelTemplate.js
+++ b/packages/core/src/kernelTemplate.js
@@ -62,7 +62,7 @@
       stackFiltering: 'verbose',
       // prevents most common override mistake cases from tripping up users
       overrideTaming: 'severe',
-      // preserves JS locale methods
+      // preserves JS locale methods, to avoid confusing users
       // prevents aliasing: toLocaleString() to toString(), etc
       localeTaming: 'unsafe',
     }


### PR DESCRIPTION
to avoid confusing users
- turn off in core kernel template
- add doc comments

resolve: https://github.com/LavaMoat/LavaMoat/issues/1029