### PR TITLE
test(core): add a test to document the support scope of unwrapping this with bind

### DIFF
--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -45,6 +45,57 @@ test('getEndowmentsForConfig - function on proto', (t) => {
   t.is(resultGlobal.lookAtMyProto.appendChild(), assertMe)
 })
 
+test('getEndowmentsForConfig - function call/bind unwrapping', (t) => {
+  const getEndowmentsForConfig = prepareTest()
+
+  const sourceGlobal = {
+    checkThis: function () {
+      return this === sourceGlobal
+    },
+  }
+  const config = {
+    globals: {
+      checkThis: true,
+    },
+  }
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  t.is(typeof resultGlobal.checkThis, 'function')
+  t.is(resultGlobal.checkThis(), true)
+  t.is(resultGlobal.checkThis.bind({})(), false)
+  t.is(resultGlobal.checkThis.bind(resultGlobal)(), true)
+  t.is(resultGlobal.checkThis.call(resultGlobal), true)
+})
+
+test.failing(
+  'getEndowmentsForConfig - function call/bind unwrapping when only methods endowed',
+  (t) => {
+    const getEndowmentsForConfig = prepareTest()
+
+    const sourceGlobal = {
+      checkThis: function () {
+        return this === sourceGlobal
+      },
+    }
+
+    const config = {
+      globals: {
+        'checkThis.bind': true,
+        'checkThis.call': true,
+      },
+    }
+    const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+    t.is(typeof resultGlobal.checkThis, 'object') // the function is never wrapped
+
+    // This case is not supported and might be too risky to support. We should rather avoid producing it.
+    // In policy generation we could trim .bind (and probably also .call and .apply) to avoid hitting this problem.
+
+    // When a function is endowed, call and bind should work as expected because of the wrapping/unwrapping
+    // When only the call/bind methods are endowed, they are not taken from a wrapped function but from the source directly and `this` doesn't get correctly unwrapped.
+    t.is(resultGlobal.checkThis.call(resultGlobal), true)
+    t.is(resultGlobal.checkThis.bind(resultGlobal)(), true)
+  }
+)
+
 test('getEndowmentsForConfig - siblings', (t) => {
   const getEndowmentsForConfig = prepareTest()
   const sourceGlobal = { Buffer }

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -14,6 +14,8 @@ const {
   getParents,
 } = require('./util')
 
+const avoidEndingPathsIn = ['bind', 'call', 'apply']
+
 module.exports = {
   inspectGlobals,
   inspectRequires,
@@ -101,6 +103,11 @@ function inspectGlobals(
         // skip if global and only used for detecting presence
         if (path.length === 0) {
           return
+        }
+        // Sometimes nesting further doesn't make sense, like in case of Function methods
+        // Eliminating cases of nesting unwanted path endings like func.bind.call was considered not worth the complexity
+        if (avoidEndingPathsIn.includes(path[path.length - 1])) {
+          path.pop()
         }
         // submit as a global usage
         const pathString = path.join('.')

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -238,6 +238,17 @@ testInspect(
 )
 
 testInspect(
+  'get granular platform api - but avoid going down to Function methods',
+  { globalRefs: ['globalThis'] },
+  () => {
+    fetch.bind(globalThis)
+  },
+  {
+    fetch: 'read',
+  }
+)
+
+testInspect(
   'get granular platform api when nested under global',
   {
     globalRefs: ['window'],


### PR DESCRIPTION
This test documents the gap in unwrapping `this` support in lavamoat core. 
(this was first identified in Snaps: https://github.com/MetaMask/metamask-extension/pull/26431/files#diff-63ab7391d870a62d8bcd3cc5d5371432068538deb98e5effcb899434ed8649bbL2640)

@kumavis anticipates security issues if we handle unwrapping these. 

We could try to add support (regardless?) but it's a very niche thing and we might be better off eliminating endowments limited to `functionName.bind` from policy generation instead. the return value of bind is the function anyway, so why restrict it?

Therefore in policy generation we could trim `.bind` (and probably also `.call` and `.apply`) to solve this in the default case.  

Update:
Added a commit changing the behavior in Tofu to skip certain path endings. 
How likely is it that a nested global actually has a `.bind` method that's custom, not a Function method?
Is it too much of a POLA scope widening by default in the case of these not being function methods?
I'm thinking it's fine to have that default if we don't support wrapping.


