### PR TITLE
chore(eslint): validate config files against JSON schemas

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import { readFileSync } from 'node:fs'
 import eslintJs from '@eslint/js'
 import prettierConfig from 'eslint-config-prettier/flat'
 import avaPlugin from 'eslint-plugin-ava'
+import jsonSchemaValidatorPlugin from 'eslint-plugin-json-schema-validator'
 import jsoncPlugin from 'eslint-plugin-jsonc'
 import nodePlugin from 'eslint-plugin-n'
 import nodeImportPlugin from 'eslint-plugin-node-import'
@@ -486,6 +487,9 @@ export default defineConfig(
     ...config,
     files: ['**/tsconfig*.json', '**/*.json5', '**/*.jsonc'],
   })),
+
+  // Schema validation across YAML, TOML, JSON, JSONC, JSON5
+  ...jsonSchemaValidatorPlugin.configs.recommended,
 
   // ---------------------------------------------------------------------------
   // 8. Prettier (must be last to override conflicting rules)

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "10.0.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-ava": "16.0.0",
+        "eslint-plugin-json-schema-validator": "6.2.0",
         "eslint-plugin-jsonc": "3.1.2",
         "eslint-plugin-n": "17.24.0",
         "eslint-plugin-node-import": "1.2.0",
@@ -9681,6 +9682,74 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-plugin-json-schema-validator": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-6.2.0.tgz",
+      "integrity": "sha512-jHdo7MwJm94Z0lhlBtwa2dtRKBgiJNk3d5HGeyjhHszmlnCXsEu3blTjGWO0tzWg04UANoygB10CaRYcTBZCsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.3.0",
+        "ajv": "^8.0.0",
+        "debug": "^4.3.1",
+        "eslint-json-compat-utils": "^0.2.1",
+        "json-schema-migrate-x": "^2.1.0",
+        "jsonc-eslint-parser": "^3.1.0",
+        "minimatch": "^10.0.0",
+        "synckit": "^0.11.1",
+        "toml-eslint-parser": "^1.0.0",
+        "tunnel-agent": "^0.6.0",
+        "yaml-eslint-parser": "^2.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.38.0"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-plugin-jsonc": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-3.1.2.tgz",
@@ -12258,6 +12327,22 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-migrate-x": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate-x/-/json-schema-migrate-x-2.1.0.tgz",
+      "integrity": "sha512-idC5B/FLaEsMydSW+I302kEmg9RecqsdG12nAfmgp9SmrqDzmea9wTlE56rQlV3P3cWY6AAcA8/By4gyCQES/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/un-ts"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -17796,6 +17881,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toml-eslint-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-1.0.3.tgz",
+      "integrity": "sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
     "node_modules/toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -17891,6 +17992,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/typanion": {
@@ -18633,6 +18747,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-2.0.0.tgz",
+      "integrity": "sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^5.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint": "10.0.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-ava": "16.0.0",
+    "eslint-plugin-json-schema-validator": "6.2.0",
     "eslint-plugin-jsonc": "3.1.2",
     "eslint-plugin-n": "17.24.0",
     "eslint-plugin-node-import": "1.2.0",


### PR DESCRIPTION
This change adds [eslint-plugin-json-schema-validator](https://npm.im/eslint-plugin-json-schema-validator) to provide validation of config files against JSON schemas. It supports JSON, JSON5 and YAML config files.

The plugin will either a) download and cache schemas from the URL provided by the top-level `$schema` property (if present in file being linted); or b) it will load a catalog from [SchemaStore](https://www.schemastore.org) and try to match the file. If it matches, it will download and cache the schema. Cached schemas are stored in `node_modules/eslint-plugin-json-schema-validator/.cached_schemastore`. This is essentially the same thing that VSCode does by default.

I understand we may be concerned about this behavior, but I could not find a quick way around it without loss of functionality; there's no way to manually configure an association between any given file and a vendored schema _without_ using the `$schema` prop. This is needed because `$schema` is just a convention and some strict schemas do not allow the property (specifically the GHA workflow schema)!

If we are truly concerned and feel it's worth taking further steps to improve our posture, I can think of a couple options:

- We _may_ be able to vendor schemas and pre-populate `eslint-plugin-json-schema-validator`'s cache with symlinks of vendored schemas (and the catalog, I guess?) as part of the `setup` script.
- Upstream a PR to allow manually mapping config files to schemas.

Meanwhile, if we decide to merge this, we should carefully inspect any proposed upgrades to `eslint-plugin-json-schema-validator`.

---

The subsequent change lints the `nodejs` workflow.
