### PR TITLE
chore(ci): no windows tests for allow-scripts, yarn-plugin-allow-scripts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -133,12 +133,10 @@ jobs:
       FORCE_COLOR: 1
       TEST_WORKSPACES: >-
         --workspace=packages/aa
-        --workspace=packages/allow-scripts
         --workspace=packages/core
         --workspace=packages/lavapack
         --workspace=packages/preinstall-always-fail
         --workspace=packages/tofu
-        --workspace=packages/yarn-plugin-allow-scripts
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4


### PR DESCRIPTION
- chore(ci): Disable Windows tests for `allow-scripts`, `yarn-plugin-allow-scripts`