### PR TITLE
chore(ci): migrate from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4


### PR DESCRIPTION
Annotation from CI run on `main`:
    
     google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.