### PR TITLE
Revert "fix(allow-scripts): indicate peerDependency on @lavamoat/preinstall-always-fail"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18193,9 +18193,6 @@
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
-      },
-      "peerDependencies": {
-        "@lavamoat/preinstall-always-fail": "*"
       }
     },
     "packages/browserify": {

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -48,9 +48,6 @@
   "devDependencies": {
     "@types/npmcli__promise-spawn": "6.0.3"
   },
-  "peerDependencies": {
-    "@lavamoat/preinstall-always-fail": "*"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Reverts LavaMoat/LavaMoat#1197

Merged it before I noticed the intention to ship it as a breaking change that was only indicated in https://github.com/LavaMoat/LavaMoat/pull/1135#pullrequestreview-2089364748