### PR TITLE
chore: attempt to fix initial release of @lavamoat/node

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "2108f25d223576f8a01067ae2113ceccbc5e58ee",
+  "bootstrap-sha": "b7b011567d068a2bcddee4bb8497f04d74c6ae65",
   "packages": {
     "packages/aa": {},
     "packages/allow-scripts": {},


### PR DESCRIPTION
RP is confused by a new package taking the same path as an old package (`packages/node`). This change sets the `bootstrapSha` to the version immediately after the SHA of the commit which moved the directory, so that RP has no knowledge of another package at this path. Maybe it will even work!

Ref: #1477