### PR TITLE
chore(lavapack)!: remove support for Node.js v16; add support for v22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,6 @@ jobs:
             test-workspaces: >-
               --workspace=packages/aa
               --workspace=packages/allow-scripts
-              --workspace=packages/lavapack
               --workspace=packages/preinstall-always-fail
               --workspace=packages/tofu
               --workspace=packages/yarn-plugin-allow-scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -18433,7 +18433,7 @@
         "source-map": "0.7.4"
       },
       "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
       }
     },
     "packages/lavapack/node_modules/buffer": {

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+    "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
   },
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
- Context: https://github.com/LavaMoat/LavaMoat/pull/1230#discussion_r1695079404

### Related
- #1230
- #1256