### PR TITLE
fix: 2 bugs manifested in walking content from policy-overrides: atte…

### DIFF
--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -74,6 +74,9 @@ function createModuleInspector(opts) {
     moduleRecord,
     { isBuiltin, includeDebugInfo = false }
   ) {
+    if (moduleRecord === undefined) {
+      return
+    }
     const { packageName, specifier, type } = moduleRecord
     // record the module
     moduleIdToModuleRecord.set(specifier, moduleRecord)

--- a/packages/core/src/walk.js
+++ b/packages/core/src/walk.js
@@ -56,6 +56,9 @@ async function* eachNodeInTree({
 }) {
   // walk next record
   const moduleRecord = await importHook(moduleSpecifier)
+  if (moduleRecord === undefined) {
+    return
+  }
   yield moduleRecord
 
   // walk children specified in importMap and policyOverride

--- a/packages/lavamoat-node/src/parseForPolicy.js
+++ b/packages/lavamoat-node/src/parseForPolicy.js
@@ -186,14 +186,22 @@ function makeImportHook({
     const extension = path.extname(filename)
     const packageName = getPackageNameForModulePath(canonicalNameMap, filename)
 
-    if (commonjsExtensions.includes(extension)) {
-      return makeJsModuleRecord(specifier, filename, packageName)
-    }
     if (extension === '.node') {
       return makeNativeModuleRecord(specifier, filename, packageName)
     }
+    try {
+      var content = await fs.readFile(filename, 'utf8')
+    } catch (err) {
+      console.warn(
+        `lavamoat-node/makeImportHook - could not read file "${filename}"`
+      )
+      return undefined
+    }
+    if (commonjsExtensions.includes(extension)) {
+      return makeJsModuleRecord(specifier, content, filename, packageName)
+    }
     if (extension === '.json') {
-      return makeJsonModuleRecord(specifier, filename, packageName)
+      return makeJsonModuleRecord(specifier, content, filename, packageName)
     }
     throw new Error(
       `lavamoat-node/makeImportHook - unknown module file extension "${extension}" in filename "${filename}"`
@@ -226,9 +234,7 @@ function makeImportHook({
     })
   }
 
-  async function makeJsModuleRecord(specifier, filename, packageName) {
-    // load src
-    const content = await fs.readFile(filename, 'utf8')
+  async function makeJsModuleRecord(specifier, content, filename, packageName) {
     // parse
     const ast = parseModule(content, specifier)
     // get imports
@@ -264,8 +270,18 @@ function makeImportHook({
         if (packageName in importMap) {
           return
         }
+        // do not pursue root as a dependency to scan
+        if (packageName === '$root$') {
+          return
+        }
         // resolve and add package main in override
         const packageRoot = getMapKeyForValue(canonicalNameMap, packageName)
+        if (!packageRoot) {
+          console.warn(
+            `could not find package root for ${packageName} as found in policy-override`
+          )
+          return
+        }
         const packageJson = JSON.parse(
           await fs.readFile(path.join(packageRoot, 'package.json'), 'utf8')
         )
@@ -318,9 +334,12 @@ function makeImportHook({
     })
   }
 
-  async function makeJsonModuleRecord(specifier, filename, packageName) {
-    // load src
-    const rawContent = await fs.readFile(filename, 'utf8')
+  async function makeJsonModuleRecord(
+    specifier,
+    rawContent,
+    filename,
+    packageName
+  ) {
     // validate json
     JSON.parse(rawContent)
     // wrap as commonjs module

--- a/packages/lavamoat-node/src/parseForPolicy.js
+++ b/packages/lavamoat-node/src/parseForPolicy.js
@@ -278,7 +278,7 @@ function makeImportHook({
         const packageRoot = getMapKeyForValue(canonicalNameMap, packageName)
         if (!packageRoot) {
           console.warn(
-            `could not find package root for ${packageName} as found in policy-override`
+            `lavamoat could not find package's entry script for ${packageName} as found in policy-override`
           )
           return
         }


### PR DESCRIPTION
…mpt to go down `$root$` and failure to load content from the main of the package