### PR TITLE
chore(allow-scripts): improve type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16720,6 +16720,7 @@
       "version": "4.26.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
       "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -17680,6 +17681,7 @@
         "@npmcli/run-script": "8.1.0",
         "bin-links": "4.0.4",
         "npm-normalize-package-bin": "3.0.1",
+        "type-fest": "4.26.1",
         "yargs": "17.7.2"
       },
       "bin": {

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -38,18 +38,19 @@
     "test:prep": "node test/prepare.js",
     "test:run": "ava"
   },
+  "peerDependencies": {
+    "@lavamoat/preinstall-always-fail": "*"
+  },
   "dependencies": {
     "@lavamoat/aa": "^4.3.0",
     "@npmcli/run-script": "8.1.0",
     "bin-links": "4.0.4",
     "npm-normalize-package-bin": "3.0.1",
+    "type-fest": "4.26.1",
     "yargs": "17.7.2"
   },
   "devDependencies": {
     "@types/npmcli__promise-spawn": "6.0.3"
-  },
-  "peerDependencies": {
-    "@lavamoat/preinstall-always-fail": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/allow-scripts/src/config.js
+++ b/packages/allow-scripts/src/config.js
@@ -16,15 +16,6 @@ const bannedBins = new Set(['corepack', 'node', 'npm', 'pnpm', 'yarn'])
 const DEFAULT_LIFECYCLE_EVENTS = ['preinstall', 'install', 'postinstall']
 
 /**
- * @typedef {Object} PkgConfs
- * @property {LavamoatPackageJson} packageJson
- * @property {Object} configs
- * @property {ScriptsConfig} configs.lifecycle
- * @property {BinsConfig} configs.bin
- * @property {boolean} somePoliciesAreMissing
- * @property {Map<string, string>} canonicalNamesByPath
- */
-/**
  * @param {Object} args
  * @param {string} args.rootDir
  * @param {string[]=} args.lifecycleEvents - which script names to consider
@@ -149,14 +140,7 @@ async function loadAllPackageConfigurations({ rootDir, lifecycleEvents = DEFAULT
 }
 
 /**
- * @typedef GetOptionsForBinOpts
- * @property {string} rootDir
- * @property {string} name
- * @property {string[]=} lifecycleEvents
- */
-
-/**
- * @param {GetOptionsForBinOpts} param0
+ * @param {GetOptionsForBinParams} params
  * @returns {Promise<BinInfo[] | undefined>}
  */
 async function getOptionsForBin({ rootDir, name, lifecycleEvents = DEFAULT_LIFECYCLE_EVENTS }) {
@@ -170,13 +154,7 @@ async function getOptionsForBin({ rootDir, name, lifecycleEvents = DEFAULT_LIFEC
 }
 
 /**
- * @typedef SetDefaultConfigurationOpts
- * @property {string} rootDir
- * @property {string[]=} lifecycleEvents
- */
-
-/**
- * @param {SetDefaultConfigurationOpts} param0
+ * @param {SetDefaultConfigurationParams} params
  */
 async function setDefaultConfiguration({ rootDir, lifecycleEvents = DEFAULT_LIFECYCLE_EVENTS }) {
   const conf = await loadAllPackageConfigurations({ rootDir, lifecycleEvents })
@@ -233,13 +211,7 @@ function prepareBinScriptsPolicy(binCandidates) {
 }
 
 /**
- * @typedef SavePackageConfigurationsOpts
- * @property {string} rootDir
- * @property {PkgConfs} conf
- */
-
-/**
- * @param {SavePackageConfigurationsOpts} param0
+ * @param {SavePackageConfigurationsParams} params
  * @returns {Promise<void>}
  */
 async function savePackageConfigurations({

--- a/packages/allow-scripts/src/config.js
+++ b/packages/allow-scripts/src/config.js
@@ -16,19 +16,6 @@ const bannedBins = new Set(['corepack', 'node', 'npm', 'pnpm', 'yarn'])
 const DEFAULT_LIFECYCLE_EVENTS = ['preinstall', 'install', 'postinstall']
 
 /**
- * @typedef PkgLavamoatConfig
- * @property {Record<string, any>} [allowScripts]
- * @property {Record<string, any>} [allowBins]
- * @property {Record<string, any>} [allowConfig]
- * @property {Record<string, any>} [allowedPatterns]
- * @property {Record<string, any>} [disallowedPatterns]
- * @property {Record<string, any>} [missingPolicies]
- * @property {Record<string, any>} [excessPolicies]
- */
-/**
- * @typedef {import('type-fest').PackageJson & { lavamoat: PkgLavamoatConfig }} LavamoatPackageJson
- */
-/**
  * @typedef {Object} PkgConfs
  * @property {LavamoatPackageJson} packageJson
  * @property {Object} configs

--- a/packages/allow-scripts/src/report.js
+++ b/packages/allow-scripts/src/report.js
@@ -6,18 +6,7 @@
 const { loadAllPackageConfigurations } = require('./config.js')
 
 /**
- * @typedef PrintPackagesListOpts
- * @property {string} rootDir
- */
-
-/**
- * @typedef PrintMissingPoliciesIfAnyOpts
- * @property {string[]} [missingPolicies]
- * @property {Map<string, unknown[]>} [packagesWithScripts]
- */
-
-/**
- * @param {PrintPackagesListOpts} param0
+ * @param {PrintPackagesListParams} params
  * @returns {Promise<void>}
  */
 async function printPackagesList({ rootDir }) {
@@ -30,7 +19,7 @@ async function printPackagesList({ rootDir }) {
 }
 
 /**
- * @param {PrintMissingPoliciesIfAnyOpts} param0
+ * @param {PrintMissingPoliciesIfAnyParams} params
  */
 function printMissingPoliciesIfAny({
   missingPolicies = [],

--- a/packages/allow-scripts/src/runAllowedPackages.js
+++ b/packages/allow-scripts/src/runAllowedPackages.js
@@ -11,12 +11,7 @@ const { printMissingPoliciesIfAny } = require('./report.js')
 const { FEATURE } = require('./toggles.js')
 
 /**
- * @typedef RunAllowedPackagesOpts
- * @property {string} rootDir
- */
-
-/**
- * @param {RunAllowedPackagesOpts} param0
+ * @param {RunAllowedPackagesParams} params
  * @returns {Promise<void>}
  */
 async function runAllowedPackages({ rootDir }) {
@@ -131,13 +126,7 @@ async function installBinFirewall(firewalledBins, link) {
 }
 
 /**
- * @typedef RunScriptOpts
- * @property {string} event
- * @property {string} path
- */
-
-/**
- * @param {RunScriptOpts} param0
+ * @param {RunScriptParams} params
  * @returns {Promise<void>}
  */
 async function runScript({ path, event }) {

--- a/packages/allow-scripts/src/setup.js
+++ b/packages/allow-scripts/src/setup.js
@@ -41,12 +41,7 @@ module.exports = {
 }
 
 /**
- * @typedef AreBinsBlockedOpts
- * @property {boolean} [noMemoization] Turn off memoization, make a fresh lookup
- */
-
-/**
- * @param {AreBinsBlockedOpts} args
+ * @param {AreBinsBlockedParams} args
  * @returns {boolean}
  */
 function areBinsBlocked({ noMemoization = false } = {}) {
@@ -178,13 +173,7 @@ function isEntryPresent(entry, file) {
 }
 
 /**
- * @typedef WriteRcFileContentOpts
- * @property {string} file
- * @property {string} entry
- */
-
-/**
- * @param {WriteRcFileContentOpts} param0
+ * @param {WriteRcFileContentParams} params
  */
 function writeRcFileContent({ file, entry }) {
   const rcPath = addInstallParentDir(file)

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -58,29 +58,29 @@ declare global {
   }
 
   // config.js
-  interface SetDefaultConfigurationParams {
+  export interface SetDefaultConfigurationParams {
     rootDir: string;
     lifecycleEvents?: string[];
   }
 
-  interface SavePackageConfigurationsParams {
+  export interface SavePackageConfigurationsParams {
     rootDir: string;
     conf: PkgConfs;
   }
 
-  interface GetOptionsForBinParams {
+  export interface GetOptionsForBinParams {
     rootDir: string;
     name: string;
     lifecycleEvents?: string[];
   }
 
   // setup.js
-  interface AreBinsBlockedParams {
+  export interface AreBinsBlockedParams {
     /** Turn off memoization, make a fresh lookup */
     noMemoization?: boolean;
   }
 
-  interface PkgConfs {
+  export interface PkgConfs {
     packageJson: LavamoatPackageJson;
     configs: {
       lifecycle: ScriptsConfig;
@@ -90,27 +90,27 @@ declare global {
     canonicalNamesByPath: Map<string,string>;
   }
 
-  interface WriteRcFileContentParams {
+  export interface WriteRcFileContentParams {
     file: string;
     entry: string;
   }
 
   // runAllowedPackages.js
-  interface RunAllowedPackagesParams {
+  export interface RunAllowedPackagesParams {
     rootDir: string;
   }
 
-  interface RunScriptParams {
+  export interface RunScriptParams {
     event: string;
     path: string;
   }
 
   // report.js
-  interface PrintPackagesListParams {
+  export interface PrintPackagesListParams {
     rootDir: string;
   }
 
-  interface PrintMissingPoliciesIfAnyParams {
+  export interface PrintMissingPoliciesIfAnyParams {
     missingPolicies: string[];
     packagesWithScripts: Map<string, unknown[]>;
   }

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -23,7 +23,7 @@ declare global {
    * Configuration for a type of scripts policies
    */
   export interface ScriptsConfig {
-    allowConfig: Record<string, any>;
+    allowConfig: JsonObject;
     packagesWithScripts: Map<string, [PkgInfo]>;
     allowedPatterns: string[];
     disallowedPatterns: string[];
@@ -95,4 +95,23 @@ declare global {
     entry: string;
   }
 
+  // runAllowedPackages.js
+  interface RunAllowedPackagesParams {
+    rootDir: string;
+  }
+
+  interface RunScriptParams {
+    event: string;
+    path: string;
+  }
+
+  // report.js
+  interface PrintPackagesListParams {
+    rootDir: string;
+  }
+
+  interface PrintMissingPoliciesIfAnyParams {
+    missingPolicies: string[];
+    packagesWithScripts: Map<string, unknown[]>;
+  }
 }

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -1,8 +1,22 @@
+import type { JsonObject, PackageJson } from 'type-fest';
+
 declare global {
+  export interface PkgLavamoatConfig {
+    ['allowBins']?: JsonObject;
+    ['allowConfig']?: JsonObject;
+    ['allowScripts']?: JsonObject;
+    ['allowedPatterns']?: JsonObject;
+    ['disallowedPatterns']?: JsonObject;
+    ['excessPolicies']?: JsonObject;
+    ['missingPolicies']?: JsonObject;
+  }
+
+  export type LavamoatPackageJson = PackageJson & { lavamoat: PkgLavamoatConfig };
+
   export interface PkgInfo {
     canonicalName: string;
     path: string;
-    scripts: Object;
+    scripts: JsonObject;
   }
 
   /**

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -56,4 +56,43 @@ declare global {
      excessPolicies: string[];
      somePoliciesAreMissing: boolean;
   }
+
+  // config.js
+  interface SetDefaultConfigurationParams {
+    rootDir: string;
+    lifecycleEvents?: string[];
+  }
+
+  interface SavePackageConfigurationsParams {
+    rootDir: string;
+    conf: PkgConfs;
+  }
+
+  interface GetOptionsForBinParams {
+    rootDir: string;
+    name: string;
+    lifecycleEvents?: string[];
+  }
+
+  // setup.js
+  interface AreBinsBlockedParams {
+    /** Turn off memoization, make a fresh lookup */
+    noMemoization?: boolean;
+  }
+
+  interface PkgConfs {
+    packageJson: LavamoatPackageJson;
+    configs: {
+      lifecycle: ScriptsConfig;
+      bin: BinsConfig;
+    }
+    somePoliciesAreMissing: boolean;
+    canonicalNamesByPath: Map<string,string>;
+  }
+
+  interface WriteRcFileContentParams {
+    file: string;
+    entry: string;
+  }
+
 }

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -2,13 +2,13 @@ import type { JsonObject, PackageJson } from 'type-fest';
 
 declare global {
   export interface PkgLavamoatConfig {
-    ['allowBins']?: JsonObject;
-    ['allowConfig']?: JsonObject;
-    ['allowScripts']?: JsonObject;
-    ['allowedPatterns']?: JsonObject;
-    ['disallowedPatterns']?: JsonObject;
-    ['excessPolicies']?: JsonObject;
-    ['missingPolicies']?: JsonObject;
+    allowBins?: JsonObject;
+    allowConfig?: JsonObject;
+    allowScripts?: JsonObject;
+    allowedPatterns?: JsonObject;
+    disallowedPatterns?: JsonObject;
+    excessPolicies?: JsonObject;
+    missingPolicies?: JsonObject;
   }
 
   export type LavamoatPackageJson = PackageJson & { lavamoat: PkgLavamoatConfig };


### PR DESCRIPTION
- chore(allow-scripts): unify `PkgInfo` and `PkgLavamoatConfig` types
  - Use `type-fest`.`JsonObject` to type objects serialized to/from json 
- chore(allow-scripts): break out @typedefs to package-global types
- chore(allow-scripts): Rename in interface names `s/Opts/Params/` as none of these are actually optional
  - For aesthetics, `s/param0/params/`  

I personally find the improved readability and familiar syntax of TypeScript definitions vs JsDoc to be worth losing colocating definitions and usage. Trivial non-named one-off definitions are still kept in-line, though.

### Related
- Follow-up to #1377
