### PR TITLE
chore(vscode): organize imports where possible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
     "source.fixAll": "explicit",
     "source.formatDocument": "explicit"
   },


### PR DESCRIPTION
In TS and ESM projects, this setting causes VSCode to organize the imports in a module by type.  If order is necessary, place a blank line between the imports which should not be changed, e.g.:

```js
import "ses"

import path from "node:path"
import util from "node:util"
```

This will ensure `ses` always comes first.