### PR TITLE
chore(ci): update labeler action config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,6 +63,16 @@
       - any-glob-to-any-file:
           - 'packages/laverna/**'
 
+'pkg:@lavamoat/node':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/node/**'
+
+'pkg:lavamoat-node':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/lavamoat-node/**'
+
 'dependencies':
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
This adds `pkg:@lavamoat/node` and `pkg:lavamoat-node` to the auto-labeler config.