### PR TITLE
chore(vscode): format on save & disable insertion of final newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "source.formatDocument": "explicit"
   },
   "prettier.useEditorConfig": true,
-  "files.insertFinalNewline": false
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
Insertion of final newline causes certain generated files to churn if they are opened by VS Code.
