### PR TITLE
chore(ci): add env flag to Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,11 +34,6 @@ jobs:
           image: 'dev:latest'
           run: |
             npm run setup && npm run rebuild
-      - name: lint
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
-        with:
-          image: 'dev:latest'
-          run: 'npm run lint'
       - name: test
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
       - name: test
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
         with:
+          options: '-e DOCKER_CI=1'
           image: 'dev:latest'
           run: |
             npm run test:prep && npm run test


### PR DESCRIPTION
This adds the `DOCKER_CI` flag to the environment of the Docker workflow, so that tests can change their behavior based on it.  We need this because we have a couple failing tests using native modules in #772.

This also removes the "lint" job from the Docker workflow, since it provides little value.