### PR TITLE
feat(core): add external package name fallback function to options in generatePolicy, use it in webpack

### DIFF
--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -449,18 +449,21 @@ function createModuleInspector(opts) {
 }
 
 /**
- * @param {{
- *   packageModules: Record<
- *     string,
- *     import('./moduleRecord').LavamoatModuleRecord
- *   >
- *   moduleIdToModuleRecord: Map<
- *     string,
- *     import('./moduleRecord').LavamoatModuleRecord
- *   >
- *   moduleToPackageFallback?: (specifier: string) => string | undefined
- * }} opts
- * @returns
+ * @callback ModuleToPackageFallbackFn
+ * @param {string} requestedName
+ * @returns {string | undefined}
+ */
+
+/**
+ * @typedef {Object} AggregateDepsOptions
+ * @property {Record<string, import('./moduleRecord').LavamoatModuleRecord>} packageModules
+ * @property {Map<string, import('./moduleRecord').LavamoatModuleRecord>} moduleIdToModuleRecord
+ * @property {ModuleToPackageFallbackFn} [moduleToPackageFallback]
+ */
+
+/**
+ * @param {AggregateDepsOptions} opts
+ * @returns {string[]}
  */
 function aggregateDeps({
   packageModules,
@@ -504,8 +507,7 @@ function aggregateDeps({
  * For when you encounter a `requestedName` that was not inspected, likely
  * because resolution was skipped for that module
  *
- * @param {string} requestedName
- * @returns {string | undefined}
+ * @type {ModuleToPackageFallbackFn}
  */
 function guessPackageName(requestedName) {
   const isNotPackageName =

--- a/packages/webpack/src/buildtime/policyGenerator.js
+++ b/packages/webpack/src/buildtime/policyGenerator.js
@@ -52,7 +52,7 @@ module.exports = {
           if (policyFromOptions) {
             // TODO: avoid loading the policy file if policyFromOptions is present
             final = policyFromOptions
-          } else {
+          } else if (policy) {
             final = applyOverride(policy)
           }
           if (emit) {
@@ -67,14 +67,16 @@ module.exports = {
 
     // load policy file
     // load overrides
-    // generate policy if requested and write to file
+    // generate policy if requested and write to fileWe're not aware of any
     // merge result with overrides
     // return that and emit snapshot
     const moduleInspector = createModuleInspector({
       isBuiltin: () => false,
       includeDebugInfo: false,
       // If the specifier is requested as a dependency in importMap but was never passed to inspectModule, its package name will be looked up here.
-      // This is a workaround to inconsistencies in how webpack represents connections. We're not aware of any security implications of this, since the package is already resolved clearly and this is only a part of policy generation, not runtime.
+      // This is a workaround to inconsistencies in how webpack represents connections.
+      // Specifically what happened to surface this issue: `connections` in webpack contain a module entry that's identified by the path to its index.mjs entrypoint while the index.js entrypoint is actually used in the bundle, so inspector doesn't have a cached entry for this one and without the fallback handler would return <unknown:/...>
+      // There should be no security implications of this, since the package is already resolved clearly and this is only a part of policy generation, not runtime.
       moduleToPackageFallback: (specifier) =>
         getPackageNameForModulePath(canonicalNameMap, specifier),
     })

--- a/packages/webpack/src/buildtime/policyGenerator.js
+++ b/packages/webpack/src/buildtime/policyGenerator.js
@@ -73,6 +73,10 @@ module.exports = {
     const moduleInspector = createModuleInspector({
       isBuiltin: () => false,
       includeDebugInfo: false,
+      // If the specifier is requested as a dependency in importMap but was never passed to inspectModule, its package name will be looked up here.
+      // This is a workaround to inconsistencies in how webpack represents connections. We're not aware of any security implications of this, since the package is already resolved clearly and this is only a part of policy generation, not runtime.
+      moduleToPackageFallback: (specifier) =>
+        getPackageNameForModulePath(canonicalNameMap, specifier),
     })
 
     return {


### PR DESCRIPTION
This is generally useful for paving over incompatibilities.

In this particular situation, it helps solve a case where `connections` in webpack contain a module entry that's identified by the path to its index.mjs entrypoint while the index.js entrypoint is actually used in the bundle, so inspector doesn't have a cached entry for this one and without the fallback handler would return `<unknown:/...>`

A fix for this situation with less code reuse would be to replace the whole aggregateDeps logic. The benefit of that would be being able to avoid allocating moduleIdToModuleRecord. What discourages this change is increased reliance on canonicalNameMap and limiting portability of inspector. 