### PR TITLE
chore(ci): add socket config

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,6 @@
+# top level version field is required
+version: 2
+
+projectIgnorePaths:
+  - "**/test/**/fixture/**"
+  - "**/test/**/fixtures/**"


### PR DESCRIPTION
This adds a Socket config (`socket.yml`) which disables checking of test fixtures, which are not designed to be `npm install`-ed.
