### PR TITLE
chore(lavamoat): increase scenario test timeout

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -49,6 +49,6 @@
     "files": [
       "test/*.spec.js"
     ],
-    "timeout": "30s"
+    "timeout": "1m"
   }
 }


### PR DESCRIPTION
macOS is now timing out on some of these. I want to try increasing the test timeout first. Disabling the tests entirely on macOS can be the last resort.