### PR TITLE
feat(webpack): avoid errors when code is instrumented with harmony module wrapper

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -104,7 +104,7 @@ This plugin will skip policy enforcement for such ignored modules.
 
 #### HMR
 
-LavaMoat is not compatible with Hot Module Replacement (HMR) and any form of it would not make much sense with the security guarantees, so you're better off disabling LavaMoat for development builds where HMR is required.
+LavaMoat is not compatible with Hot Module Replacement (HMR). Disable LavaMoat for development builds where HMR is required while keeping it enabled for production builds.
 
 # Security
 

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -104,8 +104,7 @@ This plugin will skip policy enforcement for such ignored modules.
 
 #### HMR
 
-LavaMoat is not compatible with Hot Module Replacement and any form of it would not make much sense with the security guarantees, so you're better off using lavamoat in your production build.
-It's not easy to spot when a tool or setting is enabling HMR though, so LavaMoat plugin will stub out some of the HMR functionality to do nothing.
+LavaMoat is not compatible with Hot Module Replacement (HMR) and any form of it would not make much sense with the security guarantees, so you're better off disabling LavaMoat for development builds where HMR is required.
 
 # Security
 

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -102,6 +102,11 @@ Sadly, even treeshaking doesn't eliminate that module. It's left there and faili
 
 This plugin will skip policy enforcement for such ignored modules.
 
+#### HMR
+
+LavaMoat is not compatible with Hot Module Replacement and any form of it would not make much sense with the security guarantees, so you're better off using lavamoat in your production build.
+It's not easy to spot when a tool or setting is enabling HMR though, so LavaMoat plugin will stub out some of the HMR functionality to do nothing.
+
 # Security
 
 **This is an experimental software. Use at your own risk!**

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -265,14 +265,15 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
     policyRequire.g = compartmentMap.get(resourceId).globalThis
 
     // override nmd to limit what it can mutate
-    policyRequire.nmd = (/** @type {any} */ moduleReference) => {
-      if (moduleReference === module) {
-        module = __webpack_require__.nmd(module)
-        return module
-      }
-    }
-    // override hmd to silently disable it
-    policyRequire.hmd = (/** @type {any} */ mo) => mo
+    policyRequire.nmd = (/** @type {any} */ moduleReference) =>
+      moduleReference === module
+        ? __webpack_require__.nmd(module)
+        : moduleReference
+    // override hmd to limit what it can mutate
+    policyRequire.hmd = (/** @type {any} */ moduleReference) =>
+      moduleReference === module
+        ? __webpack_require__.hmd(module)
+        : moduleReference
 
     overrides.__webpack_require__ = policyRequire
   }

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -271,6 +271,8 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
         return module
       }
     }
+    // override hmd to silently disable it
+    policyRequire.hmd = (/** @type {any} */ mo) => mo
 
     overrides.__webpack_require__ = policyRequire
   }


### PR DESCRIPTION
~~Webpack, for reasons I didn't uncover, wraps some references in `.hmd()` call despite HMR not being enabled.
This PR stubs out the method to avoid errors.~~
This has nothing to do with Hot Module Replacement - hmd is a module wrapper that's only used in case of transforming from ESM. 