### PR TITLE
fix(browserify): use @lavamoat/sourcemap-validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2461,6 +2461,39 @@
       "resolved": "packages/preinstall-always-fail",
       "link": true
     },
+    "node_modules/@lavamoat/sourcemap-validator": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@lavamoat/sourcemap-validator/-/sourcemap-validator-2.1.1.tgz",
+      "integrity": "sha512-ikPoTmQu+UkoaObVkBJ8tWB4IiA762kXuWG3h+N+7nHrp+t1Mbz+1JyMfn3C5+Crctz4Qd9G2vtFzHmRpFYXTA==",
+      "license": "MIT",
+      "dependencies": {
+        "jsesc": "~0.3.x",
+        "lodash": "^4.17.21",
+        "source-map": "~0.1.x"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@lavamoat/sourcemap-validator/node_modules/jsesc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
+      "integrity": "sha512-UHQmAeTXV+iwEk0aHheJRqo6Or90eDxI6KIYpHSjKLXKuKlPt1CQ7tGBerFcFA8uKU5mYxiPMlckmFptd5XZzA==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/@lavamoat/sourcemap-validator/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@lavamoat/webpack": {
       "resolved": "packages/webpack",
       "link": true
@@ -4526,7 +4559,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.2"
       }
@@ -11513,12 +11545,6 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -11529,12 +11555,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
-    },
-    "node_modules/lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
       "dev": true
     },
     "node_modules/lodash.isplainobject": {
@@ -11577,25 +11597,6 @@
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -15679,42 +15680,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-validator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-2.1.0.tgz",
-      "integrity": "sha512-87aDeWwPT6Flaz6fJQdXmTmW2uZ1kebAthB3i2NmCZzAFkJtNpUm6vqIs5SGO44L92W8WpewkdBwVgNPvZeT+Q==",
-      "dev": true,
-      "dependencies": {
-        "jsesc": "~0.3.x",
-        "lodash.foreach": "^4.5.0",
-        "lodash.template": "^4.5.0",
-        "source-map": "~0.1.x"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/sourcemap-validator/node_modules/jsesc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
-      "integrity": "sha512-UHQmAeTXV+iwEk0aHheJRqo6Or90eDxI6KIYpHSjKLXKuKlPt1CQ7tGBerFcFA8uKU5mYxiPMlckmFptd5XZzA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/sourcemap-validator/node_modules/source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -17702,6 +17667,7 @@
       "dependencies": {
         "@lavamoat/aa": "^4.3.0",
         "@lavamoat/lavapack": "^7.0.2",
+        "@lavamoat/sourcemap-validator": "2.1.1",
         "browser-resolve": "2.0.0",
         "concat-stream": "2.0.0",
         "convert-source-map": "2.0.0",
@@ -17718,7 +17684,6 @@
         "browserify": "17.0.1",
         "keccak": "3.0.4",
         "source-map-explorer": "2.5.3",
-        "sourcemap-validator": "2.1.0",
         "tmp-promise": "3.0.3",
         "watchify": "4.0.0"
       },

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@lavamoat/aa": "^4.3.0",
     "@lavamoat/lavapack": "^7.0.2",
+    "@lavamoat/sourcemap-validator": "2.1.1",
     "browser-resolve": "2.0.0",
     "concat-stream": "2.0.0",
     "convert-source-map": "2.0.0",
@@ -47,7 +48,6 @@
     "browserify": "17.0.1",
     "keccak": "3.0.4",
     "source-map-explorer": "2.5.3",
-    "sourcemap-validator": "2.1.0",
     "tmp-promise": "3.0.3",
     "watchify": "4.0.0"
   },

--- a/packages/browserify/test/sourcemaps.js
+++ b/packages/browserify/test/sourcemaps.js
@@ -1,5 +1,5 @@
 const { SourceMapConsumer } = require('source-map')
-const validate = require('sourcemap-validator')
+const validate = require('@lavamoat/sourcemap-validator')
 const { fromSource: extractSourceMap } = require('convert-source-map')
 const { explore } = require('source-map-explorer')
 const { codeFrameColumns } = require('@babel/code-frame')


### PR DESCRIPTION
I started investigating an `npm audit` issue and wound up creating a patch for `lodash.template`, but realized that Lego had created a fork of `sourcemap-validator` which removes the `lodash.template` dep. He never got around to actually using it--I am sure that this is what he created it for.
