### PR TITLE
chore(deps): remove conventional-changelog-conventionalcommits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@typescript-eslint/eslint-plugin": "7.1.0",
         "@typescript-eslint/parser": "7.1.0",
         "ava": "5.3.1",
-        "conventional-changelog-conventionalcommits": "7.0.2",
         "cross-env": "7.0.3",
         "depcheck": "1.4.7",
         "eslint": "8.57.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@typescript-eslint/eslint-plugin": "7.1.0",
     "@typescript-eslint/parser": "7.1.0",
     "ava": "5.3.1",
-    "conventional-changelog-conventionalcommits": "7.0.2",
     "cross-env": "7.0.3",
     "depcheck": "1.4.7",
     "eslint": "8.57.0",


### PR DESCRIPTION
This package is unused since we dropped Lerna.  I guess we don't run `depcheck` on the monorepo root...

Ref: #820 