### PR TITLE
chore(ci): fix typo

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        inlude:
+        include:
           - node-version: 16.x
             test-workspaces: >-
               --workspace=packages/aa

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,6 +49,7 @@ jobs:
               --workspace=packages/aa
               --workspace=packages/browserify
               --workspace=packages/core
+              --workspace=packages/lavapack
               --workspace=packages/node
               --workspace=packages/tofu
               --workspace=packages/webpack
@@ -58,6 +59,7 @@ jobs:
               --workspace=packages/aa
               --workspace=packages/browserify
               --workspace=packages/core
+              --workspace=packages/lavapack
               --workspace=packages/node
               --workspace=packages/tofu
               --workspace=packages/webpack

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,6 @@ jobs:
             test-workspaces: >-
               --workspace=packages/aa
               --workspace=packages/allow-scripts
-              --workspace=packages/lavapack
               --workspace=packages/preinstall-always-fail
               --workspace=packages/tofu
               --workspace=packages/yarn-plugin-allow-scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -18433,7 +18433,7 @@
         "source-map": "0.7.4"
       },
       "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || ^22.0.0."
       }
     },
     "packages/lavapack/node_modules/buffer": {

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^16.20.0 || ^18.0.0 || ^20.0.0"
+    "node": "^18.0.0 || ^20.0.0 || ^22.0.0."
   },
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
The ci change in e21ae79ddf introduced a typo in the workflows file (`inlude` vs `include`). This fixes that, as well as resolving an emerging build/test dependency between lavapack and browserify packages where browserify tests expect the artefact buld from lavapack to be present.

---
### Related
- #1230
#### Blocked by
- [ ] #1257 