### PR TITLE
export endowmentsToolkit from lavamoat-core

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -10,6 +10,7 @@ const {
 const { mergePolicy } = require('./mergePolicy')
 const { applySourceTransforms } = require('./sourceTransforms')
 const { makeInitStatsHook } = require('./makeInitStatsHook')
+const endowmentsToolkit = require('./endowmentsToolkit')
 
 module.exports = {
   // generating the kernel
@@ -27,4 +28,5 @@ module.exports = {
   LavamoatModuleRecord,
   // utils
   makeInitStatsHook,
+  endowmentsToolkit
 }

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -3,8 +3,7 @@
   "extends": "../../../.config/tsconfig.src.json",
   "compilerOptions": {
     "checkJs": false,
-    "rootDir": "..",
-    "outDir": "../types"
+    "outDir": "../types/test"
   },
   "include": ["**/*.js", "**/*.ts"],
   "references": [


### PR DESCRIPTION
This exports `endowmentsToolkit` from `lavamoat-core`.  It's painful to need to reach into `lavamoat-core/src/endowmentsToolkikt` to get at it; likewise it can break type resolution.

It's likely `@lavamoat/webpack` will want to use this.  cc @naugtur

- Bonus: simplification tweak of `core/test/tsconfig.json`