### PR TITLE
chore(renovate): enable @types/node versioning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
     ':enableVulnerabilityAlerts', // enables GitHub vulnerability alerts
     ':semanticCommits', // use semantic commits
     'group:linters', // group lint-related packages together
+    'workarounds:typesNodeVersioning', // tracks node versions from engines field in package.json for @types/node
   ],
   packageRules: [
     {


### PR DESCRIPTION
This updates the Renovate config to include [workarounds:typesNodeVersioning](https://docs.renovatebot.com/presets-workarounds/\#workaroundstypesnodeversioning) which should keep `@types/node` in sync with our supported Node.js versions.

Unfortunately I do not know if it syncs with the minimum or maximum version.
