### PR TITLE
fix(core): remove circular ref to ambient.ts

### DIFF
--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,2 +1,1 @@
-import './ambient'
 export type * from './lavamoat-policy.v0-0-1.schema.js'


### PR DESCRIPTION
This causes a cycle as detected by `dependency-cruiser`

Extracted from #820 
