### PR TITLE
chore: corepack is devDependency of lavamoat-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,6 @@
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0",
         "npm": ">=7.0.0"
-      },
-      "optionalDependencies": {
-        "corepack": "0.29.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7405,7 +7402,6 @@
       "version": "0.29.3",
       "resolved": "https://registry.npmjs.org/corepack/-/corepack-0.29.3.tgz",
       "integrity": "sha512-Weu+WZq04wGXykGZ7WtTilJU/OZsAXEM9ys6zW2uEQTLbyVOguQ2h1PkznKfULqVxXQH/LakALk7GmRNm8DXuw==",
-      "optional": true,
       "bin": {
         "corepack": "dist/corepack.js",
         "pnpm": "dist/pnpm.js",
@@ -18590,6 +18586,7 @@
         "@babel/highlight": "7.24.7",
         "@lavamoat/aa": "^4.3.0",
         "bindings": "1.5.0",
+        "corepack": "0.29.3",
         "htmlescape": "1.1.1",
         "json-stable-stringify": "1.1.1",
         "lavamoat-core": "^16.0.0",
@@ -19183,6 +19180,9 @@
         "@yarnpkg/cli": "3.8.5",
         "@yarnpkg/core": "3.7.0",
         "clipanion": "3.2.1"
+      },
+      "devDependencies": {
+        "corepack": "0.29.3"
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "workspaces": [
     "packages/*"
   ],
+  "packageManager": "npm@9.9.3+sha512.67597eadc4399186f5ec5de11ed3bad356ab129bdd4589c22ed83cc68dc01adca3dc8b61c1aada10e7b123df74dee00d9227c56ea1c2f214f9dca22ba335a0f0",
   "engines": {
     "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0",
     "npm": ">=7.0.0"
@@ -35,9 +36,6 @@
     "test:prep": "npm run --workspaces --if-present test:prep",
     "test:workspaces": "npm run --workspaces --if-present test",
     "watch:types": "tsc -b --watch"
-  },
-  "optionalDependencies": {
-    "corepack": "0.29.3"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",
@@ -93,6 +91,5 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "tsdoc": true
-  },
-  "packageManager": "npm@9.9.3+sha512.67597eadc4399186f5ec5de11ed3bad356ab129bdd4589c22ed83cc68dc01adca3dc8b61c1aada10e7b123df74dee00d9227c56ea1c2f214f9dca22ba335a0f0"
+  }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,6 +37,7 @@
     "@babel/highlight": "7.24.7",
     "@lavamoat/aa": "^4.3.0",
     "bindings": "1.5.0",
+    "corepack": "0.29.3",
     "htmlescape": "1.1.1",
     "json-stable-stringify": "1.1.1",
     "lavamoat-core": "^16.0.0",


### PR DESCRIPTION
This changes `corepack` from being in `optionalDependencies` of root project to `devDependencies` of project where it is actually used in tests:
- chore(lavamoat-node): add `corepack` to `devDependencies` 
- chore: remove `corepack` from `optionalDependencies`

---

#### Blocking
- #1218 