### PR TITLE
chore(webpack): lint e2e test

### DIFF
--- a/packages/webpack/test/e2e-manual.js
+++ b/packages/webpack/test/e2e-manual.js
@@ -1,6 +1,6 @@
 // run this with node to produce the test build to disk
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const { scaffold, runScriptWithSES } = require('./scaffold.js')
 const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
 const webpackConfig = {


### PR DESCRIPTION
This is failing in `main`. I think it was due to a PR passing the build _before_ the `eslint-plugin-node-import` addition was merged, but merged _after_.

Consider requiring all PRs to be up-to-date onto `main`. cc @naugtur
