### PR TITLE
chore: remove corepack from optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,6 @@
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0",
         "npm": ">=7.0.0"
-      },
-      "optionalDependencies": {
-        "corepack": "0.20.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7416,22 +7413,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/corepack": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/corepack/-/corepack-0.20.0.tgz",
-      "integrity": "sha512-iMeLFtXB3V3tk22c95hwMcM9pK2MJifdsCh+qxVntHF/Rz3bJBI+WXK3K7mkNl1Lwi2373OTaC6f7OghjtXh2Q==",
-      "optional": true,
-      "bin": {
-        "corepack": "dist/corepack.js",
-        "pnpm": "dist/pnpm.js",
-        "pnpx": "dist/pnpx.js",
-        "yarn": "dist/yarn.js",
-        "yarnpkg": "dist/yarnpkg.js"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "test:workspaces": "npm run --workspaces --if-present test",
     "watch:types": "tsc -b --watch"
   },
-  "optionalDependencies": {
-    "corepack": "0.20.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "19.3.0",
     "@commitlint/config-conventional": "19.2.2",


### PR DESCRIPTION
- Originally introduced in 7e8e3547bd28782cf19953762d5639a279a27e33 (#648).

corepack is part of Node.js as of v18. The global version is preferred
and installing a separate one for the root package may interfere with tests.


#### Related:
- 1192