### PR TITLE
chore(browserify): disable scenario tests on macos in CI for now

### DIFF
--- a/packages/browserify/ava.config.mjs
+++ b/packages/browserify/ava.config.mjs
@@ -1,0 +1,13 @@
+const files = ['./test/*.spec.js']
+
+// FIXME: these tests timeout half of the time on GH's macOS CI runners
+if (process.env.CI && process.platform === 'darwin') {
+  files.push('!./test/runScenarios.spec.js')
+  console.error('[SKIP] runScenarios.spec.js skipped - flaky macOS CI')
+}
+
+export default {
+  files,
+  timeout: '4m',
+  concurrency: 1,
+}

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -25,7 +25,7 @@
     "build:ses": "(cd ./node_modules/ses && npm install && npm run build && cp ./dist/ses.umd.js ../../lib/)",
     "lint:deps": "depcheck",
     "test": "npm run test:prep && npm run test:ava",
-    "test:ava": "ava --serial",
+    "test:ava": "ava",
     "test:prep": "cross-env WRITE_AUTO_POLICY=1 node ./test/fixtures/secureBundling/run.js"
   },
   "dependencies": {
@@ -52,13 +52,6 @@
     "tmp-promise": "3.0.3",
     "vinyl-buffer": "1.0.1",
     "watchify": "4.0.0"
-  },
-  "ava": {
-    "files": [
-      "test/*.spec.js"
-    ],
-    "timeout": "4m",
-    "concurrency": 1
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
This suite frequently times out and it needs investigation. Until then, let's disable the tests to avoid CI flake.
