### PR TITLE
feat(webpack): introduce enhancements to support webpack integration

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -105,8 +105,7 @@ This plugin will skip policy enforcement for such ignored modules.
 
 #### HMR
 
-LavaMoat is not compatible with Hot Module Replacement and any form of it would not make much sense with the security guarantees, so you're better off using lavamoat in your production build.
-It's not easy to spot when a tool or setting is enabling HMR though, so LavaMoat plugin will stub out some of the HMR functionality to do nothing.
+LavaMoat is not compatible with Hot Module Replacement (HMR) and any form of it would not make much sense with the security guarantees, so you're better off disabling LavaMoat for development builds where HMR is required.
 
 # Security
 

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -52,7 +52,7 @@ One important thing to note when using the LavaMoat plugin is that it disables t
 > [!WARNING]
 > This is an experimental feature and excluding may be configured differently in the future if this approach is proven insecure.
 
-The default way to define specific behaviors for webpack is creating module rules. To ensure exclude rules are applied on the same exact files that match certain rules (the same RegExp may be matched against different things at different times) we're providing the exclude functionality as a loader you can add to the list of existing loaders or use individually.  
+The default way to define specific behaviors for webpack is creating module rules. To ensure exclude rules are applied on the same exact files that match certain rules (the same RegExp may be matched against different things at different times) we're providing the exclude functionality as a loader you can add to the list of existing loaders or use individually.
 The loader is available as `LavaMoatPlugin.exclude` from the default export of the plugin. It doesn't do anything to the code, but its presence is detected and treated as a mark on the file. Any file that's been processed by `LavaMoatPlugin.exclude` will not be wrapped in a Compartment.
 
 > [!NOTE]
@@ -113,9 +113,7 @@ LavaMoat is not compatible with Hot Module Replacement (HMR). Disable LavaMoat f
 
 - [SES lockdown][] must be added to the page without any bundling or transforming for any security guarantees to be sustained.
   - The plugin is attempting to add it as an asset to the compilation for the sake of Developer Experience. `.js` extension is omitted to prevent minification.
-  - Optionally lockdown can be inlined into the bundle files. You need to declare which of the output files to inline lockdown runtime code to. These need to be the first file of the bundle that get loaded on the page.  
-    When you have a single bundle, you just configure a regex with one unique file name or a `.*`. It gets more complex with builds for multiple pages. The plugin doesn't attempt to guess where to inline lockdown.  
-    e.g. If you have 2 entries `user.js` and `admin.js` and a set up to suffix resulting bundles with commit id, you can use `/user\.[a-f0-9]+\.js|admin\.[a-f0-9]+\.js/` to match the files.
+  - Optionally lockdown can be inlined into the bundle files. You need to match the scripts that get to load as the first script on the page to apply lockdown only once when inlined. When you have a single bundle, you just configure a regex with one unique file name or a `.*`. It gets more complex with builds for multiple pages. The plugin doesn't attempt to guess where to inline lockdown.
 - Each javascript module resulting from the webpack build is scoped to its package's policy
 
 ## Threat Model

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -105,7 +105,8 @@ This plugin will skip policy enforcement for such ignored modules.
 
 #### HMR
 
-LavaMoat is not compatible with Hot Module Replacement (HMR). Disable LavaMoat for development builds where HMR is required while keeping it enabled for production builds.
+LavaMoat is not compatible with Hot Module Replacement and any form of it would not make much sense with the security guarantees, so you're better off using lavamoat in your production build.
+It's not easy to spot when a tool or setting is enabling HMR though, so LavaMoat plugin will stub out some of the HMR functionality to do nothing.
 
 # Security
 

--- a/packages/webpack/src/buildtime/emitSes.js
+++ b/packages/webpack/src/buildtime/emitSes.js
@@ -3,8 +3,11 @@ const {
   sources: { RawSource, ConcatSource },
 } = require('webpack')
 
-const lockdownSource = readFileSync(require.resolve('ses'), 'utf-8')
-const lockdownSourcePrefix = `/*! SES sources included by LavaMoat. Do not optimize or minify. */\n;\n${lockdownSource}\n;/*! end SES */\n`
+const lockdownSource = readFileSync(
+  path.join(require.resolve('ses'), '../lockdown.umd.js'),
+  'utf-8'
+)
+const lockdownSourcePrefix = `/* SES sources included by LavaMoat. Do not optimize or minify. */\n;\n${lockdownSource}\n;/* end SES */\n`
 
 module.exports = {
   /**

--- a/packages/webpack/src/buildtime/emitSes.js
+++ b/packages/webpack/src/buildtime/emitSes.js
@@ -3,11 +3,8 @@ const {
   sources: { RawSource, ConcatSource },
 } = require('webpack')
 
-const lockdownSource = readFileSync(
-  path.join(require.resolve('ses'), '../lockdown.umd.js'),
-  'utf-8'
-)
-const lockdownSourcePrefix = `/* SES sources included by LavaMoat. Do not optimize or minify. */\n;\n${lockdownSource}\n;/* end SES */\n`
+const lockdownSource = readFileSync(require.resolve('ses'), 'utf-8')
+const lockdownSourcePrefix = `/*! SES sources included by LavaMoat. Do not optimize or minify. */\n;\n${lockdownSource}\n;/*! end SES */\n`
 
 module.exports = {
   /**

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -525,59 +525,81 @@ class LavaMoatPlugin {
                   )
                   return
                 }
-                diag.rawDebug(
-                  1,
-                  '> adding runtime (additionalChunkRuntimeRequirements)'
-                )
-                // narrow down the policy and map to module identifiers
-                const policyData = identifierLookup.getTranslatedPolicy()
+                let runtimeChunks = []
+                if (
+                  chunk.name &&
+                  options.unlockedChunksUnsafe?.test(chunk.name)
+                ) {
+                  diag.rawDebug(
+                    1,
+                    `> adding UNLOCKED runtime for chunk ${chunk.name}`
+                  )
+                  runtimeChunks = [
+                    {
+                      name: 'ENUM',
+                      file: path.join(__dirname, './ENUM.json'),
+                      json: true,
+                    },
+                    {
+                      name: 'runtime',
+                      file: path.join(
+                        __dirname,
+                        './runtime/runtimeUnlocked.js'
+                      ),
+                    },
+                  ]
+                } else {
+                  diag.rawDebug(1, `> adding runtime for chunk ${chunk.name}`)
+                  // narrow down the policy and map to module identifiers
+                  const policyData = identifierLookup.getTranslatedPolicy()
 
-                const runtimeChunks = [
-                  {
-                    name: 'root',
-                    data: identifierLookup.root || null,
-                    json: true,
-                  },
-                  {
-                    name: 'idmap',
-                    data: identifierLookup.identifiersForModuleIds || null,
-                    json: true,
-                  },
-                  {
-                    name: 'unenforceable',
-                    data: identifierLookup.unenforceableModuleIds || null,
-                    json: true,
-                  },
-                  {
-                    name: 'externals',
-                    data: identifierLookup.externals || null,
-                    json: true,
-                  },
-                  { name: 'options', data: runtimeOptions, json: true },
-                  (typeof runtimeOptions?.scuttleGlobalThis === 'boolean' &&
-                    runtimeOptions.scuttleGlobalThis === true) ||
-                  (typeof runtimeOptions?.scuttleGlobalThis === 'object' &&
-                    runtimeOptions.scuttleGlobalThis.enabled === true)
-                    ? {
+                  runtimeChunks = [
+                    {
+                      name: 'root',
+                      data: identifierLookup.root || null,
+                      json: true,
+                    },
+                    {
+                      name: 'idmap',
+                      data: identifierLookup.identifiersForModuleIds || null,
+                      json: true,
+                    },
+                    {
+                      name: 'unenforceable',
+                      data: identifierLookup.unenforceableModuleIds || null,
+                      json: true,
+                    },
+                    {
+                      name: 'externals',
+                      data: identifierLookup.externals || null,
+                      json: true,
+                    },
+                    { name: 'options', data: runtimeOptions, json: true },
+                    (typeof runtimeOptions?.scuttleGlobalThis === 'boolean' &&
+                      runtimeOptions.scuttleGlobalThis === true) ||
+                    (typeof runtimeOptions?.scuttleGlobalThis === 'object' &&
+                      runtimeOptions.scuttleGlobalThis.enabled === true)
+                      ? {
                         name: 'scuttling',
                         shimRequire: 'lavamoat-core/src/scuttle.js',
                       }
-                    : {},
-                  { name: 'policy', data: policyData, json: true },
-                  {
-                    name: 'ENUM',
-                    file: path.join(__dirname, './ENUM.json'),
-                    json: true,
-                  },
-                  {
-                    name: 'endowmentsToolkit',
-                    shimRequire: 'lavamoat-core/src/endowmentsToolkit.js',
-                  },
-                  {
-                    name: 'runtime',
-                    file: path.join(__dirname, './runtime/runtime.js'),
-                  },
-                ]
+                      : {},
+                    {name: 'policy', data: policyData, json: true},
+                    {
+                      name: 'ENUM',
+                      file: path.join(__dirname, './ENUM.json'),
+                      json: true,
+                    },
+                    {
+                      name: 'endowmentsToolkit',
+                      shimRequire: 'lavamoat-core/src/endowmentsToolkit.js',
+                    },
+                    {
+                      name: 'runtime',
+                      file: path.join(__dirname, './runtime/runtime.js'),
+                    },
+                  ]
+                }
 
                 if (options.debugRuntime) {
                   runtimeChunks.push({
@@ -682,6 +704,8 @@ module.exports = LavaMoatPlugin
  * @property {boolean} [HtmlWebpackPluginInterop] - Add a script tag to the html
  *   output for lockdown.js if HtmlWebpackPlugin is in use
  * @property {RegExp} [inlineLockdown] - Prefix the matching files with lockdown
+ * @property {RegExp} [unlockedChunksUnsafe] - Give matching chunks an unsafe
+ *   runtime with no policy enforcement
  * @property {number} [diagnosticsVerbosity] - A number representing diagnostics
  *   output verbosity, the larger the more overwhelming
  * @property {LockdownOptions} lockdown - Options to pass to SES lockdown

--- a/packages/webpack/src/runtime/debug.js
+++ b/packages/webpack/src/runtime/debug.js
@@ -15,7 +15,6 @@ globalThis.LM_printPolicyDebug = printPolicyDebug
 let debounceTimer
 
 const PRINT_AFTER_NO_NEW_POLICY_DISCOVERED_MS = 3000
-
 /**
  * Adds a key to the incremental policy.
  *
@@ -66,7 +65,6 @@ function recursiveProxy(hint, path) {
 /**
  * Finds all non-symbol keys for an object and its prototype chain. Symbol keys
  * are not included to simplify the implementation of debugProxy.
- *
  * @param {object | null} obj
  */
 function getAllKeys(obj) {

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -275,6 +275,16 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
       policyRequire[item] = harden(__webpack_require__[item])
     }
 
+    /**
+     * @param {number} chunkId
+     */
+    policyRequire.e = (chunkId) => {
+      return Promise.all(Object.keys(__webpack_require__.f).reduce((promises, key) => {
+        __webpack_require__.f[key](chunkId, promises);
+        return promises;
+      }, []));
+    };
+
     policyRequire.m = new Proxy(
       {},
       {

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -176,7 +176,6 @@ const installGlobalsForPolicy = (resourceId, packageCompartmentGlobal) => {
         ])
       ),
     })
-
     if (LAVAMOAT.debug) {
       LAVAMOAT.debug.debugProxy(
         packageCompartmentGlobal,

--- a/packages/webpack/src/runtime/runtimeUnlocked.js
+++ b/packages/webpack/src/runtime/runtimeUnlocked.js
@@ -1,0 +1,47 @@
+/// <reference path="./lavamoat.d.ts" />
+/* global LAVAMOAT */
+
+const { create, freeze, defineProperty } = Object
+const warn = typeof console === 'object' ? console.warn : () => {}
+warn('LavaMoat: using unlocked runtime')
+
+const { NAME_globalThis, NAME_scopeTerminator, NAME_runtimeHandler } =
+  LAVAMOAT.ENUM
+
+/**
+ * Wraps the webpack runtime with Lavamoat security features.
+ *
+ * @param {string} resourceId - The identifier of the resource.
+ * @param {any} runtimeKit - The runtime kit containing bits from the webpack
+ *   runtime.
+ * @returns {Object} - An object containing the wrapped runtime and other
+ *   related properties.
+ */
+const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
+  let { module } = runtimeKit
+  const runtimeHandler = runtimeKit
+
+  // allow setting, but ignore value for /* module decorator */ module = __webpack_require__.nmd(module)
+  defineProperty(runtimeHandler, 'module', {
+    get: () => module,
+    set: () => {},
+  })
+  // Make it possible to overwrite `exports` locally despite runtimeHandler being frozen
+  let exportsReference = runtimeHandler.exports
+  defineProperty(runtimeHandler, 'exports', {
+    get: () => exportsReference,
+    set: (value) => {
+      exportsReference = value
+    },
+  })
+  freeze(runtimeHandler)
+
+  return {
+    [NAME_scopeTerminator]: create(null),
+    [NAME_runtimeHandler]: runtimeHandler,
+    [NAME_globalThis]: globalThis, // TODO: apply some defensive coding to the global here to give at least some benefits to the user
+  }
+}
+
+// defaultExport is getting assigned to __webpack_require__._LM_
+LAVAMOAT.defaultExport = freeze(lavamoatRuntimeWrapper)


### PR DESCRIPTION
This PR focuses on preparing webpack plugin to work well with MetaMask effort to integrate it (see https://github.com/MetaMask/metamask-extension/pull/30134).

In order to do that, I had to:

* cac9e9aa70d809797aaa5acf79d24908a80a3c4e - fix emitSes part regarding how to load SES (I'm not sure about this part, I'm a bit confused regarding where this part came from, this might be redudent)
* 33e836d0f87ea90f82025a29b618a6123751a008 - cache natives in the debug file so that scuttling doesn't collide with it
* feb2bd6015dbdfbea1de9f686208ee001335b129 - add support to the webpack `e` function which support context modules which required support since MetaMask added support in dynamic imports
* 6fee72a97b5cee69d99ab4ed78c4d85299622316 - add a chunk that caches natives needed for webpack core logic so that it doesn't clash with scuttling

These make it so that when integrated with the MetaMask PR, compilation and execution of the app works well