### PR TITLE
expose core test types properly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -108,7 +108,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*/*/test/**/*.js'],
+      files: ['**/*/*/test/**/*.js', '**/*/*/test/**/*.ts'],
       extends: ['plugin:ava/recommended'],
       env: {
         browser: true,

--- a/packages/core/src/options.js
+++ b/packages/core/src/options.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+/**
+ * Value of the {@link LavaMoatOpts.scuttleGlobalThis} option.
+ *
+ * @typedef LavaMoatScuttleOpts
+ * @property {boolean} [enabled]
+ * @property {string[]} [exceptions]
+ * @property {string} [scuttlerName]
+ */
+
+/**
+ * Options for LavaMoat
+ *
+ * @typedef LavaMoatOpts
+ * @property {LavaMoatScuttleOpts} [scuttleGlobalThis] Enable or disable
+ *   scuttling of `globalThis`
+ * @property {string[]} [scuttleGlobalThisExceptions]
+ * @property {boolean} [writeAutoPolicy] Automatically write a policy file
+ * @property {boolean} [writeAutoPolicyDebug] Automatically write a debug policy
+ *   file
+ * @property {boolean} [writeAutoPolicyAndRun] Automatically write a policy file
+ *   and run the application
+ * @property {string} [policyPath] Path to policy file
+ * @property {string} [policyDebugPath] Path to policy debug file
+ * @property {string} [policyOverridePath] Path to policy override file
+ * @property {string} [projectRoot] Path to project root
+ * @property {boolean} [debugMode] Enable debug mode
+ * @property {boolean} [statsMode] Enable stats mode
+ */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
+export type * from './generatePolicy'
 export * from './index'
 export type * from './moduleRecord'
+export type * from './options'
 export type * from './parseForPolicy'
 export type * from './schema'
-export type * from './generatePolicy'

--- a/packages/core/test/scenario.ts
+++ b/packages/core/test/scenario.ts
@@ -1,8 +1,7 @@
-// @ts-check
-
 import type { ExecutionContext } from 'ava'
-import type { LavaMoatOpts } from '../../../node/src/defaults'
-import type { LavaMoatPolicySchema } from '../../schema'
+import { ModuleInitializer } from '../src/moduleRecord'
+import type { LavaMoatOpts } from '../src/options'
+import { LavaMoatPolicy, LavaMoatPolicyOverrides } from '../src/schema'
 
 export type ScenarioType = 'truthy' | 'falsy' | 'deepEqual'
 
@@ -31,11 +30,7 @@ export interface NormalizedScenarioJSFile extends ScenarioFile {
 
 export interface NormalizedBuiltin extends NormalizedScenarioJSFile {
   specifier: string
-  moduleInitializer: (
-    exports: Record<string, any>,
-    require: (id: string) => any,
-    module: Record<string, any>
-  ) => void
+  moduleInitializer: ModuleInitializer
 }
 /**
  * Scenario file as provided by user
@@ -54,21 +49,17 @@ export interface ScenarioFile {
   type?: ScenarioFileType
   entry?: boolean
   importMap?: Record<string, string>
-  moduleInitializer?: (
-    exports: Record<string, any>,
-    require: (id: string) => any,
-    module: Record<string, any>
-  ) => void
+  moduleInitializer?: ModuleInitializer
 }
 
 export type ScenarioSourceFn = () => void
 
 export interface Scenario<Result = unknown> {
   name?: string
-  config?: LavaMoatPolicySchema
-  configOverride?: LavaMoatPolicySchema
+  config?: LavaMoatPolicy
+  configOverride?: LavaMoatPolicyOverrides
   expectedFailure?: boolean
-  expectedResult?: any
+  expectedResult?: Result
   defineEntry?: ScenarioSourceFn
   defineOne?: ScenarioSourceFn
   defineTwo?: ScenarioSourceFn
@@ -77,14 +68,14 @@ export interface Scenario<Result = unknown> {
   expectedFailureMessageRegex?: RegExp
   files?: Record<string, ScenarioFile>
   defaultPolicy?: boolean
-  builtin?: Record<string, any>
-  context?: Record<string, any>
+  builtin?: Record<string, unknown>
+  context?: Record<string, unknown>
   opts?: LavaMoatOpts
   dir?: string
   checkPostRun?: ScenarioCheckPostRunFn<Result>
   checkError?: ScenarioCheckErrorFn<Result>
   checkResult?: ScenarioCheckResultFn<Result>
-  kernelArgs?: Record<string, any>
+  kernelArgs?: Record<string, unknown>
   beforeCreateKernel?: (scenario: NormalizedScenario<Result>) => void
 }
 
@@ -109,8 +100,8 @@ export type NormalizedScenario<Result = unknown> = Required<
 > &
   Pick<Scenario<Result>, 'dir' | 'kernelArgs' | 'beforeCreateKernel'> & {
     entries: string[]
-    globalThis?: Record<string, any>
-    vmContext?: Record<string, any>
+    globalThis?: Record<string, unknown>
+    vmContext?: Record<string, unknown>
   }
 
 export type ScenarioCheckPostRunFn<Result = unknown> = (

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,10 +1,12 @@
 {
-  "extends": "../../../.config/tsconfig.test.json",
+  // not extending the test config b/c we must output some types
+  "extends": "../../../.config/tsconfig.src.json",
   "compilerOptions": {
     "checkJs": false,
-    "rootDir": "."
+    "rootDir": "..",
+    "outDir": "../types"
   },
-  "include": ["**/*"],
+  "include": ["**/*.js", "**/*.ts"],
   "references": [
     {
       "path": "../src/tsconfig.json"

--- a/packages/node/src/defaults.js
+++ b/packages/node/src/defaults.js
@@ -2,32 +2,7 @@ const { getDefaultPaths } = require('lavamoat-core')
 
 const defaultPaths = getDefaultPaths('node')
 
-/**
- * @typedef LavaMoatScuttleOpts
- * @property {boolean} [enabled]
- * @property {string[]} [exceptions]
- * @property {string} [scuttlerName]
- */
-
-/**
- * @typedef LavaMoatOpts
- * @property {LavaMoatScuttleOpts} [scuttleGlobalThis] Enable or disable
- *   scuttling of `globalThis`
- * @property {string[]} [scuttleGlobalThisExceptions]
- * @property {boolean} [writeAutoPolicy] Automatically write a policy file
- * @property {boolean} [writeAutoPolicyDebug] Automatically write a debug policy
- *   file
- * @property {boolean} [writeAutoPolicyAndRun] Automatically write a policy file
- *   and run the application
- * @property {string} [policyPath] Path to policy file
- * @property {string} [policyDebugPath] Path to policy debug file
- * @property {string} [policyOverridePath] Path to policy override file
- * @property {string} [projectRoot] Path to project root
- * @property {boolean} [debugMode] Enable debug mode
- * @property {boolean} [statsMode] Enable stats mode
- */
-
-/** @type {LavaMoatOpts} */
+/** @type {import('lavamoat-core').LavaMoatOpts} */
 const defaults = {
   scuttleGlobalThis: {},
   scuttleGlobalThisExceptions: [],


### PR DESCRIPTION
This change exposes the types added in #651 to consumers (including our own packages).  This is necessary for _any_ package to use types like `Scenario`.

Of note, I moved the `LavaMoatOpts` type into `lavamoat-core`, because that type is used directly by the `Scenario` type.  This will avoid an implicit cycle in `lavamoat-core` & `lavamoat`.

* * *

- **chore(node, core): move LavaMoatOpts typedef into lavamoat-core**
- **chore(core): expose types from test/util and scenario definition**
- **chore(eslint): prevent `n/no-extraneous-*` from touching test files with .ts extensions**
