### PR TITLE
chore: set @lavamoat/webpack to use prerelease

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,9 @@
   "packages": {
     "packages/aa": {},
     "packages/allow-scripts": {},
-    "packages/webpack": {},
+    "packages/webpack": {
+      "versioning": "prerelease"
+    },
     "packages/browserify": {},
     "packages/core": {},
     "packages/lavapack": {},


### PR DESCRIPTION
This configures release-please to use the `prerelease` versioning strategy for `@lavamoat/webpack`.

Ref: https://github.com/googleapis/release-please/blob/main/docs/customizing.md\#versioning-strategies
