### PR TITLE
webpack fixes for metamask config

### DIFF
--- a/packages/webpack/src/buildtime/diagnostics.js
+++ b/packages/webpack/src/buildtime/diagnostics.js
@@ -7,6 +7,8 @@ module.exports = {
     return level
   },
   /**
+   * Run the callback if verbosity is greater or equal given number
+   *
    * @param {number} verbosity
    * @param {function} cb
    */

--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -12,7 +12,7 @@ const diag = require('./diagnostics.js')
 const RUNTIME_GLOBALS = require('webpack/lib/RuntimeGlobals')
 const { RUNTIME_KEY } = require('../ENUM.json')
 
-const { isExcluded } = require('./exclude.js')
+const { isExcluded } = require('./exclude')
 
 // TODO: processing requirements needs to be a tiny bit more clever yet.
 // Look in JavascriptModulesPlugin for how it decides if module and exports are unused.

--- a/packages/webpack/src/buildtime/policyGenerator.js
+++ b/packages/webpack/src/buildtime/policyGenerator.js
@@ -11,7 +11,8 @@ const {
   sources: { RawSource },
 } = require('webpack')
 
-const { isExcludedUnsafe } = require('./exclude.js')
+const { isExcludedUnsafe } = require('./exclude')
+const diag = require('./diagnostics')
 
 const POLICY_SNAPSHOT_FILENAME = 'policy-snapshot.json'
 
@@ -99,6 +100,14 @@ module.exports = {
         // Skip modules the user intentionally excludes.
         // This is policy generation so we don't need to protect ourselves from an attack where the module has a loader defined in the specifier.
         if (isExcludedUnsafe(module)) return
+        if (module.userRequest === undefined) {
+          diag.rawDebug(
+            1,
+            `LavaMoatPlugin: Module ${module} has no userRequest`
+          )
+          diag.rawDebug(2, { skippingInspectingModule: module })
+          return
+        }
         const packageName = getPackageNameForModulePath(
           canonicalNameMap,
           module.userRequest

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -102,6 +102,18 @@ class LavaMoatPlugin {
     })
 
     const options = this.options
+
+    diag.run(2, () => {
+      // Log stack traces for all errors on higher verbosity because webpack won't
+      compiler.hooks.done.tap(PLUGIN_NAME, (stats) => {
+        if (stats.hasErrors()) {
+          stats.compilation.errors.forEach((error) => {
+            console.error(error.stack || error)
+          })
+        }
+      })
+    })
+
     if (typeof options.readableResourceIds === 'undefined') {
       // default options.readableResourceIds to true if webpack configuration sets development mode
       options.readableResourceIds = compiler.options.mode !== 'production'
@@ -139,7 +151,7 @@ class LavaMoatPlugin {
     // run long asynchronous processing ahead of all compilations
     compiler.hooks.beforeRun.tapAsync(PLUGIN_NAME, (compilation, callback) =>
       loadCanonicalNameMap({
-        rootDir: compiler.context,
+        rootDir: options.rootDir || compiler.context,
         includeDevDeps: true, // even the most proper projects end up including devdeps in their bundles :()
         resolve: browserResolve,
       })
@@ -363,11 +375,13 @@ class LavaMoatPlugin {
         // This hook happens after all module generators have been executed.
         compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
           diag.rawDebug(3, '> afterProcessAssets')
-          mainCompilationWarnings.push(
-            new WebpackError(
-              `in LavaMoatPlugin: excluded modules \n  ${excludes.join('\n  ')}`
+          if (excludes.length > 0) {
+            mainCompilationWarnings.push(
+              new WebpackError(
+                `in LavaMoatPlugin: excluded modules \n  ${excludes.join('\n  ')}`
+              )
             )
-          )
+          }
         })
 
         // =================================================================
@@ -517,6 +531,8 @@ module.exports = LavaMoatPlugin
 /**
  * @typedef {Object} LavaMoatPluginOptions
  * @property {boolean} [generatePolicy] - Generate the policy file
+ * @property {string} [rootDir] - Specify root directory for canonicalNames to
+ *   be resolved from if different than compiler.context
  * @property {string} policyLocation - Directory containing policy files are
  *   stored, defaults to './lavamoat/webpack'
  * @property {boolean} [emitPolicySnapshot] - Additionally put policy in dist of

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -108,7 +108,7 @@ class LavaMoatPlugin {
       compiler.hooks.done.tap(PLUGIN_NAME, (stats) => {
         if (stats.hasErrors()) {
           stats.compilation.errors.forEach((error) => {
-            console.error(error.stack || error)
+            console.error(error)
           })
         }
       })


### PR DESCRIPTION
- rootDir setting to let aa find the right package.json while webpack `compiler.context` is set to a subpath
- prevent error in policy generation for virtual modules webpack uses for juggling things that don't actually have sources
- added some debugging helpers