### PR TITLE
chore: align internal dependency ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18578,8 +18578,8 @@
         "ses": "1.8.0"
       },
       "devDependencies": {
-        "lavamoat": "^8.0.0",
-        "lavamoat-browserify": "^17.0.0",
+        "lavamoat": "^9.0.0",
+        "lavamoat-browserify": "^18.0.0",
         "serve": "14.2.3"
       },
       "engines": {
@@ -18747,55 +18747,6 @@
         "node": ">=4"
       }
     },
-    "packages/perf/node_modules/lavamoat": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/lavamoat/-/lavamoat-8.0.7.tgz",
-      "integrity": "sha512-hNamqs5Ag6l7VFGGII/OwdcKyiVteSn7JWOm8LRgw7ioJQbNO3yHA5/4cc03ZcRNOAlhkFVHQ5VXAtycHV0C9g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "7.24.6",
-        "@babel/highlight": "7.24.6",
-        "@lavamoat/aa": "^4.3.0",
-        "bindings": "1.5.0",
-        "htmlescape": "1.1.1",
-        "json-stable-stringify": "1.1.1",
-        "lavamoat-core": "^15.4.0",
-        "lavamoat-tofu": "^7.3.0",
-        "node-gyp-build": "4.8.1",
-        "resolve": "1.22.8",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "lavamoat": "src/cli.js",
-        "lavamoat-run-command": "src/run-command.js"
-      },
-      "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0 <20.15.0 || ^22.0.0 <22.2.0"
-      }
-    },
-    "packages/perf/node_modules/lavamoat-browserify": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/lavamoat-browserify/-/lavamoat-browserify-17.0.8.tgz",
-      "integrity": "sha512-5CJnWZ0bJ1gfmlDPhy4CHC/AcIPqxjl38iDKAaeMcT3WX/vSzT8orU+pm/p+jTXMYH74xbUIHxrhBxJ622LIoA==",
-      "dev": true,
-      "dependencies": {
-        "@lavamoat/aa": "^4.3.0",
-        "@lavamoat/lavapack": "^6.1.4",
-        "browser-resolve": "2.0.0",
-        "concat-stream": "2.0.0",
-        "convert-source-map": "2.0.0",
-        "duplexify": "4.1.3",
-        "json-stable-stringify": "1.1.1",
-        "lavamoat-core": "^15.4.0",
-        "pify": "5.0.0",
-        "readable-stream": "4.5.2",
-        "source-map": "0.7.4",
-        "through2": "4.0.2"
-      },
-      "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0 <20.15.0 || ^22.0.0 <22.2.0"
-      }
-    },
     "packages/perf/node_modules/lavamoat-core": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/lavamoat-core/-/lavamoat-core-15.4.0.tgz",
@@ -18896,9 +18847,9 @@
       "license": "MIT",
       "dependencies": {
         "cheerio": "1.0.0",
-        "lavamoat": "^8.0.0",
-        "lavamoat-core": "^15.0.0",
-        "lavamoat-tofu": "^7.0.0",
+        "lavamoat": "^9.0.0",
+        "lavamoat-core": "^16.0.0",
+        "lavamoat-tofu": "^8.0.0",
         "node-fetch": "2.7.0",
         "p-limit": "3.1.0"
       },
@@ -19014,64 +18965,6 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "packages/survey/node_modules/lavamoat": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/lavamoat/-/lavamoat-8.0.7.tgz",
-      "integrity": "sha512-hNamqs5Ag6l7VFGGII/OwdcKyiVteSn7JWOm8LRgw7ioJQbNO3yHA5/4cc03ZcRNOAlhkFVHQ5VXAtycHV0C9g==",
-      "dependencies": {
-        "@babel/code-frame": "7.24.6",
-        "@babel/highlight": "7.24.6",
-        "@lavamoat/aa": "^4.3.0",
-        "bindings": "1.5.0",
-        "htmlescape": "1.1.1",
-        "json-stable-stringify": "1.1.1",
-        "lavamoat-core": "^15.4.0",
-        "lavamoat-tofu": "^7.3.0",
-        "node-gyp-build": "4.8.1",
-        "resolve": "1.22.8",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "lavamoat": "src/cli.js",
-        "lavamoat-run-command": "src/run-command.js"
-      },
-      "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0 <20.15.0 || ^22.0.0 <22.2.0"
-      }
-    },
-    "packages/survey/node_modules/lavamoat-core": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/lavamoat-core/-/lavamoat-core-15.4.0.tgz",
-      "integrity": "sha512-GmaweS0PYRsiRuPEUzLu5MV6g7kOkiZLUPCbwo6GHwvoRW4wCn6BOTCttUoxGJpQiC8Lywm2P2Ia4r5pEmr22A==",
-      "dependencies": {
-        "@babel/types": "7.24.6",
-        "json-stable-stringify": "1.1.1",
-        "lavamoat-tofu": "^7.3.0",
-        "merge-deep": "3.0.3",
-        "type-fest": "4.15.0"
-      },
-      "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0"
-      }
-    },
-    "packages/survey/node_modules/lavamoat-tofu": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/lavamoat-tofu/-/lavamoat-tofu-7.3.0.tgz",
-      "integrity": "sha512-f/BmaBOK+FSY2aHQ/Q3xe1C9LzvSCnZ+8tsBCq2fT2/qhVOYb9aSda531PppycStWFqqJb3e238QHUoKdq1wpg==",
-      "dependencies": {
-        "@babel/parser": "7.24.6",
-        "@babel/traverse": "7.24.6",
-        "@babel/types": "7.24.6",
-        "@types/babel__traverse": "7.20.6",
-        "type-fest": "4.15.0"
-      },
-      "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0 || ^22.0.0"
-      },
-      "peerDependencies": {
-        "lavamoat-core": "^15.4.0"
       }
     },
     "packages/survey/node_modules/node-gyp-build": {

--- a/packages/node/examples/express/package.json
+++ b/packages/node/examples/express/package.json
@@ -9,7 +9,7 @@
     "express": "^4.19.2"
   },
   "devDependencies": {
-    "lavamoat": "^8.0.7",
+    "lavamoat": "^9.0.0",
     "patch-package": "^6.5.1",
     "postinstall-postinstall": "^2.1.0"
   },

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -29,8 +29,8 @@
     "ses": "1.8.0"
   },
   "devDependencies": {
-    "lavamoat": "^8.0.0",
-    "lavamoat-browserify": "^17.0.0",
+    "lavamoat": "^9.0.0",
+    "lavamoat-browserify": "^18.0.0",
     "serve": "14.2.3"
   }
 }

--- a/packages/survey/package.json
+++ b/packages/survey/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "cheerio": "1.0.0",
-    "lavamoat": "^8.0.0",
-    "lavamoat-core": "^15.0.0",
-    "lavamoat-tofu": "^7.0.0",
+    "lavamoat": "^9.0.0",
+    "lavamoat-core": "^16.0.0",
+    "lavamoat-tofu": "^8.0.0",
     "node-fetch": "2.7.0",
     "p-limit": "3.1.0"
   }


### PR DESCRIPTION
Aligning workspace dependency versions to not pull old releases from npmjs.org.

- Follow-up to #1228 