### PR TITLE
chore(ci): pin node.js v20 to v20.14 (#1211)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,5 @@
 name: CI
-on: 
+on:
   push:
     branches:
       - main # limit to main, because pushes to pull-requested branches are triggered below
@@ -18,7 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version:
+          - 16.x
+          - 18.x
+          # TODO: Resolve whttps://github.com/LavaMoat/LavaMoat/issues/1211 and enable v20.x, v22.x
+          - 20.14.x
+          #- 20.x
+          #- 22.x
     steps:
       - name: Checkout (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Temporarily pin Node.js v20 to v20.14 until #1211 is resolved.