### PR TITLE
fix(tofu): ClassProperty nodes are not globals

### DIFF
--- a/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
+++ b/packages/browserify/test/fixtures/secureBundling/lavamoat/node/policy.json
@@ -1040,17 +1040,9 @@
       },
       "globals": {
         "__dirname": true,
-        "ast": true,
         "console.error": true,
         "console.warn": true,
-        "content": true,
-        "define": true,
-        "file": true,
-        "importMap": true,
-        "moduleInitializer": true,
-        "packageName": true,
-        "specifier": true,
-        "type": true
+        "define": true
       },
       "packages": {
         "json-stable-stringify": true,

--- a/packages/tofu/src/findGlobals.js
+++ b/packages/tofu/src/findGlobals.js
@@ -84,6 +84,11 @@ function findGlobals(ast) {
         return
       }
 
+      // class props are not globals
+      if (parentType === 'ClassProperty' && path.parent.key === path.node) {
+        return
+      }
+
       // save global
       saveGlobal(path)
     },

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -430,6 +430,21 @@ testInspect(
   }
 )
 
+testInspect(
+  'class properties',
+  {},
+  () => {
+    class X {
+      y = 123
+      z
+      why() {
+        return this.y
+      }
+    }
+  },
+  {}
+)
+
 function testInspect(label, opts, fn, expectedResultObj) {
   test(label, (t) => {
     const src = fnToCodeBlock(fn)


### PR DESCRIPTION
Adds an exception to `findGlobals()` for AST nodes of type `ClassProperty`.

Closes #1098
