### PR TITLE
tofu no dep core

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -18614,9 +18614,6 @@
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0"
-      },
-      "peerDependencies": {
-        "lavamoat-core": "^15.4.0"
       }
     },
     "packages/webpack": {

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -25,9 +25,6 @@
     "lint:deps": "depcheck",
     "test": "ava"
   },
-  "peerDependencies": {
-    "lavamoat-core": "^15.4.0"
-  },
   "dependencies": {
     "@babel/parser": "7.24.8",
     "@babel/traverse": "7.24.8",


### PR DESCRIPTION
- **chore(ci): migrate from google-github-actions/release-please-action@v4 to googleapis/release-please-action@v4**
  

- **fix(allow-scripts): Indicate peerDependency on @lavamoat/preinstall-always-fail**
  This commit intentionally left empty to backfill missing changelog entry
  for #1201 (c2c3dc122).
  

- **fix(tofu): remove lavamoat-core from peerDependencies**
  Circular dependencies are not nice.
  