### PR TITLE
chore(core): normalize non-existent package references in test files

### DIFF
--- a/packages/core/test/builtin.spec.js
+++ b/packages/core/test/builtin.spec.js
@@ -79,8 +79,8 @@ test('builtin - paths soft-bindings preserve "this" but allow override', async (
 
     defineTwo: () => {
       const { Buffer } = require('node:buffer')
-      const thisChecker = require('thisChecker')
-      const { SomeClass } = require('someClass')
+      const thisChecker = require('abc')
+      const { SomeClass } = require('xyz')
       // this test ensures "Buffer.prototype.slice" is copied in a way that allows "this" to be overridden
       module.exports.overrideCheck = (buf) =>
         Buffer.prototype.slice.call(buf, 1, 2)[0] === buf[1]
@@ -108,8 +108,8 @@ test('builtin - paths soft-bindings preserve "this" but allow override', async (
           builtin: {
             // these paths are carefully constructed to try and split the fn from its parent
             'node:buffer.Buffer.prototype.slice': true,
-            'thisChecker.check': true,
-            'someClass.SomeClass': true,
+            'abc.check': true,
+            'xyz.SomeClass': true,
           },
         },
       },
@@ -121,14 +121,14 @@ test('builtin - paths soft-bindings preserve "this" but allow override', async (
     },
     builtin: {
       'node:buffer': require('node:buffer'),
-      thisChecker: (() => {
+      abc: (() => {
         const parent = {}
         parent.check = function () {
           return this === parent
         }
         return parent
       })(),
-      someClass: { SomeClass: class SomeClass {} },
+      xyz: { SomeClass: class SomeClass {} },
     },
   })
 


### PR DESCRIPTION
Essentially, we want to keep use of "phony" module names to a minimum to avoid a tool like `dependency-cruiser` raising errors. They must be explicitly whitelisted, and it's best to keep that list length minimal.

Extracted from #820

