### PR TITLE
fix(webpack): support regex in scuttling exceptions

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -483,6 +483,15 @@ class LavaMoatPlugin {
         // I stole the idea from Zach of module federation fame
 
         const onceForChunkSet = new WeakSet()
+
+        if (typeof options.scuttleGlobalThis === 'object') {
+          if (typeof options.scuttleGlobalThis.exceptions === 'object') {
+            options.scuttleGlobalThis.exceptions.forEach((exception, i, exceptions) => {
+              exceptions[i] = exception.toString()
+            })
+          }
+        }
+
         const runtimeOptions = {
           scuttleGlobalThis: options.scuttleGlobalThis,
           lockdown: options.lockdown,


### PR DESCRIPTION
`core/src/scuttle.js` knows that if a string in the array starts with '/' it should first be turned into a RE, and other packages know to transform REs to strings before passing them on (because if you don't, when embedding conf as a hardcoded string to the final bundle, REs will become `"{}"` instead of the actual RE statement).

This was missed at #1298 - #1529 addresses that