### PR TITLE
chore(allow-scripts): handle spaces in execPath in Windows tests

### DIFF
--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -1,11 +1,10 @@
 const test = require('ava')
-const os = require('node:os')
 const fs = require('node:fs')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 const { pathToFileURL } = require('node:url')
+const { isWindows, fixWindowsExecPath } = require('./utils.js')
 
-const isWindows = os.platform() === 'win32'
 const NPM_CMD = isWindows ? 'npm.cmd' : 'npm'
 /* eslint-disable ava/no-skip-test */
 const skipOnWindows = isWindows
@@ -31,7 +30,7 @@ const run = (t, args, cwd) => {
   const ALLOW_SCRIPTS_BIN = require.resolve('../src/cli')
   const options = realisticEnvOptions(cwd)
   const result = spawnSync(
-    process.execPath,
+    isWindows ? fixWindowsExecPath(process.execPath) : process.execPath,
     [ALLOW_SCRIPTS_BIN, ...args],
     options
   )

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -3,7 +3,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 const { pathToFileURL } = require('node:url')
-const { isWindows, fixWindowsExecPath } = require('./utils.js')
+const { isWindows, portableExecPath } = require('./utils.js')
 
 const NPM_CMD = isWindows ? 'npm.cmd' : 'npm'
 /* eslint-disable ava/no-skip-test */
@@ -29,8 +29,9 @@ const run = (t, args, cwd) => {
   // Path to the allow-scripts executable
   const ALLOW_SCRIPTS_BIN = require.resolve('../src/cli')
   const options = realisticEnvOptions(cwd)
+  const execPath = portableExecPath(process.execPath)
   const result = spawnSync(
-    isWindows ? fixWindowsExecPath(process.execPath) : process.execPath,
+    execPath,
     [ALLOW_SCRIPTS_BIN, ...args],
     options
   )
@@ -39,7 +40,7 @@ const run = (t, args, cwd) => {
     t.log('Result from a failed spawnSync:', result)
 
     t.fail(
-      `Failed calling '${process.execPath} ${ALLOW_SCRIPTS_BIN} ${args.join(' ')}'`,
+      `Failed calling '${execPath} ${ALLOW_SCRIPTS_BIN} ${args.join(' ')}'`,
       {
         cwd,
         options,

--- a/packages/allow-scripts/test/prepare.js
+++ b/packages/allow-scripts/test/prepare.js
@@ -1,6 +1,7 @@
 const { execSync } = require('node:child_process')
 const { existsSync, readdirSync } = require('node:fs')
 const { join, normalize } = require('node:path')
+const { isWindows, fixWindowsExecPath } = require('./utils.js')
 
 // Execute allow-scripts command inside each test project directory
 const baseDir = join(__dirname, '../test/projects/')
@@ -8,9 +9,12 @@ readdirSync(baseDir, { withFileTypes: true })
   .filter((p) => p.isDirectory() && existsSync(join(baseDir, p.name, 'package.json')))
   .forEach((dir) => {
     execSync(
-      [process.execPath, normalize('../../../src/cli.js'), 'auto', '--experimental-bins'].join(' '),
+      [
+        isWindows ? fixWindowsExecPath(process.execPath) : process.execPath,
+        normalize('../../../src/cli.js'), 'auto', '--experimental-bins'].join(' '),
       {
         cwd: join(baseDir, dir.name),
+        shell: true,
         stdio: 'inherit',
       }
     )

--- a/packages/allow-scripts/test/prepare.js
+++ b/packages/allow-scripts/test/prepare.js
@@ -1,7 +1,7 @@
 const { execSync } = require('node:child_process')
 const { existsSync, readdirSync } = require('node:fs')
 const { join, normalize } = require('node:path')
-const { isWindows, fixWindowsExecPath } = require('./utils.js')
+const { portableExecPath } = require('./utils.js')
 
 // Execute allow-scripts command inside each test project directory
 const baseDir = join(__dirname, '../test/projects/')
@@ -10,7 +10,7 @@ readdirSync(baseDir, { withFileTypes: true })
   .forEach((dir) => {
     execSync(
       [
-        isWindows ? fixWindowsExecPath(process.execPath) : process.execPath,
+        portableExecPath(process.execPath),
         normalize('../../../src/cli.js'), 'auto', '--experimental-bins'].join(' '),
       {
         cwd: join(baseDir, dir.name),

--- a/packages/allow-scripts/test/utils.js
+++ b/packages/allow-scripts/test/utils.js
@@ -1,0 +1,12 @@
+const { platform } = require('node:os')
+
+const isWindows = platform() === 'win32'
+
+// https://github.com/nodejs/node/issues/38490
+const fixWindowsExecPath = (inPath) =>
+  '"' + inPath.replace(/"/g, '\\"') + '"'
+
+module.exports = {
+  fixWindowsExecPath,
+  isWindows,
+};

--- a/packages/allow-scripts/test/utils.js
+++ b/packages/allow-scripts/test/utils.js
@@ -6,7 +6,19 @@ const isWindows = platform() === 'win32'
 const fixWindowsExecPath = (inPath) =>
   '"' + inPath.replace(/"/g, '\\"') + '"'
 
+const portableExecPath = (inPath, debugLogging) => {
+  if (!isWindows) {
+    return inPath;
+  }
+  const portablePath = fixWindowsExecPath(inPath);
+  if (debugLogging && inPath !== portablePath) {
+    console.log(`@lavamoat/allow-scripts: transforming absolute path from ${inPath} to ${portablePath}`);
+  }
+  return portablePath;
+}
+
 module.exports = {
   fixWindowsExecPath,
   isWindows,
+  portableExecPath,
 };


### PR DESCRIPTION
Fixes breaking test on Windows when nodejs installed under `C:\Program Files`