### PR TITLE
refactor(core/browserify): export global this aliases to one place

### DIFF
--- a/packages/browserify/src/index.js
+++ b/packages/browserify/src/index.js
@@ -1,6 +1,6 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const { getDefaultPaths, jsonStringifySortedPolicy } = require('lavamoat-core')
+const { getDefaultPaths, jsonStringifySortedPolicy, DEFAULT_GLOBAL_THIS_REFS } = require('lavamoat-core')
 const { createModuleInspectorSpy } = require('./createModuleInspectorSpy.js')
 const { createPackageDataStream } = require('./createPackageDataStream.js')
 const createLavaPack = require('@lavamoat/lavapack')
@@ -166,7 +166,7 @@ function getConfigurationFromPluginOpts(pluginOpts) {
   }
 
   if (!pluginOpts.globalThisRefs) {
-    pluginOpts.globalThisRefs = ['window', 'self', 'global', 'globalThis', 'top', 'frames', 'parent']
+    pluginOpts.globalThisRefs = DEFAULT_GLOBAL_THIS_REFS
   }
 
   if (pluginOpts.scuttleGlobalThisExceptions) {

--- a/packages/browserify/test/globalRef.spec.js
+++ b/packages/browserify/test/globalRef.spec.js
@@ -19,7 +19,7 @@ test('globalRef - has only the expected global circular refs', async (t) => {
       })
       module.exports = circularKeys.sort()
     },
-    expectedResult: DEFAULT_GLOBAL_THIS_REFS.sort(),
+    expectedResult: DEFAULT_GLOBAL_THIS_REFS.slice().sort(),
   })
   await runAndTestScenario(t, scenario, runScenario)
 })

--- a/packages/browserify/test/globalRef.spec.js
+++ b/packages/browserify/test/globalRef.spec.js
@@ -3,6 +3,7 @@
 
 const test = require('ava')
 const { runScenario } = require('./util')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('lavamoat-core')
 const {
   createScenarioFromScaffold,
   runAndTestScenario,
@@ -18,7 +19,7 @@ test('globalRef - has only the expected global circular refs', async (t) => {
       })
       module.exports = circularKeys.sort()
     },
-    expectedResult: ['window', 'self', 'global', 'globalThis', 'top', 'frames', 'parent'].sort(),
+    expectedResult: DEFAULT_GLOBAL_THIS_REFS.sort(),
   })
   await runAndTestScenario(t, scenario, runScenario)
 })

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,20 +1,19 @@
-const GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
-  WINDOW: 'window',
-  SELF: 'self',
-  GLOBAL: 'global',
-  GLOBAL_THIS: 'globalThis',
-  TOP: 'top',
-  FRAMES: 'frames',
-  PARENT: 'parent',
-}))
+const GLOBAL_THIS_REFS = Object.freeze(
+  /** @type {const} */ ({
+    WINDOW: 'window',
+    SELF: 'self',
+    GLOBAL: 'global',
+    GLOBAL_THIS: 'globalThis',
+    TOP: 'top',
+    FRAMES: 'frames',
+    PARENT: 'parent',
+  })
+)
 
 const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(Object.values(GLOBAL_THIS_REFS))
 
 /**
- * @typedef {typeof DEFAULT_GLOBAL_THIS_REFS[number]} GlobalThisRef
+ * @typedef {(typeof DEFAULT_GLOBAL_THIS_REFS)[number]} GlobalThisRef
  */
 
-
-module.exports = {GLOBAL_THIS_REFS, DEFAULT_GLOBAL_THIS_REFS}
-
-module.exports = {DEFAULT_GLOBAL_THIS_REFS}
+module.exports = { GLOBAL_THIS_REFS, DEFAULT_GLOBAL_THIS_REFS }

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,4 +1,4 @@
-const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */({
+const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */(Object.values({
   WINDOW: 'window',
   SELF: 'self',
   GLOBAL: 'global',
@@ -6,6 +6,6 @@ const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */(
   TOP: 'top',
   FRAMES: 'frames',
   PARENT: 'parent',
-}));
+})));
 
 module.exports = {DEFAULT_GLOBAL_THIS_REFS}

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,4 +1,4 @@
-const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */(Object.values({
+const GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
   WINDOW: 'window',
   SELF: 'self',
   GLOBAL: 'global',
@@ -6,6 +6,15 @@ const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */(
   TOP: 'top',
   FRAMES: 'frames',
   PARENT: 'parent',
-})));
+}))
+
+const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(Object.values(GLOBAL_THIS_REFS))
+
+/**
+ * @typedef {typeof DEFAULT_GLOBAL_THIS_REFS[number]} GlobalThisRef
+ */
+
+
+module.exports = {GLOBAL_THIS_REFS, DEFAULT_GLOBAL_THIS_REFS}
 
 module.exports = {DEFAULT_GLOBAL_THIS_REFS}

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,4 +1,4 @@
-const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
+const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {readonly string[]} */({
   WINDOW: 'window',
   SELF: 'self',
   GLOBAL: 'global',

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,4 +1,4 @@
-export const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
+const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
   WINDOW: 'window',
   SELF: 'self',
   GLOBAL: 'global',
@@ -7,3 +7,5 @@ export const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
   FRAMES: 'frames',
   PARENT: 'parent',
 }));
+
+module.exports = {DEFAULT_GLOBAL_THIS_REFS}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,9 @@
+const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
+  WINDOW: 'window',
+  SELF: 'self',
+  GLOBAL: 'global',
+  GLOBAL_THIS: 'globalThis',
+  TOP: 'top',
+  FRAMES: 'frames',
+  PARENT: 'parent',
+}));

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,4 @@
-const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
+export const DEFAULT_GLOBAL_THIS_REFS = Object.freeze(/** @type {const} */({
   WINDOW: 'window',
   SELF: 'self',
   GLOBAL: 'global',

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -20,6 +20,7 @@ const {
   // @ts-ignore cycle causes this to be an error sometimes
 } = require('lavamoat-tofu')
 const { mergePolicy } = require('./mergePolicy')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
 
 const rootSlug = '$root$'
 
@@ -283,7 +284,7 @@ function createModuleInspector(opts) {
       // browserify commonjs scope
       ignoredRefs: [...moduleRefs, ...globalObjPrototypeRefs],
       // browser global refs + browserify global
-      globalRefs: ['window', 'self', 'global', 'globalThis', 'top', 'frames', 'parent'],
+      globalRefs: DEFAULT_GLOBAL_THIS_REFS,
     })
     // skip if no results
     if (!foundGlobals.size) {

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -20,7 +20,7 @@ const {
   // @ts-ignore cycle causes this to be an error sometimes
 } = require('lavamoat-tofu')
 const { mergePolicy } = require('./mergePolicy')
-const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants.ts')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
 
 const rootSlug = '$root$'
 

--- a/packages/core/src/generatePolicy.js
+++ b/packages/core/src/generatePolicy.js
@@ -20,7 +20,7 @@ const {
   // @ts-ignore cycle causes this to be an error sometimes
 } = require('lavamoat-tofu')
 const { mergePolicy } = require('./mergePolicy')
-const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants.ts')
 
 const rootSlug = '$root$'
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,8 +12,10 @@ const { applySourceTransforms } = require('./sourceTransforms')
 const { makeInitStatsHook } = require('./makeInitStatsHook')
 const endowmentsToolkit = require('./endowmentsToolkit')
 const { jsonStringifySortedPolicy } = require('./stringifyPolicy')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
 
 module.exports = {
+  DEFAULT_GLOBAL_THIS_REFS,
   // generating the kernel
   generateKernel,
   // generating lavamoat config

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,7 +12,7 @@ const { applySourceTransforms } = require('./sourceTransforms')
 const { makeInitStatsHook } = require('./makeInitStatsHook')
 const endowmentsToolkit = require('./endowmentsToolkit')
 const { jsonStringifySortedPolicy } = require('./stringifyPolicy')
-const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants.ts')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
 
 module.exports = {
   DEFAULT_GLOBAL_THIS_REFS,

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -12,7 +12,7 @@ const { applySourceTransforms } = require('./sourceTransforms')
 const { makeInitStatsHook } = require('./makeInitStatsHook')
 const endowmentsToolkit = require('./endowmentsToolkit')
 const { jsonStringifySortedPolicy } = require('./stringifyPolicy')
-const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants')
+const { DEFAULT_GLOBAL_THIS_REFS } = require('./constants.ts')
 
 module.exports = {
   DEFAULT_GLOBAL_THIS_REFS,


### PR DESCRIPTION
export globalThis aliases to a single file to be consumed by the rest of the codebase