### PR TITLE
E2E dogfOOding test - run a webpack project with @lavamoat/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -121,7 +120,6 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -151,7 +149,6 @@
       "version": "6.3.1",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -432,7 +429,6 @@
       "version": "7.26.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/types": "^7.26.0"
@@ -1273,6 +1269,75 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+      "integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+      "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
+      "integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
+      "integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.25.9",
       "dev": true,
@@ -1574,6 +1639,27 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-react-display-name": "^7.25.9",
+        "@babel/plugin-transform-react-jsx": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-development": "^7.25.9",
+        "@babel/plugin-transform-react-pure-annotations": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -1916,6 +2002,16 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@endo/cjs-module-analyzer": {
@@ -2327,6 +2423,10 @@
     },
     "node_modules/@lavamoat/__bin-fix__": {
       "resolved": "packages/__bin-fix__",
+      "link": true
+    },
+    "node_modules/@lavamoat/__e2e-dogfooding__": {
+      "resolved": "packages/__e2e-dogfooding__",
       "link": true
     },
     "node_modules/@lavamoat/aa": {
@@ -2805,6 +2905,28 @@
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.13.tgz",
       "integrity": "sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==",
       "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -3630,6 +3752,45 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -8760,6 +8921,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/envinfo": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -9895,6 +10069,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
@@ -10137,6 +10321,16 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -10355,7 +10549,6 @@
       "version": "1.0.0-beta.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -10888,6 +11081,8 @@
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz",
+      "integrity": "sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11119,6 +11314,105 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-local/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -11294,6 +11588,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ip-address": {
@@ -13538,6 +13842,8 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.2.tgz",
+      "integrity": "sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15233,6 +15539,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.26.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.4.tgz",
+      "integrity": "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15706,6 +16023,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -18674,6 +19004,130 @@
         }
       }
     },
+    "node_modules/webpack-cli": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.2.0",
+        "@webpack-cli/info": "^1.5.0",
+        "@webpack-cli/serve": "^1.7.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "cross-spawn": "^7.0.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-merge/node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/webpack-merge/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webpack-merge/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webpack-merge/node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "dev": true,
@@ -18899,6 +19353,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -19182,6 +19643,154 @@
       "peerDependencies": {
         "@lavamoat/node": "*",
         "lavamoat": "*"
+      }
+    },
+    "packages/__e2e-dogfooding__": {
+      "name": "@lavamoat/__e2e-dogfooding__",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/preset-env": "7.26.9",
+        "@babel/preset-react": "^7.23.3",
+        "@babel/preset-typescript": "7.26.0",
+        "babel-loader": "9.2.1",
+        "css-loader": "7.1.2",
+        "html-webpack-plugin": "5.6.3",
+        "mini-css-extract-plugin": "2.9.2",
+        "preact": "^10.5.14",
+        "typescript": "^5.3.3",
+        "webpack": "5.95.0",
+        "webpack-cli": "^4.9.1"
+      },
+      "peerDependencies": {
+        "@lavamoat/node": "*",
+        "@lavamoat/webpack": "*"
+      }
+    },
+    "packages/__e2e-dogfooding__/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/__e2e-dogfooding__/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "packages/__e2e-dogfooding__/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "packages/__e2e-dogfooding__/node_modules/terser-webpack-plugin": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
+      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "packages/__e2e-dogfooding__/node_modules/webpack": {
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.11",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "packages/aa": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10881,6 +10881,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
@@ -19655,6 +19657,7 @@
         "@babel/preset-typescript": "7.26.0",
         "babel-loader": "9.2.1",
         "css-loader": "7.1.2",
+        "graceful-fs": "4.2.11",
         "html-webpack-plugin": "5.6.3",
         "mini-css-extract-plugin": "2.9.2",
         "preact": "^10.5.14",

--- a/packages/__e2e-dogfooding__/README.md
+++ b/packages/__e2e-dogfooding__/README.md
@@ -7,3 +7,19 @@ To each their own, eh?
 ## What is this?
 
 This is an elaborate end-to-end test aiming at ensuring `@lavamoat/node` works with a setup containing `@lavamoat/webpack` plugin so the build can run with protections.
+
+## How to run it?
+
+```sh
+npm run lavamoat:generate
+npm run lavamoat
+```
+
+Or for the simpler case of bypassing the webpack cli usaage
+
+```sh
+npm run lavamoat_2:generate
+npm run lavamoat_2
+```
+
+One of those is always wired up to `test:prep` and `test` scripts in the `package.json` file.

--- a/packages/__e2e-dogfooding__/README.md
+++ b/packages/__e2e-dogfooding__/README.md
@@ -1,0 +1,9 @@
+# Drinking your own champagne
+
+AKA Eating your own dogfood
+
+To each their own, eh?
+
+## What is this?
+
+This is an elaborate end-to-end test aiming at ensuring `@lavamoat/node` works with a setup containing `@lavamoat/webpack` plugin so the build can run with protections.

--- a/packages/__e2e-dogfooding__/build.js
+++ b/packages/__e2e-dogfooding__/build.js
@@ -1,0 +1,29 @@
+const webpack = require('webpack')
+const config = require('./webpack.config.js')
+const path = require('node:path')
+
+// Ensure the output directory exists
+const outputDir = path.resolve(__dirname, 'dist')
+
+// Run webpack compilation
+webpack(config, (err, stats) => {
+  if (err) {
+    console.error('Webpack configuration error:', err)
+    process.exit(1)
+  }
+
+  const info = stats.toJson()
+
+  if (stats.hasErrors()) {
+    console.error('Webpack build errors:', info.errors[0].message)
+    process.exit(1)
+  }
+
+  if (stats.hasWarnings()) {
+    console.warn('Webpack build warnings:', info.warnings[0].message)
+  }
+
+  console.log(stats.toString({ chunks: false, colors: true }))
+
+  console.log('Build complete! Output in', outputDir)
+})

--- a/packages/__e2e-dogfooding__/lavamoat/node/policy.json
+++ b/packages/__e2e-dogfooding__/lavamoat/node/policy.json
@@ -1,0 +1,21 @@
+{
+  "resources": {
+    "graceful-fs": {
+      "builtin": {
+        "assert.equal": true,
+        "constants.O_SYMLINK": true,
+        "constants.O_WRONLY": true,
+        "constants.hasOwnProperty": true,
+        "fs": true,
+        "stream.Stream.call": true,
+        "util": true
+      },
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "process": true,
+        "setTimeout": true
+      }
+    }
+  }
+}

--- a/packages/__e2e-dogfooding__/lavamoat/node_2/policy.json
+++ b/packages/__e2e-dogfooding__/lavamoat/node_2/policy.json
@@ -1,0 +1,864 @@
+{
+  "resources": {
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/code-frame": {
+      "globals": {
+        "console.warn": true,
+        "process": true
+      },
+      "packages": {
+        "@lavamoat/node>lavamoat-core>@babel/types>@babel/helper-validator-identifier": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/code-frame>js-tokens": true,
+        "@lavamoat/webpack>webpack>browserslist>update-browserslist-db>picocolors": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@lavamoat/node>lavamoat-core>@babel/types": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>@jridgewell/gen-mapping": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>jsesc": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/template": {
+      "packages": {
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/code-frame": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/parser": true,
+        "@lavamoat/node>lavamoat-core>@babel/types": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/code-frame": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/parser": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/template": true,
+        "@lavamoat/node>lavamoat-core>@babel/types": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>debug": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>globals": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env": true
+      },
+      "packages": {
+        "@lavamoat/node>lavamoat-core>@babel/types>@babel/helper-string-parser": true,
+        "@lavamoat/node>lavamoat-core>@babel/types>@babel/helper-validator-identifier": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>@jridgewell/gen-mapping": {
+      "packages": {
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>@jridgewell/gen-mapping>@jridgewell/set-array": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>terser>@jridgewell/source-map": {
+      "packages": {
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>@jridgewell/gen-mapping": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping": {
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "@lavamoat/webpack>@lavamoat/aa": {
+      "builtin": {
+        "node:fs.lstatSync": true,
+        "node:fs.readFileSync": true,
+        "node:fs.realpathSync": true,
+        "node:path.dirname": true,
+        "node:path.join": true,
+        "node:path.relative": true
+      },
+      "packages": {
+        "resolve": true
+      }
+    },
+    "@lavamoat/webpack": {
+      "builtin": {
+        "node:assert": true,
+        "node:fs.mkdirSync": true,
+        "node:fs.readFileSync": true,
+        "node:fs.writeFileSync": true,
+        "node:path.join": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.error": true,
+        "console.trace": true,
+        "console.warn": true,
+        "process._rawDebug": true
+      },
+      "packages": {
+        "@lavamoat/webpack>@lavamoat/aa": true,
+        "@lavamoat/webpack>browser-resolve": true,
+        "@lavamoat/node>lavamoat-core": true,
+        "webpack": true,
+        "@lavamoat/webpack>webpack": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/ast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-wasm-bytecode": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers>@webassemblyjs/floating-point-hex-parser": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/helper-api-error": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers>@xtuc/long": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/helper-wasm-section": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/helper-buffer": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-wasm-bytecode": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/wasm-gen": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/ieee754": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/ieee754>@xtuc/ieee754": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/leb128": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers>@xtuc/long": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit": {
+      "packages": {
+        "@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/helper-buffer": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-wasm-bytecode": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/helper-wasm-section": true,
+        "@webassemblyjs/wasm-gen": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/wasm-gen": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/wasm-opt": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/wasm-gen": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-wasm-bytecode": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/ieee754": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/leb128": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/utf8": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/wasm-opt": {
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit>@webassemblyjs/helper-buffer": true,
+        "@webassemblyjs/wasm-gen": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser": {
+      "globals": {
+        "console.log": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/helper-api-error": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-wasm-bytecode": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/ieee754": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/leb128": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser>@webassemblyjs/utf8": true
+      }
+    },
+    "@lavamoat/webpack>webpack>@webassemblyjs/ast>@webassemblyjs/helper-numbers>@xtuc/long": {
+      "globals": {
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true
+      }
+    },
+    "@lavamoat/webpack>webpack>acorn": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv-formats": {
+      "packages": {
+        "ajv": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv-keywords": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "ajv": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv>fast-deep-equal": true
+      }
+    },
+    "@lavamoat/webpack>webpack>schema-utils>ajv-keywords": {
+      "globals": {
+        "Buffer": true,
+        "console.error": true,
+        "console.warn": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>schema-utils>ajv>fast-deep-equal": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv>fast-uri": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv>json-schema-traverse": true
+      }
+    },
+    "@lavamoat/webpack>webpack>schema-utils>ajv": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>schema-utils>ajv>fast-deep-equal": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv>fast-json-stable-stringify": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv>json-schema-traverse": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv>uri-js": true
+      }
+    },
+    "@lavamoat/webpack>browser-resolve": {
+      "builtin": {
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "path": true
+      },
+      "globals": {
+        "__dirname": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@lavamoat/webpack>@lavamoat/aa>resolve": true
+      }
+    },
+    "@lavamoat/webpack>webpack>browserslist": {
+      "builtin": {
+        "fs.existsSync": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.relative": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "console.warn": true,
+        "process.env": true,
+        "process.versions.node": true
+      },
+      "packages": {
+        "caniuse-lite": true,
+        "electron-to-chromium": true,
+        "@lavamoat/webpack>webpack>browserslist>node-releases": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers>es-errors": true,
+        "function-bind": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>es-define-property": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length": true
+      }
+    },
+    "@lavamoat/webpack>webpack>chrome-trace-event": {
+      "builtin": {
+        "stream.Readable": true
+      },
+      "globals": {
+        "process.hrtime": true,
+        "process.pid": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>merge-deep>clone-deep": {
+      "packages": {
+        "@lavamoat/node>lavamoat-core>merge-deep>clone-deep>for-own": true,
+        "@lavamoat/node>lavamoat-core>merge-deep>clone-deep>lazy-cache": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util.deprecate": true,
+        "util.formatWithOptions": true,
+        "util.inspect": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "ms": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length>define-data-property": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>es-define-property": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers>es-errors": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>gopd": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>get-proto>dunder-proto": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>gopd": true
+      }
+    },
+    "@lavamoat/webpack>webpack>enhanced-resolve": {
+      "builtin": {
+        "module.findPnpApi": true,
+        "path.basename": true,
+        "path.posix.normalize": true,
+        "path.win32.normalize": true,
+        "process.nextTick": true,
+        "process.versions.pnp": true
+      },
+      "globals": {
+        "Buffer.isBuffer": true,
+        "URL": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>graceful-fs": true,
+        "@lavamoat/webpack>webpack>tapable": true
+      }
+    },
+    "@lavamoat/webpack>webpack>es-module-lexer": {
+      "globals": {
+        "Buffer": true,
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true,
+        "WebAssembly.compile": true,
+        "WebAssembly.instantiate": true,
+        "atob": true
+      }
+    },
+    "@lavamoat/webpack>webpack>eslint-scope": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>eslint-scope>esrecurse": true,
+        "@lavamoat/webpack>webpack>eslint-scope>estraverse": true
+      }
+    },
+    "@lavamoat/webpack>webpack>eslint-scope>esrecurse": {
+      "packages": {
+        "@lavamoat/webpack>webpack>eslint-scope>esrecurse>estraverse": true
+      }
+    },
+    "@lavamoat/webpack>webpack>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv>fast-uri": {
+      "globals": {
+        "URL.domainToASCII": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>merge-deep>clone-deep>for-own": {
+      "packages": {
+        "@lavamoat/node>lavamoat-core>merge-deep>clone-deep>for-own>for-in": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>es-define-property": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers>es-errors": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>es-object-atoms": true,
+        "function-bind": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>get-proto": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>gopd": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>has-symbols": true,
+        "@lavamoat/webpack>@lavamoat/aa>resolve>is-core-module>hasown": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>get-proto": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>get-proto>dunder-proto": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>es-object-atoms": true
+      }
+    },
+    "@lavamoat/webpack>webpack>graceful-fs": {
+      "builtin": {
+        "assert.equal": true,
+        "constants.O_SYMLINK": true,
+        "constants.O_WRONLY": true,
+        "constants.hasOwnProperty": true,
+        "fs": true,
+        "stream.Stream.call": true,
+        "util": true
+      },
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "process": true,
+        "setTimeout": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length>has-property-descriptors": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>es-define-property": true
+      }
+    },
+    "@lavamoat/webpack>@lavamoat/aa>resolve>is-core-module>hasown": {
+      "packages": {
+        "function-bind": true
+      }
+    },
+    "@lavamoat/webpack>@lavamoat/aa>resolve>is-core-module": {
+      "globals": {
+        "process.versions": true
+      },
+      "packages": {
+        "@lavamoat/webpack>@lavamoat/aa>resolve>is-core-module>hasown": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker": {
+      "builtin": {
+        "child_process": true,
+        "os": true,
+        "path": true,
+        "stream": true,
+        "worker_threads": true
+      },
+      "globals": {
+        "__dirname": true,
+        "clearTimeout": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker>merge-stream": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker>supports-color": true
+      }
+    },
+    "@lavamoat/node>@endo/evasive-transform>@babel/traverse>@babel/generator>jsesc": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@lavamoat/webpack>webpack>json-parse-even-better-errors": {
+      "globals": {
+        "Buffer.isBuffer": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>json-stable-stringify": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind": true,
+        "@lavamoat/webpack>json-stable-stringify>isarray": true,
+        "@lavamoat/webpack>json-stable-stringify>jsonify": true,
+        "@lavamoat/webpack>json-stable-stringify>object-keys": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>merge-deep>kind-of": {
+      "packages": {
+        "@lavamoat/node>lavamoat-core>merge-deep>kind-of>is-buffer": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core": {
+      "builtin": {
+        "node:events": true,
+        "node:fs.readFileSync": true,
+        "node:fs/promises.writeFile": true,
+        "node:path.extname": true,
+        "node:path.join": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      },
+      "packages": {
+        "@lavamoat/node>lavamoat-core>json-stable-stringify": true,
+        "lavamoat-tofu": true,
+        "@lavamoat/node>lavamoat-core>lavamoat-tofu": true,
+        "@lavamoat/node>lavamoat-core>merge-deep": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>lavamoat-tofu": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "@lavamoat/node>@endo/evasive-transform>@babel/parser": true,
+        "@lavamoat/node>@endo/evasive-transform>@babel/traverse": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>merge-deep>clone-deep>lazy-cache": {
+      "globals": {
+        "process.env.TRAVIS": true,
+        "process.env.UNLAZY": true
+      }
+    },
+    "@lavamoat/webpack>webpack>loader-runner": {
+      "builtin": {
+        "fs": true,
+        "url": true
+      },
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "console.error": true,
+        "process.nextTick": true,
+        "setImmediate": true
+      }
+    },
+    "@lavamoat/node>lavamoat-core>merge-deep": {
+      "packages": {
+        "@lavamoat/node>lavamoat-core>merge-deep>arr-union": true,
+        "@lavamoat/node>lavamoat-core>merge-deep>clone-deep": true,
+        "@lavamoat/node>lavamoat-core>merge-deep>kind-of": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker>merge-stream": {
+      "builtin": {
+        "stream.PassThrough": true
+      }
+    },
+    "@lavamoat/webpack>webpack>mime-types": {
+      "builtin": {
+        "path.extname": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>mime-types>mime-db": true
+      }
+    },
+    "@lavamoat/webpack>webpack>neo-async": {
+      "globals": {
+        "clearTimeout": true,
+        "console": true,
+        "define": true,
+        "process": true,
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "@lavamoat/webpack>@lavamoat/aa>resolve>path-parse": {
+      "globals": {
+        "process.platform": true
+      }
+    },
+    "@lavamoat/webpack>webpack>browserslist>update-browserslist-db>picocolors": {
+      "globals": {
+        "process": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>serialize-javascript>randombytes": {
+      "builtin": {
+        "crypto.randomBytes": true
+      }
+    },
+    "@lavamoat/webpack>@lavamoat/aa>resolve": {
+      "builtin": {
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "fs.realpath": true,
+        "fs.realpathSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
+        "os.homedir": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.relative": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "process.env.HOME": true,
+        "process.env.HOMEDRIVE": true,
+        "process.env.HOMEPATH": true,
+        "process.env.LNAME": true,
+        "process.env.LOGNAME": true,
+        "process.env.USER": true,
+        "process.env.USERNAME": true,
+        "process.env.USERPROFILE": true,
+        "process.getuid": true,
+        "process.nextTick": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@lavamoat/webpack>@lavamoat/aa>resolve>is-core-module": true,
+        "@lavamoat/webpack>@lavamoat/aa>resolve>path-parse": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv-formats": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv-keywords": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils>ajv": true
+      }
+    },
+    "@lavamoat/webpack>webpack>schema-utils": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "ajv": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv-keywords": true,
+        "@lavamoat/webpack>webpack>schema-utils>ajv": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>serialize-javascript": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>serialize-javascript>randombytes": true
+      }
+    },
+    "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length": {
+      "packages": {
+        "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length>define-data-property": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>call-bind-apply-helpers>es-errors": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>get-intrinsic>gopd": true,
+        "@lavamoat/webpack>json-stable-stringify>call-bind>set-function-length>has-property-descriptors": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker>supports-color": {
+      "globals": {
+        "navigator.userAgent": true
+      }
+    },
+    "@lavamoat/webpack>webpack>tapable": {
+      "builtin": {
+        "util.deprecate": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin": {
+      "builtin": {
+        "os.availableParallelism": true,
+        "os.cpus": true,
+        "path.dirname": true,
+        "path.relative": true
+      },
+      "globals": {
+        "Buffer.isBuffer": true,
+        "__dirname": true,
+        "__filename": true,
+        "process.stderr.write": true,
+        "process.stdout.write": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>@jridgewell/trace-mapping": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>jest-worker": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>schema-utils": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>serialize-javascript": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>terser": true
+      }
+    },
+    "@lavamoat/webpack>webpack>terser-webpack-plugin>terser": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console.log": true,
+        "console.warn": true,
+        "process": true,
+        "require": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>terser-webpack-plugin>terser>@jridgewell/source-map": true
+      }
+    },
+    "@lavamoat/webpack>webpack>schema-utils>ajv>uri-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@lavamoat/webpack>webpack>watchpack": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.readlinkSync": true,
+        "fs.watch": true,
+        "os.platform": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "process.env.WATCHPACK_POLLING": true,
+        "process.env.WATCHPACK_RECURSIVE_WATCHER_LOGGING": true,
+        "process.env.WATCHPACK_WATCHER_LIMIT": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "process.stderr.write": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>glob-to-regexp": true,
+        "@lavamoat/webpack>webpack>graceful-fs": true
+      }
+    },
+    "@lavamoat/webpack>webpack>webpack-sources": {
+      "globals": {
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "process": true
+      }
+    },
+    "@lavamoat/webpack>webpack": {
+      "builtin": {
+        "buffer.constants.MAX_LENGTH": true,
+        "crypto": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "http": true,
+        "https": true,
+        "inspector": true,
+        "module.builtinModules": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.posix.dirname": true,
+        "path.posix.isAbsolute": true,
+        "path.posix.join": true,
+        "path.posix.relative": true,
+        "path.resolve": true,
+        "path.sep": true,
+        "path.win32.dirname": true,
+        "path.win32.isAbsolute": true,
+        "path.win32.join": true,
+        "path.win32.relative": true,
+        "querystring.parse": true,
+        "stream.pipeline": true,
+        "url.URL": true,
+        "url.fileURLToPath": true,
+        "url.pathToFileURL": true,
+        "util.deprecate": true,
+        "util.format": true,
+        "util.inspect.custom": true,
+        "vm.createContext": true,
+        "vm.runInContext": true,
+        "vm.runInThisContext": true,
+        "zlib.constants.BROTLI_MODE_TEXT": true,
+        "zlib.constants.BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING": true,
+        "zlib.constants.BROTLI_PARAM_MODE": true,
+        "zlib.constants.BROTLI_PARAM_QUALITY": true,
+        "zlib.constants.BROTLI_PARAM_SIZE_HINT": true,
+        "zlib.constants.Z_BEST_SPEED": true,
+        "zlib.createBrotliCompress": true,
+        "zlib.createBrotliDecompress": true,
+        "zlib.createGunzip": true,
+        "zlib.createGzip": true,
+        "zlib.createInflate": true
+      },
+      "globals": {
+        "Buffer.allocUnsafe": true,
+        "Buffer.allocUnsafeSlow": true,
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "Buffer.prototype.readBigUInt64LE": true,
+        "Buffer.prototype.writeBigUInt64LE": true,
+        "URL": true,
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true,
+        "__dirname": true,
+        "__webpack_require__": true,
+        "clearTimeout": true,
+        "console.clear": true,
+        "console.error": true,
+        "console.log": true,
+        "console.profile": true,
+        "console.profileEnd": true,
+        "console.warn": true,
+        "process.cwd": true,
+        "process.env": true,
+        "process.hrtime": true,
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.versions.modules": true,
+        "process.versions.pnp": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@lavamoat/webpack>webpack>@webassemblyjs/ast": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-edit": true,
+        "@lavamoat/webpack>webpack>@webassemblyjs/wasm-parser": true,
+        "acorn-import-attributes": true,
+        "@lavamoat/webpack>webpack>acorn": true,
+        "@lavamoat/webpack>webpack>browserslist": true,
+        "@lavamoat/webpack>webpack>chrome-trace-event": true,
+        "@lavamoat/webpack>webpack>enhanced-resolve": true,
+        "@lavamoat/webpack>webpack>es-module-lexer": true,
+        "eslint-scope": true,
+        "@lavamoat/webpack>webpack>eslint-scope": true,
+        "@lavamoat/webpack>webpack>events": true,
+        "@lavamoat/webpack>webpack>glob-to-regexp": true,
+        "@lavamoat/webpack>webpack>graceful-fs": true,
+        "@lavamoat/webpack>webpack>json-parse-even-better-errors": true,
+        "@lavamoat/webpack>webpack>loader-runner": true,
+        "@lavamoat/webpack>webpack>mime-types": true,
+        "@lavamoat/webpack>webpack>neo-async": true,
+        "@lavamoat/webpack>webpack>schema-utils": true,
+        "@lavamoat/webpack>webpack>tapable": true,
+        "@lavamoat/webpack>webpack>terser-webpack-plugin": true,
+        "@lavamoat/webpack>webpack>watchpack": true,
+        "@lavamoat/webpack>webpack>webpack-sources": true
+      }
+    }
+  }
+}

--- a/packages/__e2e-dogfooding__/lavamoat/webpack/policy.json
+++ b/packages/__e2e-dogfooding__/lavamoat/webpack/policy.json
@@ -1,0 +1,10 @@
+{
+  "resources": {
+    "preact": {
+      "globals": {
+        "document": true,
+        "setTimeout": true
+      }
+    }
+  }
+}

--- a/packages/__e2e-dogfooding__/package.json
+++ b/packages/__e2e-dogfooding__/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@lavamoat/__e2e-dogfooding__",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack --mode production",
+    "test": "echo run the webpack setup here and assert it actually worked"
+  },
+  "peerDependencies": {
+    "@lavamoat/node": "*",
+    "@lavamoat/webpack": "*"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@babel/preset-env": "7.26.9",
+    "@babel/preset-react": "^7.23.3",
+    "@babel/preset-typescript": "7.26.0",
+    "babel-loader": "9.2.1",
+    "css-loader": "7.1.2",
+    "html-webpack-plugin": "5.6.3",
+    "mini-css-extract-plugin": "2.9.2",
+    "preact": "^10.5.14",
+    "typescript": "^5.3.3",
+    "webpack": "5.95.0",
+    "webpack-cli": "^4.9.1"
+  }
+}

--- a/packages/__e2e-dogfooding__/package.json
+++ b/packages/__e2e-dogfooding__/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "webpack --mode production",
-    "test": "echo run the webpack setup here and assert it actually worked"
+    "lavamoat": "lavamoat --dev --bin webpack",
+    "lavamoat:generate": "lavamoat generate --dev --bin webpack",
+    "start": "npm run lavamoat && echo 'open ./dist/index.html'",
+    "test": "npm run lavamoat && echo '[Build succeeded] \n TODO: validate bundle runs'",
+    "test:prep": "npm run lavamoat:generate || echo 'prep failed'",
+    "webpack": "webpack --mode production"
   },
   "peerDependencies": {
     "@lavamoat/node": "*",
@@ -17,6 +21,7 @@
     "@babel/preset-typescript": "7.26.0",
     "babel-loader": "9.2.1",
     "css-loader": "7.1.2",
+    "graceful-fs": "4.2.11",
     "html-webpack-plugin": "5.6.3",
     "mini-css-extract-plugin": "2.9.2",
     "preact": "^10.5.14",

--- a/packages/__e2e-dogfooding__/package.json
+++ b/packages/__e2e-dogfooding__/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "lavamoat": "lavamoat --dev --bin webpack",
     "lavamoat:generate": "lavamoat generate --dev --bin webpack",
+    "lavamoat_2": "lavamoat --policy ./lavamoat/node_2/policy.json build.js",
+    "lavamoat_2:generate": "lavamoat generate --policy ./lavamoat/node_2/policy.json build.js",
     "start": "npm run lavamoat && echo 'open ./dist/index.html'",
     "test": "npm run lavamoat && echo '[Build succeeded] \n TODO: validate bundle runs'",
     "test:prep": "npm run lavamoat:generate || echo 'prep failed'",
-    "webpack": "webpack --mode production"
+    "webpack": "webpack"
   },
   "peerDependencies": {
     "@lavamoat/node": "*",

--- a/packages/__e2e-dogfooding__/src/App.tsx
+++ b/packages/__e2e-dogfooding__/src/App.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { Fragment, h } from 'preact';
+import { FunctionComponent, h } from 'preact';
 
 interface ButtonProps {
   onClick?: () => void;
@@ -14,7 +14,7 @@ const App = () => {
   return (
     <div>
       <h1>Hello, Preact with TypeScript!</h1>
-      <button onClick={() => console.log('clicked')}>Click Me</button>
+      <Button onClick={() => alert('Gotcha!')}>Click Me</Button>
     </div>
   );
 };

--- a/packages/__e2e-dogfooding__/src/App.tsx
+++ b/packages/__e2e-dogfooding__/src/App.tsx
@@ -1,0 +1,22 @@
+/** @jsx h */
+import { Fragment, h } from 'preact';
+
+interface ButtonProps {
+  onClick?: () => void;
+  text?: string;
+}
+
+const Button: FunctionComponent<ButtonProps> = ({ onClick, text = 'Click Me' }) => (
+  <button onClick={onClick}>{text}</button>
+);
+
+const App = () => {
+  return (
+    <div>
+      <h1>Hello, Preact with TypeScript!</h1>
+      <button onClick={() => console.log('clicked')}>Click Me</button>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/__e2e-dogfooding__/src/example.ts
+++ b/packages/__e2e-dogfooding__/src/example.ts
@@ -1,0 +1,8 @@
+export interface User {
+  name: string
+  age: number
+}
+
+export function formatUser(user: User): string {
+  return `${user.name} (${user.age})`
+}

--- a/packages/__e2e-dogfooding__/src/index.tsx
+++ b/packages/__e2e-dogfooding__/src/index.tsx
@@ -1,0 +1,13 @@
+/** @jsx h */
+import { h, render } from 'preact';
+import App from './App';
+
+// Make sure we have a container
+const container = document.getElementById('app') || (() => {
+  const div = document.createElement('div');
+  div.id = 'app';
+  document.body.appendChild(div);
+  return div;
+})();
+
+render(<App />, container);

--- a/packages/__e2e-dogfooding__/src/styles.css
+++ b/packages/__e2e-dogfooding__/src/styles.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f0f0f0;
+}
+
+h1 {
+  color: #333;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 16px;
+  color: white;
+  background-color: #007bff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}

--- a/packages/__e2e-dogfooding__/tsconfig.json
+++ b/packages/__e2e-dogfooding__/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["dom", "es2015"],
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/__e2e-dogfooding__/webpack.config.js
+++ b/packages/__e2e-dogfooding__/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('node:path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const LavaMoatPlugin = require('@lavamoat/webpack')
 
 module.exports = {
   entry: './src/index.tsx',
@@ -36,7 +37,11 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          LavaMoatPlugin.exclude, // Exclude CSS from being wrapped in Compartments
+        ],
       },
     ],
   },
@@ -47,6 +52,15 @@ module.exports = {
       'react-dom': 'preact/compat',
     },
   },
-  plugins: [new HtmlWebpackPlugin(), new MiniCssExtractPlugin()],
+  plugins: [
+    new LavaMoatPlugin({
+      policyLocation: path.resolve(__dirname, 'lavamoat/webpack'),
+      generatePolicy: false,
+      HtmlWebpackPluginInterop: true, // Automatically add lockdown script tag
+      runChecks: true,
+    }),
+    new HtmlWebpackPlugin(),
+    new MiniCssExtractPlugin(),
+  ],
   devtool: 'source-map',
 }

--- a/packages/__e2e-dogfooding__/webpack.config.js
+++ b/packages/__e2e-dogfooding__/webpack.config.js
@@ -1,0 +1,52 @@
+const path = require('node:path')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    clean: true,
+  },
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                '@babel/preset-env',
+                '@babel/preset-typescript',
+                [
+                  '@babel/preset-react',
+                  {
+                    pragma: 'h',
+                    pragmaFrag: 'Fragment',
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+    },
+  },
+  plugins: [new HtmlWebpackPlugin(), new MiniCssExtractPlugin()],
+  devtool: 'source-map',
+}


### PR DESCRIPTION
Current issues:
- [ ] `@lavamoat/node` complains graceful-fs is missing, had to install it
- [x]  `@lavamoat/node` on main is incapable of handling the `#!`
- [ ] merged with `boneskull/untrusted-entrypoints` throws `Globals attenuation errors: Error while attenuating globals for "webpack" with "<default attenuator>": "Root compartment globalThis already initialized; this is a bug"`
