### PR TITLE
chore: reduce renovate churn

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,18 @@
       matchUpdateTypes: ['major'],
       enabled: false,
     },
+    {
+      // Disable frequent updates for dev tooling
+      // These can be updated manually but we still want to be notified about new majors
+      matchPackageNames: [
+        'commitlint',
+        'husky',
+        'lint-staged',
+        'linters',
+      ],
+      matchUpdateTypes: ['minor', 'patch'],
+      enabled: false,
+    }
   ],
   transitiveRemediation: true,
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,11 +54,11 @@
     {
       // Disable frequent updates for dev tooling
       // These can be updated manually but we still want to be notified about new majors
+      extends: ['packages:linters'],
+      matchPackagePrefixes: ['@commitlint'],
       matchPackageNames: [
-        'commitlint',
         'husky',
-        'lint-staged',
-        'linters',
+        'lint-staged'
       ],
       matchUpdateTypes: ['minor', 'patch'],
       enabled: false,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,15 @@
       ],
       matchUpdateTypes: ['minor', 'patch'],
       enabled: false,
+    },
+    {
+      // @types/node should be bumped to major only alongside `engines.node` in package.json
+      // We don't care about every patch release so only notify onnew minors
+      matchPackageNames: [
+        '@types/node',
+      ],
+      matchUpdateTypes: ['major', 'patch'],
+      enabled: false,
     }
   ],
   transitiveRemediation: true,


### PR DESCRIPTION
This is an attempt to reduce the amount of dependency maintenance overhead from Renovate.

- Disable `minor` and `patch` for these frequently updated (>= 4 renovate PRs merged so far) devDependencies (we have other channels for security advisories):
  - `commitlint`
  - `husky`
  - `lint-staged`
  - `linters`
- Disable `major` and `patch` for `@types/node`. `major` because it should be bumped in sync with `engines.node` and `patch` because of the update-frequency, I think we're fine on only getting automation for `minor` here.

Room for improvement: I think Renovate has some functionality for consolidating configured groups of dependencies into larger update PRs. That might be a good way to keep down the merge overhead while still staying on top of new versions. Could also group all GHA actions into one such PR group, if possible.