### PR TITLE
feat(webpack): support thisAsExports runtime requirement

### DIFF
--- a/packages/webpack/src/ENUM.json
+++ b/packages/webpack/src/ENUM.json
@@ -3,5 +3,4 @@
   "NAME_scopeTerminator": "ST",
   "NAME_runtimeHandler": "RH",
   "RUNTIME_KEY": "_LM_"
-
 }

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -4,6 +4,9 @@ const fs = require('node:fs')
 const q = JSON.stringify
 
 /**
+ * Flags enabling runtime features based on webpack's runtime requirements.
+ * Using this decouples the concept of runtime requirements from wrapper.
+ *
  * @typedef {object} RuntimeFlags
  * @property {boolean} [thisAsExports]
  */

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -4,12 +4,17 @@ const fs = require('node:fs')
 const q = JSON.stringify
 
 /**
+ * @typedef {object} RuntimeFlags
+ * @property {boolean} [thisAsExports]
+ */
+/**
  * @typedef {object} WrappingInput
  * @property {string} source
  * @property {string} id
  * @property {string[] | Set<string>} runtimeKit
  * @property {string} evalKitFunctionName
  * @property {boolean} [runChecks]
+ * @property {RuntimeFlags} [runtimeFlags]
  */
 
 const {
@@ -33,12 +38,25 @@ exports.wrapper = function wrapper({
   runtimeKit,
   evalKitFunctionName,
   runChecks = true,
+  runtimeFlags = {},
 }) {
+  const runtimeKitArray = Array.from(runtimeKit)
   // validateSource(source);
 
   // No AST used in these transforms, so string cmparison should indicate if anything was changed.
   const sesCompatibleSource = applySourceTransforms(source)
   const sourceChanged = source !== sesCompatibleSource
+
+  // This adds support for mapping `this` to `exports` or `module.exports` if webpack detected it's necessary
+  let optionalBinding = ''
+
+  if (runtimeFlags.thisAsExports) {
+    if (runtimeKitArray.includes('exports')) {
+      optionalBinding = '.bind(exports)'
+    } else if (runtimeKitArray.includes('module')) {
+      optionalBinding = '.bind(module.exports)'
+    }
+  }
 
   // TODO: Consider: We could save some bytes by merging scopeTerminator and runtimeHandler, but then runtime calls would go through a proxy, which is slower. Merging runtimeKit with globalThis would also be problematic.
 
@@ -56,9 +74,9 @@ exports.wrapper = function wrapper({
       }
     }
     }
-}).call(${evalKitFunctionName}(${q(id)}, { ${Array.from(runtimeKit).join(
+}).call(${evalKitFunctionName}(${q(id)}, { ${runtimeKitArray.join(
     ','
-  )}}))()`
+  )}}))${optionalBinding}()`
   if (runChecks) {
     validateSource(before + sesCompatibleSource + after)
   }

--- a/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/index.js
@@ -1,2 +1,4 @@
 // this is how semver package exports itself, minified
 var i = (exports = module.exports = {}).re = []
+
+require('./this')

--- a/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/this.js
+++ b/packages/webpack/test/fixtures/main/node_modules/commonjs-quirks/this.js
@@ -1,0 +1,8 @@
+const thisThis = this
+
+// a line to make sure that the file is considered cjs
+exports.zz=123;
+
+if(thisThis !== exports){
+  throw new Error('[commonjs-quirks] expected exports to be available as this in cjs')
+}


### PR DESCRIPTION
In case you didn't know, in cjs modules under node.js `exports === this` and webpack is capable of emulating that, so some old modules still use it.

TODO:
 - [x] add a fixture for this to the main tests