### PR TITLE
 chore(allow-scripts): Indicate peerDependency on @lavamoat/preinstall-always-fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18351,6 +18351,9 @@
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0"
+      },
+      "peerDependencies": {
+        "@lavamoat/preinstall-always-fail": "*"
       }
     },
     "packages/browserify": {

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -48,6 +48,9 @@
   "devDependencies": {
     "@types/npmcli__promise-spawn": "6.0.3"
   },
+  "peerDependencies": {
+    "@lavamoat/preinstall-always-fail": "*"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Reverts https://github.com/LavaMoat/LavaMoat/pull/1200

Bring back the peerDependency after upcoming release