### PR TITLE
fix(webpack): an implementation of builtins that actually works

### DIFF
--- a/packages/webpack/src/buildtime/aa.js
+++ b/packages/webpack/src/buildtime/aa.js
@@ -51,6 +51,7 @@ const crossReference = (neededIds, policyIds) => {
  * @typedef {Object} IdentifierLookup
  * @property {string} root
  * @property {(string | number)[]} unenforceableModuleIds
+ * @property {Record<string | number, string>} externals
  * @property {[string, (string | number)[]][]} identifiersForModuleIds
  * @property {(path: string) => string | undefined} pathToResourceId
  * @property {(id: string) => string} policyIdentifierToResourceId
@@ -63,6 +64,7 @@ const crossReference = (neededIds, policyIds) => {
  * @param {import('lavamoat-core').LavaMoatPolicy} options.policy
  * @param {import('@lavamoat/aa').CanonicalNameMap} options.canonicalNameMap
  * @param {(string | number)[]} options.unenforceableModuleIds
+ * @param {Record<string | number, string>} options.externals
  * @param {boolean | undefined} options.readableResourceIds
  * @returns {IdentifierLookup}
  */
@@ -71,6 +73,7 @@ exports.generateIdentifierLookup = ({
   policy,
   canonicalNameMap,
   unenforceableModuleIds,
+  externals,
   readableResourceIds,
 }) => {
   /**
@@ -148,6 +151,7 @@ exports.generateIdentifierLookup = ({
   return {
     root: translate(ROOT_IDENTIFIER),
     unenforceableModuleIds,
+    externals,
     identifiersForModuleIds,
     pathToResourceId: (path) => {
       const pathInfo = lookUp(path, pathLookup)

--- a/packages/webpack/src/buildtime/exclude.js
+++ b/packages/webpack/src/buildtime/exclude.js
@@ -1,4 +1,5 @@
 /** @typedef {import('webpack').NormalModule} NormalModule */
+/** @typedef {import('./policyGenerator').InspectableWebpackModule} InspectableWebpackModule */
 
 const path = require('node:path')
 const EXCLUDE_LOADER = path.join(__dirname, '../excludeLoader.js')
@@ -24,10 +25,13 @@ module.exports = {
    * Unsafe version of exclude lookup - does not check for the possibility of
    * injecting a loader chain. Intended use in policy generation.
    *
-   * @param {NormalModule} module
+   * @param {InspectableWebpackModule} module
    * @returns {boolean}
    */
   isExcludedUnsafe: (module) => {
-    return !!module.loaders?.some(({ loader }) => loader === EXCLUDE_LOADER)
+    return (
+      'loaders' in module &&
+      !!module.loaders?.some(({ loader }) => loader === EXCLUDE_LOADER)
+    )
   },
 }

--- a/packages/webpack/src/buildtime/policyGenerator.js
+++ b/packages/webpack/src/buildtime/policyGenerator.js
@@ -19,6 +19,10 @@ const POLICY_SNAPSHOT_FILENAME = 'policy-snapshot.json'
  * @typedef {(specifier: string) => boolean} IsBuiltinFn
  */
 
+/**
+ * @typedef {import('webpack').NormalModule | import('webpack').ExternalModule} InspectableWebpackModule
+ */
+
 module.exports = {
   /**
    * @param {Object} opts
@@ -92,7 +96,7 @@ module.exports = {
 
     return {
       /**
-       * @param {import('webpack').NormalModule} module
+       * @param {InspectableWebpackModule} module
        * @param {Iterable<import('webpack').ModuleGraphConnection>} connections
        */
       inspectWebpackModule: (module, connections) => {

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -212,6 +212,13 @@ class LavaMoatPlugin {
          */
         const unenforceableModuleIds = []
         /**
+         * A record of module ids that are externals and need to be enforced as
+         * builtins.
+         *
+         * @type {Record<string | number, string>}
+         */
+        const externals = {}
+        /**
          * @type {import('./buildtime/aa.js').IdentifierLookup}
          */
         let identifierLookup
@@ -257,14 +264,23 @@ class LavaMoatPlugin {
         /**
          * @param {import('webpack').Module} m
          * @param {string} moduleClass
-         * @returns {m is import('webpack').NormalModule} // TODO: this is not
+         * @returns {m is import('webpack').ExternalModule} // TODO: this is not
          *   true anymore, but there's no superclass of all reasonable module
          *   types
+         */
+        const isExternalModule = (m, moduleClass) =>
+          ['ExternalModule'].includes(moduleClass) &&
+          'externalType' in m &&
+          m.externalType !== undefined
+        /**
+         * @param {import('webpack').Module} m
+         * @param {string} moduleClass
+         * @returns {m is import('./buildtime/policyGenerator.js').InspectableWebpackModule}
          */
         const isInspectableModule = (m, moduleClass) =>
           'userRequest' in m ||
           m.type?.startsWith('javascript') ||
-          ['ExternalModule'].includes(moduleClass)
+          isExternalModule(m, moduleClass)
 
         // Old: good for collecting all possible paths, but bad for matching them with module ids
         // collect all paths resolved for the bundle and transition afterwards
@@ -294,6 +310,9 @@ class LavaMoatPlugin {
                 if (isIgnoredModule(module)) {
                   unenforceableModuleIds.push(moduleId)
                 } else {
+                  if (isExternalModule(module, moduleClass)) {
+                    externals[moduleId] = module.userRequest
+                  }
                   if (isInspectableModule(module, moduleClass)) {
                     policyGenerator.inspectWebpackModule(
                       module,
@@ -325,6 +344,7 @@ class LavaMoatPlugin {
             identifierLookup = generateIdentifierLookup({
               readableResourceIds: options.readableResourceIds,
               unenforceableModuleIds,
+              externals,
               paths: knownPaths,
               policy: policyToApply,
               canonicalNameMap,
@@ -428,6 +448,11 @@ class LavaMoatPlugin {
                   {
                     name: 'unenforceable',
                     data: identifierLookup.unenforceableModuleIds || null,
+                    json: true,
+                  },
+                  {
+                    name: 'externals',
+                    data: identifierLookup.externals || null,
                     json: true,
                   },
                   { name: 'options', data: runtimeOptions, json: true },

--- a/packages/webpack/src/runtime/runtime-namespace.ts
+++ b/packages/webpack/src/runtime/runtime-namespace.ts
@@ -5,7 +5,8 @@ type RequiredProperty<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export interface RuntimeNamespace {
   root: string
   idmap: [string, string[]][]
-  unenforceable: string[]
+  unenforceable: (string | number)[]
+  externals: Record<string | number, string>
   options: LavaMoatPluginOptions
   policy: RequiredProperty<LavaMoatPolicy, 'resources'>
   ENUM: Record<string, string>

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -87,20 +87,21 @@ const enforcePolicy = (specifier, referrerResourceId, wrappedRequire) => {
     return wrappedRequire()
   }
   const referrerPolicy = LAVAMOAT.policy.resources[referrerResourceId] || {}
-  if (referrerPolicy.builtin) {
-    if (referrerPolicy.builtin[specifier]) {
+  if (referrerPolicy.builtin && LAVAMOAT.externals[specifier]) {
+    const builtinName = LAVAMOAT.externals[specifier]
+    if (referrerPolicy.builtin[builtinName]) {
       return wrappedRequire()
     }
     if (
-      !specifier.includes('.') &&
+      !builtinName.includes('.') &&
       keys(referrerPolicy.builtin).some((key) =>
-        key.startsWith(`${specifier}.`)
+        key.startsWith(`${builtinName}.`)
       )
     ) {
       // create minimal selection if it's a builtin and not allowed as a whole, but with subpaths
       return getBuiltinForConfig(
         wrappedRequire(),
-        specifier,
+        builtinName,
         referrerPolicy.builtin
       )
     }

--- a/packages/webpack/test/e2e-nodejs.spec.js
+++ b/packages/webpack/test/e2e-nodejs.spec.js
@@ -13,7 +13,7 @@ test.before(async (t) => {
     policyLocation: path.resolve(__dirname, 'fixtures/main/policy-node'),
   })
   webpackConfig.target = 'node'
-  webpackConfig.mode = 'development'
+  webpackConfig.optimization.minimize = false
   webpackConfig.entry = {
     app: './node.js',
   }

--- a/packages/webpack/test/fixtures/main/webpack.config.js
+++ b/packages/webpack/test/fixtures/main/webpack.config.js
@@ -46,8 +46,9 @@ function makeConfig(lmOptions = {}) {
       }),
       new HtmlWebpackPlugin(),
     ],
-    resolve:{
-      fallback: { "crypto": false }
+    optimization: {},
+    resolve: {
+      fallback: { crypto: false },
     },
     module: {
       rules: [
@@ -57,10 +58,7 @@ function makeConfig(lmOptions = {}) {
             {
               loader: 'babel-loader',
               options: {
-                presets: [
-                  '@babel/preset-env',
-                  '@babel/preset-typescript',
-                ],
+                presets: ['@babel/preset-env', '@babel/preset-typescript'],
               },
             },
           ],


### PR DESCRIPTION
- previous implementation relied on information that was not available in webpack production mode
- current implementation is more resilient as it only looks up known external modules as builtins, not everything in a module that has builtins allowed.