### PR TITLE
fix(allow-scripts): consider wider range of lifecycle scripts

### DIFF
--- a/packages/allow-scripts/src/config.js
+++ b/packages/allow-scripts/src/config.js
@@ -13,7 +13,14 @@ const bannedBins = new Set(['corepack', 'node', 'npm', 'pnpm', 'yarn'])
 /**
  * Scripts with names other than these are ignored and unenforced by default.
  */
-const DEFAULT_LIFECYCLE_EVENTS = ['preinstall', 'install', 'postinstall']
+const DEFAULT_LIFECYCLE_EVENTS = [
+  'install',
+  'postinstall', 'postinstallonly', 'preinstall', 'preinstallonly',
+  'preaudit', 'preauditonly', 'postaudit', 'postauditonly',
+  'prepack', 'prepackonly', 'postpack', 'postpackonly',
+  'preprepare', 'preprepareonly', 'postprepare', 'postprepareonly',
+  'prepublish', 'prepublishonly', 'postpublish', 'postpublishonly',
+];
 
 /**
  * @typedef PkgLavamoatConfig

--- a/packages/allow-scripts/src/config.js
+++ b/packages/allow-scripts/src/config.js
@@ -88,8 +88,9 @@ async function loadAllPackageConfigurations({ rootDir, lifecycleEvents = DEFAULT
       throw err
     }
     const depScripts = depPackageJson.scripts || {}
+    const packageScriptNames = new Set(Object.keys(depScripts).map(scriptName => scriptName.toLowerCase()))
     const lifecycleScripts = lifecycleEvents.filter(
-      (name) => Object.prototype.hasOwnProperty.call(depScripts, name)
+      (name) => packageScriptNames.has(name.toLowerCase())
     )
 
     if (

--- a/packages/allow-scripts/test/projects/1/node_modules/bbb/node_modules/evil_dep/package.json
+++ b/packages/allow-scripts/test/projects/1/node_modules/bbb/node_modules/evil_dep/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"preinstall": "echo evil!"
+		"preinstallOnly": "echo evil!"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
There may be other lifecycle scripts relevant than the currently recognized (`preinstall`, `install`, `postinstall`).

New ones have historically been added somewhat inconsistently and arbitrarily to package managers, so this updates allow-scripts to recognize with a wider range of lifecycle events out of the box.

I think this may be considered a breaking change?

### Related
- #1218 

#### Blocked by
- [x] #1383 