### PR TITLE
feat(node): add custom errors

### DIFF
--- a/packages/node/src/compartment/parse-native.js
+++ b/packages/node/src/compartment/parse-native.js
@@ -10,9 +10,10 @@
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { NATIVE_PARSER_NAME } from '../constants.js'
+import { PermissionDeniedError } from '../error.js'
+import { hrLabel } from '../util.js'
 
 const { freeze, keys } = Object
-const { quote: q } = assert
 
 /**
  * @import {ParseFn, ParserImplementation} from '@endo/compartment-mapper'
@@ -47,8 +48,9 @@ const parseNative = (
       /** @type {LavaMoatEndoPackagePolicy} */ (compartmentDescriptor?.policy)
         ?.options?.native !== true
     ) {
-      throw new Error(
-        `Native modules are disallowed in compartment ${q(compartment.name)}`
+      // TODO: we may be guaranteed a compartmentDescriptor. find out!
+      throw new PermissionDeniedError(
+        `Native modules are disallowed in package ${hrLabel(compartmentDescriptor?.label ?? compartment.name)}`
       )
     }
 

--- a/packages/node/src/error-code.js
+++ b/packages/node/src/error-code.js
@@ -1,0 +1,28 @@
+/**
+ * Provides {@link ErrorCodes} enum
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Enum of error codes thrown by this package
+ *
+ * Each one of these corresponds to a specific implementation of
+ * `LavaMoatError`.
+ */
+export const ErrorCodes = Object.freeze(
+  /** @type {const} */ ({
+    AttenuationFailure: 'LMN_ATTENUATION_FAILURE',
+    GenerationFailure: 'LMN_GENERATION_FAILURE',
+    ExecutionFailure: 'LMN_EXECUTION_FAILURE',
+    ConversionFailure: 'LMN_CONVERSION_FAILURE',
+    InvalidArguments: 'LMN_INVALID_ARGUMENTS',
+    InvalidCompartment: 'LMN_INVALID_COMPARTMENT',
+    InvalidPolicy: 'LMN_INVALID_POLICY',
+    NoExecutable: 'LMN_NO_EXECUTABLE',
+    NoPolicy: 'LMN_NO_POLICY',
+    NoWorkspace: 'LMN_NO_WORKSPACE',
+    PermissionDenied: 'LMN_PERMISSION_DENIED',
+    TrustMismatch: 'LMN_TRUST_MISMATCH',
+  })
+)

--- a/packages/node/src/error.js
+++ b/packages/node/src/error.js
@@ -1,0 +1,140 @@
+/**
+ * @import {ErrorCode, LavaMoatErrorClass, LavaMoatErrorClassParams} from './errors.js'
+ * @import {Class} from 'type-fest'
+ */
+import { ErrorCodes } from './error-code.js'
+
+/**
+ * Given a name, code, and implementation, create a new
+ * {@link LavaMoatErrorClass}.
+ *
+ * This handles some boilerplate when creating new custom error classes.
+ *
+ * @template {ErrorCode} Code
+ * @template {ErrorOptions} [Options=ErrorOptions] Default is `ErrorOptions`
+ * @param {string} name
+ * @param {Code} code
+ * @param {Class<Error, LavaMoatErrorClassParams<Options>>} ctor
+ * @returns {LavaMoatErrorClass<Code, Options>}
+ */
+export const createLavaMoatError = (name, code, ctor) => {
+  Object.defineProperties(ctor, {
+    code: { value: code, enumerable: true },
+    name: { value: name },
+  })
+  Object.defineProperties(ctor.prototype, {
+    code: { value: code, enumerable: true },
+    name: { value: name },
+    [Symbol.toStringTag]: { value: name },
+  })
+
+  return /** @type {LavaMoatErrorClass<Code, Options>} */ (
+    /** @type {unknown} */ (ctor)
+  )
+}
+
+/**
+ * An error thrown if the attenuator has a problem
+ */
+export const AttenuationError = createLavaMoatError(
+  'AttenuationError',
+  ErrorCodes.AttenuationFailure,
+  class extends Error {}
+)
+
+export const GenerationError = createLavaMoatError(
+  'GenerationError',
+  ErrorCodes.GenerationFailure,
+  class extends Error {}
+)
+
+export const ExecutionError = createLavaMoatError(
+  'ExecutionError',
+  ErrorCodes.ExecutionFailure,
+  class extends Error {}
+)
+
+export const ConversionError = createLavaMoatError(
+  'ConversionError',
+  ErrorCodes.ConversionFailure,
+  class extends Error {}
+)
+
+export const InvalidArgumentsError = createLavaMoatError(
+  'InvalidArgumentsError',
+  ErrorCodes.InvalidArguments,
+  class extends Error {}
+)
+
+export const InvalidCompartmentError = createLavaMoatError(
+  'InvalidCompartmentError',
+  ErrorCodes.InvalidCompartment,
+  class extends Error {}
+)
+
+export const InvalidPolicyError = createLavaMoatError(
+  'InvalidPolicyError',
+  ErrorCodes.InvalidPolicy,
+  class extends Error {
+    /** @type {Readonly<string | undefined>} */
+    filepath
+
+    /** @type {Readonly<'policy' | 'policy-override'>} */
+    type
+
+    /**
+     * @param {string} message
+     * @param {Object} options
+     * @param {unknown} [options.cause]
+     * @param {string} [options.filepath]
+     * @param {'policy' | 'policy-override'} options.type
+     */
+    constructor(message, { cause, filepath, type }) {
+      super(message, { cause })
+      this.filepath = filepath
+      this.type = type
+    }
+  }
+)
+
+export const NoExecutableError = createLavaMoatError(
+  'NoExecutableError',
+  ErrorCodes.NoExecutable,
+  class extends Error {}
+)
+
+/**
+ * Error thrown if policy cannot be found
+ */ export const NoPolicyError = createLavaMoatError(
+  'NoPolicyError',
+  ErrorCodes.NoPolicy,
+  class extends Error {}
+)
+
+/**
+ * Error thrown if workspace cannot be found
+ */
+export const NoWorkspaceError = createLavaMoatError(
+  'NoWorkspaceError',
+  ErrorCodes.NoWorkspace,
+  class extends Error {}
+)
+
+/**
+ * Error thrown if policy denies access to a resource
+ */
+export const PermissionDeniedError = createLavaMoatError(
+  'PermissionDeniedError',
+  ErrorCodes.PermissionDenied,
+  class extends Error {}
+)
+
+/**
+ * Error thrown if an policy with an untrusted root is attempted to be run in a
+ * trusted context
+ */
+export const TrustMismatchError = createLavaMoatError(
+  'TrustMismatchError',
+  ErrorCodes.TrustMismatch,
+  class extends Error {}
+)

--- a/packages/node/src/error.js
+++ b/packages/node/src/error.js
@@ -79,20 +79,15 @@ export const InvalidPolicyError = createLavaMoatError(
     /** @type {Readonly<string | undefined>} */
     filepath
 
-    /** @type {Readonly<'policy' | 'policy-override'>} */
-    type
-
     /**
      * @param {string} message
      * @param {Object} options
      * @param {unknown} [options.cause]
      * @param {string} [options.filepath]
-     * @param {'policy' | 'policy-override'} options.type
      */
-    constructor(message, { cause, filepath, type }) {
+    constructor(message, { cause, filepath } = {}) {
       super(message, { cause })
       this.filepath = filepath
-      this.type = type
     }
   }
 )

--- a/packages/node/src/errors.ts
+++ b/packages/node/src/errors.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Class, ValueOf } from 'type-fest'
+import type { ErrorCodes } from './error-code.js'
+
+export type ErrorCode = ValueOf<typeof ErrorCodes>
+
+/**
+ * A LavaMoat-specific error instance.
+ */
+export interface LavaMoatError<Code extends ErrorCode, Cause = unknown>
+  extends Error {
+  /**
+   * Underlying cause/error, if any
+   */
+  readonly cause?: Cause
+  /**
+   * Unique code for this error. This will be the same value as
+   * {@link LavaMoatErrorClass.code}
+   *
+   * This field exists on the prototype itself and is not an "own" field. It is
+   * enumerable.
+   */
+  readonly code: Code
+
+  readonly message: string
+}
+
+/**
+ * Constructor parameters for a class implementing {@link LavaMoatErrorClass}
+ * (which instantiates a {@link LavaMoatError}).
+ *
+ * @template Cause Reason for the error; usually another error. Specify if known
+ * @template Options Additional options for the error; if this object has any
+ *   required fields, the second parameter will be required.
+ */
+export type LavaMoatErrorClassParams<
+  Options extends ErrorOptions = ErrorOptions,
+> =
+  // tuples seem to struggle with conditional types, so it doesn't look like I can embed it in the tuple
+  Partial<Options> extends Options
+    ? [message: string, errOptions?: Options]
+    : [message: string, errOptions: Options]
+
+/**
+ * The _class_ of a {@link LavaMoatError}.
+ */
+export type LavaMoatErrorClass<
+  Code extends ErrorCode,
+  Options extends ErrorOptions = ErrorOptions,
+> = Class<LavaMoatError<Code, Options>, LavaMoatErrorClassParams<Options>> & {
+  /**
+   * Unique code for this error. This will be the same value as
+   * {@link LavaMoatError.code}
+   *
+   * This field is enumerable.
+   */
+  readonly code: Code
+}

--- a/packages/node/src/exec/default-attenuator.js
+++ b/packages/node/src/exec/default-attenuator.js
@@ -12,6 +12,7 @@ import {
   GLOBAL_THIS_REFS,
   LAVAMOAT_POLICY_ITEM_WRITE,
 } from '../constants.js'
+import { AttenuationError } from '../error.js'
 import { isObjectyObject } from '../util.js'
 
 /**
@@ -93,7 +94,7 @@ export const makeGlobalsAttenuator = ({
 
     if (policy === ENDO_POLICY_ITEM_ROOT) {
       if (rootCompartmentGlobalThis) {
-        throw new ReferenceError(
+        throw new AttenuationError(
           'Root compartment globalThis already initialized; this is a bug'
         )
       }

--- a/packages/node/src/exec/run.js
+++ b/packages/node/src/exec/run.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_ATTENUATOR,
   DEFAULT_TRUST_ROOT_COMPARTMENT,
 } from '../constants.js'
+import { TrustMismatchError } from '../error.js'
 import { log as defaultLog } from '../log.js'
 import { toEndoPolicy } from '../policy-converter.js'
 import { isTrusted, loadPolicies } from '../policy-util.js'
@@ -137,11 +138,11 @@ const assertTrustRootMatchesPolicy = (
   trustRoot = DEFAULT_TRUST_ROOT_COMPARTMENT
 ) => {
   if (trustRoot && !isTrusted(policy)) {
-    throw new Error(
+    throw new TrustMismatchError(
       `Attempted to execute entrypoint ${hrPath(entrypoint)} as trusted, but policy expects an untrusted root. Either call ${hrCode('run()')} with option ${hrCode('{trustRoot: true}')} or provide a policy which trusts the root (without ${hrCode('root.usePolicy')}). Aborting`
     )
   } else if (!trustRoot && isTrusted(policy)) {
-    throw new Error(
+    throw new TrustMismatchError(
       `Attempted to execute entrypoint ${hrPath(entrypoint)} as untrusted, but policy expects a trusted root. Either call ${hrCode('run()')} with option ${hrCode('{trustRoot: false}')} or provide a policy which does not trust the root. Aborting`
     )
   }

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -11,6 +11,7 @@
 import * as constants from './constants.js'
 import './preamble.js'
 
+export * from './error-code.js'
 export { execute } from './exec/execute.js'
 export { load } from './exec/load.js'
 export { run } from './exec/run.js'

--- a/packages/node/src/policy-converter.js
+++ b/packages/node/src/policy-converter.js
@@ -27,6 +27,7 @@ import {
   LAVAMOAT_PKG_POLICY_NATIVE,
   LAVAMOAT_PKG_POLICY_ROOT,
 } from './constants.js'
+import { ConversionError } from './error.js'
 import { loadPolicies } from './policy-util.js'
 import { isArray, isBoolean } from './util.js'
 
@@ -101,12 +102,12 @@ const convertToEndoPackagePolicyBuiltins = (item) => {
       let propName = rest.join('.')
       const itemForBuiltin = policyItem[builtinName]
       if (isBoolean(itemForBuiltin)) {
-        throw new TypeError(
+        throw new ConversionError(
           'Expected a FullAttenuationDefinition; got a boolean'
         )
       }
       if (isArray(itemForBuiltin)) {
-        throw new TypeError(
+        throw new ConversionError(
           'Expected a FullAttenuationDefinition; got an array'
         )
       }
@@ -139,7 +140,9 @@ const convertToEndoPackagePolicyPackages = (item) => {
   const policyItem = {}
   for (const [key, value] of entries(item)) {
     if (key === LAVAMOAT_PKG_POLICY_ROOT) {
-      throw new TypeError('Unexpected root package policy')
+      throw new ConversionError(
+        `Unexpected root package (${LAVAMOAT_PKG_POLICY_ROOT}) referenced in package policy`
+      )
     } else {
       policyItem[key] = !!value
     }

--- a/packages/node/src/policy-gen/lmr-cache.js
+++ b/packages/node/src/policy-gen/lmr-cache.js
@@ -5,6 +5,7 @@
  */
 
 import { LavamoatModuleRecord } from 'lavamoat-core'
+import { GenerationError } from '../error.js'
 
 /** @type {unique symbol} */
 const kCtor = Symbol('LMRCache.ctor')
@@ -85,7 +86,7 @@ export class LMRCache {
   add(moduleRecord) {
     const key = LMRCache.#keyFor(moduleRecord)
     if (this.has(moduleRecord)) {
-      throw new ReferenceError(
+      throw new GenerationError(
         `Module record with key "${key}" already exists in cache; this is a bug`
       )
     }

--- a/packages/node/src/policy-gen/policy-gen-compartment-class.js
+++ b/packages/node/src/policy-gen/policy-gen-compartment-class.js
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import { GenerationError } from '../error.js'
 import { hasValue, isObject } from '../util.js'
 
 /**
@@ -70,7 +71,9 @@ const updateModuleSource = (moduleDescriptor, canonicalName) => {
       : undefined
 
   if (!moduleSource) {
-    throw new TypeError(`Unsupported module descriptor type; this is a bug`)
+    throw new GenerationError(
+      `Unsupported module descriptor type; this is a bug`
+    )
   }
 
   // this just avoids adding duplicates. shouldn't happen, but who knows
@@ -94,7 +97,9 @@ const updateModuleSource = (moduleDescriptor, canonicalName) => {
   } else if (isSourceModuleDescriptor(moduleDescriptor)) {
     moduleDescriptor.source = moduleSource
   } else {
-    throw new TypeError(`Unsupported module descriptor type; this is a bug`)
+    throw new GenerationError(
+      `Unsupported module descriptor type; this is a bug`
+    )
   }
 }
 

--- a/packages/node/src/policy-gen/policy-gen-compartment-map.js
+++ b/packages/node/src/policy-gen/policy-gen-compartment-map.js
@@ -9,6 +9,7 @@ import { nullImportHook } from '../compartment/import-hook.js'
 import { DEFAULT_ENDO_OPTIONS } from '../compartment/options.js'
 import { defaultReadPowers } from '../compartment/power.js'
 import { ATTENUATORS_COMPARTMENT } from '../constants.js'
+import { GenerationError } from '../error.js'
 import { log as defaultLog } from '../log.js'
 import { hrLabel, toEndoURL } from '../util.js'
 import { makePolicyGenCompartment } from './policy-gen-compartment-class.js'
@@ -44,7 +45,7 @@ const finalCompartmentDescriptorTransform = (
   /* c8 ignore next */
   if (compartmentDescriptor.name === ATTENUATORS_COMPARTMENT) {
     // should be impossible
-    throw new TypeError(
+    throw new GenerationError(
       `Unexpected attenuator compartment found when computing canonical package name in ${compartmentDescriptor.label} (${compartmentDescriptor.location})`
     )
   }

--- a/packages/node/src/policy-gen/policy-gen-context.js
+++ b/packages/node/src/policy-gen/policy-gen-context.js
@@ -13,6 +13,7 @@ import {
   NATIVE_PARSER_NAME,
   PACKAGE_JSON,
 } from '../constants.js'
+import { GenerationError } from '../error.js'
 import { log as fallbackLog } from '../log.js'
 import { hasValue, hrLabel, hrPath } from '../util.js'
 
@@ -183,7 +184,7 @@ export class PolicyGeneratorContext {
     if (hasValue(descriptor, 'compartment') && hasValue(descriptor, 'module')) {
       const location = this.renames[descriptor.compartment]
       if (!location) {
-        throw new TypeError(
+        throw new GenerationError(
           `Compartment ${hrLabel(this.canonicalName)}: Rename map missing location for referenced compartment ${hrPath(descriptor.compartment)}`
         )
       }
@@ -342,7 +343,7 @@ export class PolicyGeneratorContext {
 
     if (!record) {
       // XXX: under what circumstances does this occur?
-      throw new TypeError(
+      throw new GenerationError(
         `Source descriptor "${specifier}" in compartment "${this.canonicalName}" missing prop: record`
       )
     }
@@ -351,7 +352,7 @@ export class PolicyGeneratorContext {
     // we can use `imports` as the discriminator
     if (!hasOwn(record, 'imports')) {
       // XXX: under what circumstances does this occur?
-      throw new TypeError(
+      throw new GenerationError(
         `StaticModuleType for source descriptor "${specifier}" in compartment "${this.canonicalName} missing prop: imports`
       )
     }

--- a/packages/node/src/policy-gen/policy-gen-util.js
+++ b/packages/node/src/policy-gen/policy-gen-util.js
@@ -6,6 +6,7 @@
  */
 
 import { LAVAMOAT_PKG_POLICY_ROOT } from '../constants.js'
+import { GenerationError } from '../error.js'
 import { hasValue, isObjectyObject } from '../util.js'
 
 /**
@@ -27,7 +28,7 @@ import { hasValue, isObjectyObject } from '../util.js'
 export const getCanonicalName = (compartment, trustRoot = true) => {
   // NOTE: the algorithm creating paths happens to be identical to the one in @lavamoat/aa package. Not that it matters because policies cannot be reused between this and other lavamoat tools.
   if (!compartment.path) {
-    throw new ReferenceError(
+    throw new GenerationError(
       `Computing canonical name failed: compartment "${compartment.name}" (${compartment.location}) has no "path" property; this is a bug`
     )
   }

--- a/packages/node/src/policy-gen/to-policy.js
+++ b/packages/node/src/policy-gen/to-policy.js
@@ -12,6 +12,7 @@ import { isBuiltin as defaultIsBuiltin } from 'node:module'
 import { stripVTControlCharacters } from 'node:util'
 import { defaultReadPowers } from '../compartment/power.js'
 import { DEFAULT_TRUST_ROOT_COMPARTMENT } from '../constants.js'
+import { GenerationError } from '../error.js'
 import { log as defaultLog } from '../log.js'
 import { hrLabel, hrPath, toPath } from '../util.js'
 import { LMRCache } from './lmr-cache.js'
@@ -159,7 +160,7 @@ export const buildModuleRecords = (
     compartmentMap.compartments[compartmentMap.entry.compartment]
 
   if (!entryCompartment) {
-    throw new TypeError('Could not find entry compartment; this is a bug')
+    throw new GenerationError('Could not find entry compartment; this is a bug')
   }
 
   const compartmentRenames = freeze({ ...renames })
@@ -199,7 +200,7 @@ export const buildModuleRecords = (
     /* c8 ignore next */
     if (!(compartmentName in sources)) {
       // "should never happen"™
-      throw new ReferenceError(
+      throw new GenerationError(
         `Could not find corresponding source for ${compartmentName}; this is a bug`
       )
     }

--- a/packages/node/src/policy-util.js
+++ b/packages/node/src/policy-util.js
@@ -12,6 +12,7 @@ import { jsonStringifySortedPolicy, mergePolicy } from 'lavamoat-core'
 import nodeFs from 'node:fs'
 import nodePath from 'node:path'
 import * as constants from './constants.js'
+import { InvalidPolicyError, NoPolicyError } from './error.js'
 import { readJsonFile } from './fs.js'
 import { log } from './log.js'
 import {
@@ -47,18 +48,18 @@ export const readPolicy = async (
     allegedPolicy = await readJsonFile(policyPath, { readFile })
   } catch (err) {
     if (err instanceof SyntaxError) {
-      throw new Error(
+      throw new InvalidPolicyError(
         `Invalid LavaMoat policy at ${hrPath(policyPath)}; failed to parse JSON`,
         { cause: err }
       )
     }
     if (/** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
-      throw new Error(
+      throw new NoPolicyError(
         `LavaMoat policy file not found at ${hrPath(policyPath)}`,
         { cause: err }
       )
     } else {
-      throw new Error(
+      throw new NoPolicyError(
         `Failed to read LavaMoat policy file at ${hrPath(policyPath)}`,
         {
           cause: err,
@@ -70,7 +71,7 @@ export const readPolicy = async (
     assertPolicy(allegedPolicy)
     return allegedPolicy
   } catch (err) {
-    throw new Error(
+    throw new InvalidPolicyError(
       `Invalid LavaMoat policy at ${hrPath(policyPath)}; does not match expected schema`,
       { cause: err }
     )
@@ -95,7 +96,7 @@ export const maybeReadPolicyOverride = async (
     allegedPolicy = await readJsonFile(policyOverridePath, { readFile })
   } catch (err) {
     if (err instanceof SyntaxError) {
-      throw new Error(
+      throw new InvalidPolicyError(
         `Invalid LavaMoat policy overrides at ${hrPath(policyOverridePath)}; failed to parse JSON`,
         { cause: err }
       )
@@ -108,11 +109,9 @@ export const maybeReadPolicyOverride = async (
     }
 
     if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ENOENT') {
-      throw new Error(
+      throw new InvalidPolicyError(
         `Failed to read LavaMoat policy overrides file at ${hrPath(policyOverridePath)}`,
-        {
-          cause: err,
-        }
+        { cause: err }
       )
     }
   }
@@ -121,7 +120,7 @@ export const maybeReadPolicyOverride = async (
     assertPolicy(allegedPolicy)
     return allegedPolicy
   } catch (err) {
-    throw new Error(
+    throw new InvalidPolicyError(
       `Invalid LavaMoat policy overrides at ${hrPath(policyOverridePath)}; does not match expected schema`,
       { cause: err }
     )
@@ -290,7 +289,7 @@ export const assertPolicy = (
   message = 'Invalid LavaMoat policy; does not match expected schema'
 ) => {
   if (!isPolicy(allegedPolicy)) {
-    throw new TypeError(message)
+    throw new InvalidPolicyError(message)
   }
 }
 

--- a/packages/node/src/resolve.js
+++ b/packages/node/src/resolve.js
@@ -8,6 +8,7 @@ import nodeFs from 'node:fs'
 import Module from 'node:module'
 import path from 'node:path'
 import { PACKAGE_JSON } from './constants.js'
+import { NoExecutableError, NoWorkspaceError } from './error.js'
 import { isExecutableSymlink, isReadableFileSync, realpathSync } from './fs.js'
 import { log } from './log.js'
 import { hrLabel, hrPath } from './util.js'
@@ -43,7 +44,9 @@ export const resolveWorkspace = ({
     }
     const parent = path.join(current, '..')
     if (parent === current) {
-      throw new Error(`Could not find a workspace from ${hrPath(from)}`)
+      throw new NoWorkspaceError(
+        `Could not find a workspace from ${hrPath(from)}`
+      )
     }
     current = parent
   }
@@ -93,8 +96,8 @@ export const resolveBinScript = (
   try {
     workspace = resolveWorkspace({ from, fs })
   } catch {
-    throw new Error(
-      `Could not find a workspace from ${niceFrom}; ensure you are in your project directory`
+    throw new NoWorkspaceError(
+      `Could not find a workspace from ${niceFrom}; are in your project directory?`
     )
   }
   let current = workspace
@@ -118,11 +121,15 @@ export const resolveBinScript = (
     try {
       next = resolveWorkspace({ from: path.join(current, '..'), fs })
     } catch {
-      throw new Error(`Could not find executable ${niceBin} from ${niceFrom}`)
+      throw new NoExecutableError(
+        `Could not find executable ${niceBin} from ${niceFrom}`
+      )
     }
     if (next === current) {
       log.debug(`Reached filesystem root; stopping search`)
-      throw new Error(`Could not find executable ${niceBin} from ${niceFrom}`)
+      throw new NoExecutableError(
+        `Could not find executable ${niceBin} from ${niceFrom}`
+      )
     }
     log.debug(`No such executable ${niceBin} in ${niceBinDir}; continuing…`)
     current = next

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -417,6 +417,8 @@ export type {
   RootPolicy,
 } from 'lavamoat-core'
 
+export type * from './errors.js'
+
 /**
  * Options for `loadPolicies()`
  */

--- a/packages/node/test/unit/policy-util.spec.js
+++ b/packages/node/test/unit/policy-util.spec.js
@@ -3,6 +3,7 @@ import '../../src/preamble.js'
 import test from 'ava'
 import { fs, vol } from 'memfs'
 import * as constants from '../../src/constants.js'
+import { ErrorCodes } from '../../src/error-code.js'
 import {
   assertPolicy,
   isPolicy,
@@ -89,16 +90,7 @@ test('assertPolicy - does not throw for valid policy', (t) => {
 
 test('assertPolicy - throws for invalid policy', (t) => {
   t.throws(() => assertPolicy({}), {
-    instanceOf: TypeError,
-    message: 'Invalid LavaMoat policy; does not match expected schema',
-  })
-})
-
-test('assertPolicy - accepts custom message', (t) => {
-  const message = 'custom message'
-  t.throws(() => assertPolicy({}, message), {
-    instanceOf: TypeError,
-    message,
+    code: ErrorCodes.InvalidPolicy,
   })
 })
 

--- a/packages/node/test/unit/policy/conversion.spec.js
+++ b/packages/node/test/unit/policy/conversion.spec.js
@@ -2,14 +2,13 @@ import '../../../src/preamble.js'
 
 import test from 'ava'
 import stringify from 'json-stable-stringify'
-import { DEFAULT_POLICY_PATH } from '../../../src/constants.js'
+import { ErrorCodes } from '../../../src/error-code.js'
 import { readJsonFile } from '../../../src/fs.js'
 import {
   ENDO_POLICY_BOILERPLATE,
   ENDO_POLICY_ENTRY_TRUSTED,
   toEndoPolicy,
 } from '../../../src/policy-converter.js'
-import { hrPath } from '../../../src/util.js'
 
 /**
  * @import {Policy} from '@endo/compartment-mapper'
@@ -79,7 +78,7 @@ test('toEndoPolicy() - no policy', async (t) => {
 
   // @ts-expect-error invalid type
   await t.throwsAsync(toEndoPolicy(lmPolicy), {
-    message: `LavaMoat policy file not found at ${hrPath(DEFAULT_POLICY_PATH)}`,
+    code: ErrorCodes.NoPolicy,
   })
 })
 
@@ -106,13 +105,13 @@ test('toEndoPolicy() - policy path as string', async (t) => {
 test('toEndoPolicy() - invalid policy', async (t) => {
   // @ts-expect-error invalid type
   await t.throwsAsync(toEndoPolicy([1, 2, 3]), {
-    message: 'Invalid LavaMoat policy; does not match expected schema',
+    code: ErrorCodes.InvalidPolicy,
   })
 })
 
 test('toEndoPolicy() - invalid policy (by path)', async (t) => {
   await t.throwsAsync(toEndoPolicy(INVALID_POLICY_URL), {
-    message: `Invalid LavaMoat policy at ${hrPath(INVALID_POLICY_URL)}; does not match expected schema`,
+    code: ErrorCodes.InvalidPolicy,
   })
 })
 
@@ -124,10 +123,7 @@ test('toEndoPolicy() - invalid policy override', async (t) => {
     toEndoPolicy(DEFAULT_POLICY, {
       policyOverride: lmPolicyOverride,
     }),
-    {
-      message:
-        'Invalid LavaMoat policy overrides; does not match expected schema',
-    }
+    { code: ErrorCodes.InvalidPolicy }
   )
 })
 
@@ -136,9 +132,7 @@ test('toEndoPolicy() - invalid policy override (by path)', async (t) => {
     toEndoPolicy(DEFAULT_POLICY, {
       policyOverridePath: INVALID_POLICY_URL,
     }),
-    {
-      message: `Invalid LavaMoat policy overrides at ${hrPath(INVALID_POLICY_URL)}; does not match expected schema`,
-    }
+    { code: ErrorCodes.InvalidPolicy }
   )
 })
 

--- a/packages/node/test/unit/resolve.spec.js
+++ b/packages/node/test/unit/resolve.spec.js
@@ -2,6 +2,7 @@ import '../../src/preamble.js'
 
 import test from 'ava'
 import { memfs } from 'memfs'
+import { ErrorCodes } from '../../src/error-code.js'
 import { resolveBinScript, resolveWorkspace } from '../../src/resolve.js'
 
 test('resolveBinScript - resolves real bin script path', (t) => {
@@ -29,7 +30,7 @@ test('resolveBinScript - throws error if workspace not found', (t) => {
     () => {
       resolveBinScript('test-bin', { from: '/nonexistent', fs })
     },
-    { message: /Could not find a workspace/ }
+    { code: ErrorCodes.NoWorkspace }
   )
 })
 
@@ -48,6 +49,6 @@ test('resolveWorkspace - throws error if workspace not found', (t) => {
     () => {
       resolveWorkspace({ from: '/nonexistent', fs })
     },
-    { message: /Could not find a workspace/ }
+    { code: ErrorCodes.NoWorkspace }
   )
 })


### PR DESCRIPTION
This adds a type definition and factory for custom error classes, including a set of custom errors.  Custom errors may or may not have specific implementations, but they all have a `code` property.

My ultimate aim here is to have all errors explained on the docs site; when one of our custom errors is thrown, it will direct the user to a URL with more information.

This sets the groundwork for adding more custom implementations and any other fancy stuff we want to do later.