### PR TITLE
feat: default attenuator initialization for write policy support

### DIFF
--- a/packages/node/src/compartment-map.js
+++ b/packages/node/src/compartment-map.js
@@ -3,10 +3,11 @@ import { captureFromMap } from '@endo/compartment-mapper/capture-lite.js'
 import { defaultParserForLanguage } from '@endo/compartment-mapper/import-parsers.js'
 import { mapNodeModules } from '@endo/compartment-mapper/node-modules.js'
 import { NATIVE_FILE_EXT, NATIVE_PARSER_NAME } from './constants.js'
+import { makeGlobalsAttenuator } from './default-attenuator.js'
 import { importHook, importNowHook } from './import-hook.js'
 import { syncModuleTransforms } from './module-transforms.js'
 import parseNative from './parse-native.js'
-import { toEndoPolicy } from './policy-converter.js'
+import { DEFAULT_ATTENUATOR, toEndoPolicy } from './policy-converter.js'
 import { defaultReadPowers } from './power.js'
 import { toURLString } from './util.js'
 
@@ -104,6 +105,11 @@ export const execute = async (readPowers, entrypointPath, policy) => {
   const entryPoint = toURLString(entrypointPath)
   const { namespace } = await importLocation(readPowers, entryPoint, {
     ...ENDO_OPTIONS,
+    modules: {
+      [DEFAULT_ATTENUATOR]: {
+        attenuateGlobals: makeGlobalsAttenuator({ policy }),
+      },
+    },
     policy: endoPolicy,
   })
   return namespace

--- a/packages/node/src/default-attenuator.js
+++ b/packages/node/src/default-attenuator.js
@@ -14,64 +14,23 @@
  */
 // @ts-expect-error - types not exported from here
 import endowmentsToolkit_ from 'lavamoat-core/src/endowmentsToolkit.js'
-import { POLICY_ITEM_ROOT, POLICY_ITEM_WRITE } from './constants.js'
+import { POLICY_ITEM_ROOT } from './constants.js'
 
 /** @type {typeof import('lavamoat-core').endowmentsToolkit} */
 const endowmentsToolkit = endowmentsToolkit_
+const {
+  values,
+  entries,
+  fromEntries,
+  defineProperties,
+  getOwnPropertyDescriptors,
+} = Object
 
 /**
  * @import {GlobalAttenuatorFn, ModuleAttenuatorFn} from '@endo/compartment-mapper'
  * @import {GlobalAttenuatorParams} from './types.js'
+ * @import {LavaMoatPolicy} from 'lavamoat-core'
  */
-
-const { copyWrappedGlobals, getEndowmentsForConfig } = endowmentsToolkit()
-
-const { fromEntries, defineProperties, getOwnPropertyDescriptors } = Object
-
-/** @type {object} */
-let rootCompartmentGlobalThis
-
-/**
- * @type {GlobalAttenuatorFn<GlobalAttenuatorParams>}
- */
-export const attenuateGlobals = (
-  [policy],
-  originalGlobalThis,
-  packageCompartmentGlobalThis
-) => {
-  if (!policy) {
-    return
-  }
-  if (policy === POLICY_ITEM_ROOT) {
-    rootCompartmentGlobalThis = packageCompartmentGlobalThis
-    // ^ this is a little dumb, but only a little - assuming importLocation is called only once in parallel. The thing is - even if it isn't, the new one will have a new copy of this module anyway.
-    // That is unless we decide to use `modules` for passing the attenuator, in which case we have an attenuator defined outside of Endo and we can scope it as we wish. Tempting. Slightly less secure, because if we have a prototype pollution or RCE in the attenuator, we're exposing the outside instead of the attenuators compartment.
-    copyWrappedGlobals(originalGlobalThis, packageCompartmentGlobalThis, [
-      'globalThis',
-      'global',
-    ])
-  } else if (policy === POLICY_ITEM_WRITE) {
-    // TODO: implement
-    // Write is per field not for all globals. It'll need to be implemented in getEndowmentsForConfig or the defineProperties step afterwards when it gets handled by another function from endowmentsToolkit (the latter more likely)
-    // - if (policy === WRITE_POLICY) {
-    // -   throw new Error('Not yet implemented')
-    // - }
-  } else {
-    const endowments = getEndowmentsForConfig(
-      rootCompartmentGlobalThis,
-      policy,
-      // rootCompartmentGlobalThis, // Not sure if it works, but with this as a 3rd argument, in theory, each compartment would unwrap functions to the root conpartment's globalThis, where all copied functions are set up to unwrap to actual globalThis
-      // instead I'm opting for a single unwrap since we now have access to the actual globalThis
-      originalGlobalThis,
-      packageCompartmentGlobalThis
-    )
-
-    defineProperties(
-      packageCompartmentGlobalThis,
-      getOwnPropertyDescriptors(endowments)
-    )
-  }
-}
 
 /**
  * Picks stuff in the policy out of the original object
@@ -81,5 +40,69 @@ export const attenuateGlobals = (
  *   Record<string, unknown>
  * >}
  */
-export const attenuateModule = (params, originalObject) =>
-  fromEntries(params.map((key) => [key, originalObject[key]]))
+export const attenuateModule = (params, originalObject) => {
+  return fromEntries(params.map((key) => [key, originalObject[key]]))
+}
+
+/**
+ * @param {object} options
+ * @param {LavaMoatPolicy} [options.policy]
+ * @returns Attenuator
+ * @internal
+ */
+export const makeGlobalsAttenuator = ({ policy } = { policy: undefined }) => {
+  const knownWritableFields = new Set()
+
+  if (policy) {
+    values(policy.resources ?? {}).forEach((resource) => {
+      if (resource.globals && typeof resource.globals === 'object') {
+        entries(resource.globals).forEach(([key, value]) => {
+          if (value === 'write') {
+            knownWritableFields.add(key)
+          }
+        })
+      }
+    })
+  }
+
+  const { getEndowmentsForConfig, copyWrappedGlobals } = endowmentsToolkit({
+    handleGlobalWrite: knownWritableFields.size > 0,
+    knownWritableFields,
+  })
+
+  /** @type {object} */
+  let rootCompartmentGlobalThis
+
+  /**
+   * @type {GlobalAttenuatorFn<GlobalAttenuatorParams>}
+   */
+  return ([policy], originalGlobalThis, packageCompartmentGlobalThis) => {
+    if (!policy) {
+      return
+    }
+    if (policy === POLICY_ITEM_ROOT) {
+      rootCompartmentGlobalThis = packageCompartmentGlobalThis
+      // ^ this is a little dumb, but only a little - assuming importLocation is called only once in parallel. The thing is - even if it isn't, the new one will have a new copy of this module anyway.
+      // That is unless we decide to use `modules` for passing the attenuator, in which case we have an attenuator defined outside of Endo and we can scope it as we wish. Tempting. Slightly less secure, because if we have a prototype pollution or RCE in the attenuator, we're exposing the outside instead of the attenuators compartment.
+      copyWrappedGlobals(originalGlobalThis, packageCompartmentGlobalThis, [
+        'globalThis',
+        'global',
+      ])
+    } else {
+      const endowments = getEndowmentsForConfig(
+        rootCompartmentGlobalThis,
+        policy,
+        // rootCompartmentGlobalThis, // Not sure if it works, but with this as a 3rd argument, in theory, each compartment would unwrap functions to the root conpartment's globalThis, where all copied functions are set up to unwrap to actual globalThis
+        // instead I'm opting for a single unwrap since we now have access to the actual globalThis
+        originalGlobalThis,
+        packageCompartmentGlobalThis
+      )
+
+      defineProperties(
+        packageCompartmentGlobalThis,
+        getOwnPropertyDescriptors(endowments)
+      )
+    }
+  }
+}
+export const attenuateGlobals = makeGlobalsAttenuator()

--- a/packages/node/src/policy-converter.js
+++ b/packages/node/src/policy-converter.js
@@ -16,11 +16,11 @@ const { isArray } = Array
 const { entries, fromEntries } = Object
 
 /**
+ * @import {GlobalPolicy, PackagePolicy, LavaMoatPolicy, ResourcePolicy, LavaMoatPolicyOverrides} from 'lavamoat-core'
  * @import {LavaMoatPackagePolicy, LavaMoatPackagePolicyOptions, LavaMoatEndoPolicy} from './types.js'
- * @import {PackagePolicy, GlobalPolicy, ResourcePolicy, LavaMoatPolicy, LavaMoatPolicyOverrides} from 'lavamoat-core'
  */
 
-const DEFAULT_ATTENUATOR = '@lavamoat/node/attenuator'
+export const DEFAULT_ATTENUATOR = '@attennuator@' // If we wanted endo to load and execute the code in attenuators compartment, we could pass '@lavamoat/endomoat/attenuator' as default attenuator and have it loaded statelessly. We're using an impossible specifier to match with an external module instead.
 
 /**
  * Converts LavaMoat `ResourcePolicy.builtins` to Endo's


### PR DESCRIPTION
Core's endowmentsToolkit has all the capability to support writable fields, but it needs to receive a result of scanning the policy for them as a prerequisite. 
That in turn forced an initialization step for the default attenuator to provide the context.

This is a draft implementation with that step. 

Alternatively, we could let attenuators export an `initialize` method and pass policy into that method, collect the return value and give that return value to all attenuator calls as argument.


TODO:
- [ ] fix modules attenuator
- [ ] tests