### PR TITLE
fix(aa): only require used sync submodule from resolve package

### DIFF
--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -2,7 +2,7 @@
 
 const { readFileSync, realpathSync, lstatSync } = require('node:fs')
 const path = require('node:path')
-const nodeResolve = require('resolve')
+const nodeResolve = require('resolve/sync')
 
 module.exports = {
   loadCanonicalNameMap,
@@ -63,7 +63,7 @@ function createPerformantResolve() {
 
   return {
     sync: (path, { basedir }) =>
-      nodeResolve.sync(path, {
+      nodeResolve(path, {
         basedir,
         readPackageSync: readPackageWithout(path),
       }),

--- a/packages/aa/src/types/resolve-sync.d.ts
+++ b/packages/aa/src/types/resolve-sync.d.ts
@@ -1,0 +1,4 @@
+declare module 'resolve/sync' {
+  import { sync } from '@types/resolve'
+  export = sync
+}


### PR DESCRIPTION
- Only importing `sync` by path allows bundled usage (like allow-scripts yarn plugin) to shake ~20KiB due to dropped branches and deps
- Fill in missing type from `@types.resolve`
