### PR TITLE
chore(core): auto-update vendored lockdown.umd.js

### DIFF
--- a/.config/lint-staged.config.js
+++ b/.config/lint-staged.config.js
@@ -1,3 +1,5 @@
+const path = require('node:path')
+
 // @ts-check
 
 /** @type {import('lint-staged').Config} */
@@ -5,4 +7,5 @@ module.exports = {
   '*.js': ['eslint --fix', 'prettier --write'],
   '*.(ts|md|ya?ml|json)': ['prettier --write'],
   '!((package-lock|policy)*).json': ['prettier --write'],
+  'package-lock.json': () => ['npm run -w lavamoat-core lib:ses'],
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "!*.tsbuildinfo"
   ],
   "scripts": {
-    "lib:ses": "cp ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js",
+    "lib:ses": "cp ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js && git add -A ./lib/lockdown.umd.js",
     "lint:deps": "depcheck",
     "test": "ava && npm run test:ses",
     "test:ses": "diff -wq ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js"


### PR DESCRIPTION
This changes the `lint-staged` configuration so that when `package-lock.json` is updated, the vendored `packages/core/lib/lockdown.umd.js` is copied from the currently-installed `ses` and added to the commit.

I'm not sure if this is something we want to be doing or not, but needing to run the `lib:ses` script in `lavamoat-core` after a `ses` upgrade is non-obvious for maintainers (me).
