### PR TITLE
fix(node): allow flags to be passed to entrypoint

### DIFF
--- a/packages/node/src/cli.js
+++ b/packages/node/src/cli.js
@@ -11,17 +11,6 @@
  * Regarding middleware: Any option which _does not_ either a) need other
  * options for postprocessing, or b) need to be asynchronous--should use
  * {@link yargs.coerce} instead.
- *
- * Finally, we deviate from yargs' default behavior by disabling
- * {@link https://github.com/yargs/yargs-parser#camel-case-expansion camel case expansion}.
- * This means an option such as `policy-override` will _not_ magically become
- * `policyOverride` in the parsed arguments object. The reason is that we need
- * to perform some post-processing of paths _in middleware_, and it's easy to
- * screw up if we have to do it twice for each option. _Furthermore_, because
- * `@types/yargs` expects camel-case expansion to be enabled, the types are
- * incorrect for the parameter to middleware and handler (`argv`); it will
- * include camel-cased properties where none exist. My advice: just pretend they
- * aren't there.
  * @packageDocumentation
  */
 
@@ -61,6 +50,52 @@ const PATH_GROUP = 'Path Options:'
  * Use this to give emphasis to words in error messages
  */
 const em = chalk.yellow
+
+/**
+ * Strip out all `lavamoat` CLI args from `process.argv` so that the entrypoint
+ * receives a `process.argv` like it would if it were executed directly with
+ * `node`.
+ *
+ * Used for execution only.
+ *
+ * For this to work, we _must_ mutate `process.argv` _in place_.
+ *
+ * @param {string} entrypoint Entry module
+ * @param {(string | number)[]} nonOptionArguments Array of stuff passed after
+ *   `--` on the command-line. Note that Yargs parses numbers, and we have to
+ *   convert them back to strings.
+ * @returns {void}
+ */
+const stripProcessArgv = (entrypoint, nonOptionArguments = []) => {
+  /**
+   * This module could be executed in myriad ways (`lavamoat`, `node
+   * /path/to/lavamoat`, `npx lavamoat2`, etc.), so we are just going to
+   * recreate the args from scratch
+   */
+  const start = 0
+
+  /**
+   * If the user provided `--` we want everything after that, but if they
+   * didn't, the entire rest of the array is lavamoat args, so it can be
+   * removed.
+   */
+  const deleteCount = process.argv.includes('--')
+    ? process.argv.indexOf('--')
+    : process.argv.length
+
+  /**
+   * Path to `node`, any args to `node`, the path to the entrypoint, then
+   * whatever was in {@link nonOptionArguments}. Hope this works!
+   */
+  const items = [
+    process.execPath,
+    ...process.execArgv,
+    entrypoint,
+    ...nonOptionArguments.map(String),
+  ]
+
+  process.argv.splice(start, deleteCount, ...items)
+}
 
 /**
  * Main entry point to CLI
@@ -123,7 +158,26 @@ const main = async (args = hideBin(process.argv)) => {
    */
   yargs(args)
     .parserConfiguration({
+      /**
+       * We deviate from yargs' default behavior by disabling
+       * {@link https://github.com/yargs/yargs-parser#camel-case-expansion camel case expansion}.
+       * This means an option such as `policy-override` will _not_ magically
+       * become `policyOverride` in the parsed arguments object. The reason is
+       * that we need to perform some post-processing of paths _in middleware_,
+       * and it's easy to screw up if we have to do it twice for each option.
+       * _Furthermore_, because `@types/yargs` expects camel-case expansion to
+       * be enabled, the types are incorrect for the parameter to middleware and
+       * handler (`argv`); it will include camel-cased properties where none
+       * exist. My advice: just pretend they aren't there.
+       */
       'camel-case-expansion': false,
+
+      /**
+       * This stuffs everything after the first `--` into its own array (in the
+       * `--` prop of yargs' parsed arguments object). We will use this to
+       * provide a "clean" `process.argv` for entrypoints.
+       */
+      'populate--': true,
     })
     .scriptName('lavamoat')
     .version(`${version}`)
@@ -359,7 +413,16 @@ const main = async (args = hideBin(process.argv)) => {
           }
         }
 
-        await run(argv.entrypoint, policy)
+        stripProcessArgv(
+          entrypoint,
+          /**
+           * `@types/yargs` doesn't know about this
+           *
+           * @type {(string | number)[]}
+           */ (argv['--'])
+        )
+
+        await run(entrypoint, policy)
       }
     )
     .command(

--- a/packages/node/test/e2e/fixture/basic/app.js
+++ b/packages/node/test/e2e/fixture/basic/app.js
@@ -1,3 +1,22 @@
-export const hello = 'world'
+import { parseArgs } from 'node:util'
 
-console.log(`hello ${hello}`)
+const args = parseArgs({
+  allowPositionals: true,
+  strict: false,
+  options: {
+    yelling: {
+      type: 'boolean',
+    },
+  },
+})
+
+export const world = 'world'
+
+let message = `${args.positionals[0] || 'hello'} ${world}`
+
+// if --yelling is passed, make the message uppercase
+if (args.values.yelling) {
+  message = message.toUpperCase()
+}
+
+console.log(message)

--- a/packages/node/test/types.ts
+++ b/packages/node/test/types.ts
@@ -2,7 +2,7 @@ import type { ExecutionContext } from 'ava'
 import type { LavaMoatPolicy } from 'lavamoat-core'
 import type { NestedDirectoryJSON } from 'memfs'
 import { ExecFileException } from 'node:child_process'
-import type { RequireAtLeastOne } from 'type-fest'
+import type { Merge, RequireAtLeastOne, Simplify } from 'type-fest'
 
 export interface RunnerWorkerData {
   entryPath: string
@@ -37,9 +37,11 @@ export type ExecLavamoatNodeExpectation<Ctx = unknown> =
 /**
  * Properties to match against the resolved value of the `runCli` function.
  */
-export type ExecLavamoatNodeExpectationProps = RequireAtLeastOne<
-  RunCliOutput,
-  keyof RunCliOutput
+export type ExecLavamoatNodeExpectationProps = Simplify<
+  RequireAtLeastOne<
+    Merge<RunCliOutput, { stdout: string | RegExp; stderr: string | RegExp }>,
+    keyof RunCliOutput
+  >
 >
 
 /**


### PR DESCRIPTION
This ensures that options and positional arguments may be passed into the entrypoint module from the command line. Such args must be provided after `--`.

`@lavamoat/node` attempts to erase itself from `process.argv` before execution, which may be right or may be wrong.

Closes #1504