### PR TITLE
feat(core): add write+define policy option to allow defineProperty on globals

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -150,8 +150,8 @@ function endowmentsToolkit({
       allowedWriteFields
     )
 
-    if (allowRedefine.length > 0 && unwrapFrom && unwrapTo) {
-      const expectedTarget = unwrapTo || endowments
+    if (allowRedefine.length > 0 && unwrapFrom) {
+      const expectedTarget = unwrapFrom || endowments
       const originalDefineProperty = unwrapFrom.Object.defineProperty
       /**
        * @param {any} target

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -123,7 +123,7 @@ function endowmentsToolkit({
           whitelistedReads.push(path)
           if (packagePolicyValue === 'write+define') {
             if (!unwrapFrom) {
-              throw Error(
+              throw ReferenceError(
                 'LavaMoat - write+define value in policy requires unwrapFrom to be set when generating endowments'
               )
             }
@@ -154,7 +154,7 @@ function endowmentsToolkit({
       const expectedTarget = unwrapFrom || endowments
       const originalDefineProperty = unwrapFrom.Object.defineProperty
       /**
-       * @param {any} target
+       * @param {Record<PropertyKey, any>} target
        * @param {PropertyKey} key
        * @param {PropertyDescriptor} descriptor
        * @returns {boolean}

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -16,12 +16,12 @@ test('getEndowmentsForConfig', (t) => {
       stringValue: 'yabbadabbadoo',
     },
   }
-  const config = {
+  const policy = {
     globals: {
       'namespace.stringValue.includes': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   t.is(sourceGlobal.namespace.stringValue.includes('dab'), true)
   t.is(resultGlobal.namespace.stringValue.includes('dab'), true)
 })
@@ -36,25 +36,25 @@ test('getEndowmentsForConfig - function on proto', (t) => {
   const sourceGlobal = {
     lookAtMyProto: Object.create(theProto),
   }
-  const config = {
+  const policy = {
     globals: {
       'lookAtMyProto.appendChild': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   t.is(resultGlobal.lookAtMyProto.appendChild(), assertMe)
 })
 
 test('getEndowmentsForConfig - siblings', (t) => {
   const { getEndowmentsForConfig } = prepareTest()
   const sourceGlobal = { Buffer }
-  const config = {
+  const policy = {
     globals: {
       'Buffer.from': true,
       'Buffer.isBuffer': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   {
     const sourceProp = Object.getOwnPropertyDescriptor(
       sourceGlobal.Buffer,
@@ -103,14 +103,14 @@ test('getEndowmentsForConfig - knownWritable', (t) => {
     b: { c: 2 },
     d: 3,
   }
-  const config = {
+  const policy = {
     globals: {
       a: true,
       'b.c': true,
       d: true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   {
     t.is(resultGlobal.a, 1)
     t.is(resultGlobal.b.c, 2)
@@ -151,7 +151,7 @@ test('getEndowmentsForConfig - knownWritable and tightening access with false', 
     a: { b: { c: 2, d: 3 }, q: 1 },
   }
 
-  const config = {
+  const policy = {
     globals: {
       'a.b.c': true,
       'a.b': false,
@@ -159,7 +159,7 @@ test('getEndowmentsForConfig - knownWritable and tightening access with false', 
     },
   }
 
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   {
     t.is(typeof resultGlobal.a.b, 'object')
     t.is(resultGlobal.a.b.c, 2)
@@ -177,7 +177,7 @@ test('getEndowmentsForConfig - knownWritable and invalid nesting', (t) => {
     a: { b: { c: 2, d: 3 }, q: 1 },
   }
 
-  const config = {
+  const policy = {
     globals: {
       'a.b': true,
       'a.b.c': true,
@@ -185,7 +185,7 @@ test('getEndowmentsForConfig - knownWritable and invalid nesting', (t) => {
     },
   }
 
-  t.throws(() => getEndowmentsForConfig(sourceGlobal, config))
+  t.throws(() => getEndowmentsForConfig(sourceGlobal, policy))
 })
 
 test('getEndowmentsForConfig - read-write', (t) => {
@@ -196,21 +196,21 @@ test('getEndowmentsForConfig - read-write', (t) => {
     b: { c: 2 },
     d: 3,
   }
-  const config1 = {
+  const policy1 = {
     globals: {
       a: true,
       'b.c': true,
       d: true,
     },
   }
-  const config2 = {
+  const policy2 = {
     globals: {
       a: 'write',
       b: 'write',
     },
   }
-  const global1 = getEndowmentsForConfig(sourceGlobal, config1)
-  const global2 = getEndowmentsForConfig(sourceGlobal, config2)
+  const global1 = getEndowmentsForConfig(sourceGlobal, policy1)
+  const global2 = getEndowmentsForConfig(sourceGlobal, policy2)
   {
     t.is(global1.a, 1)
     t.is(global1.b.c, 2)
@@ -232,12 +232,12 @@ test('getEndowmentsForConfig - basic getter', (t) => {
       return { xyz: 42 }
     },
   }
-  const config = {
+  const policy = {
     globals: {
       'abc.xyz': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   {
     const sourceProp = Object.getOwnPropertyDescriptor(sourceGlobal, 'abc')
     const resultProp = Object.getOwnPropertyDescriptor(resultGlobal, 'abc')
@@ -272,20 +272,20 @@ test('getEndowmentsForConfig - traversing with getters', (t) => {
 
   const sourceGlobal = recur(3)()
 
-  const config = {
+  const policy = {
     globals: {
       'zzz.zzz.zzz': true,
     },
   }
-  const configShallow = {
+  const policyShallow = {
     globals: {
       'zzz.zzz': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   const resultGlobalShallow = getEndowmentsForConfig(
     sourceGlobal,
-    configShallow
+    policyShallow
   )
 
   {
@@ -325,12 +325,12 @@ test('getEndowmentsForConfig - ensure window.document getter behavior support', 
       return this
     },
   }
-  const config = {
+  const policy = {
     globals: {
       xyz: true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
 
   const getter = Reflect.getOwnPropertyDescriptor(resultGlobal, 'xyz').get
 
@@ -351,12 +351,12 @@ test('getEndowmentsForConfig - specify unwrap to', (t) => {
       return this
     },
   }
-  const config = {
+  const policy = {
     globals: {
       xyz: true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config, unwrapTo)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy, unwrapTo)
   const getter = Reflect.getOwnPropertyDescriptor(resultGlobal, 'xyz').get
 
   t.is(resultGlobal.xyz, unwrapTo)
@@ -378,14 +378,14 @@ test('getEndowmentsForConfig - specify unwrap from, unwrap to', (t) => {
       return this
     },
   }
-  const config = {
+  const policy = {
     globals: {
       xyz: true,
     },
   }
   const resultGlobal = getEndowmentsForConfig(
     sourceGlobal,
-    config,
+    policy,
     unwrapTo,
     unwrapFrom
   )
@@ -409,12 +409,12 @@ test('getEndowmentsForConfig - endowing bind of a function', async (t) => {
       return this
     },
   }
-  const config = {
+  const policy = {
     globals: {
       'abc.bind': true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
 
   // the intermediate should actually be an object
   t.is(typeof resultGlobal.abc, 'object')
@@ -435,12 +435,12 @@ test('getEndowmentsForConfig - ensure setTimeout calls dont trigger illegal invo
       return this
     },
   }
-  const config = {
+  const policy = {
     globals: {
       setTimeout: true,
     },
   }
-  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, policy)
   t.is(resultGlobal.setTimeout(), sourceGlobal)
 })
 
@@ -463,23 +463,30 @@ test('getEndowmentsForConfig - allow redefine on properties', (t) => {
   const knownWritable = new Set(['x', 'y'])
   const { getEndowmentsForConfig } = prepareTest({ knownWritable })
   const sourceGlobal = {
+    ...globalThis,
     x: 1,
     y: 2,
     z: 3,
   }
-  const config = {
+  const policy = {
     globals: {
       x: 'write+define',
       y: 'write',
       z: true,
     },
   }
-  const derivedGlobal = {}
+  // Compartment's globalThis
+  const derivedGlobal = {
+    Object,
+    Array,
+    Error,
+    Promise, // and so on...
+  }
   const endowments = getEndowmentsForConfig(
     sourceGlobal,
-    config,
-    derivedGlobal,
-    globalThis
+    policy,
+    globalThis,
+    derivedGlobal
   )
   Object.defineProperties(
     derivedGlobal,

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -317,7 +317,6 @@ test('getEndowmentsForConfig - traversing with getters', (t) => {
 })
 
 test('getEndowmentsForConfig - ensure window.document getter behavior support', (t) => {
-  'use strict'
   // compartment.globalThis.document would error because 'this' value is not window
   const { getEndowmentsForConfig } = prepareTest()
   const sourceGlobal = {
@@ -342,7 +341,6 @@ test('getEndowmentsForConfig - ensure window.document getter behavior support', 
 })
 
 test('getEndowmentsForConfig - specify unwrap to', (t) => {
-  'use strict'
   // compartment.globalThis.document would error because 'this' value is not window
   const unwrapTo = {}
   const { getEndowmentsForConfig } = prepareTest()
@@ -368,7 +366,6 @@ test('getEndowmentsForConfig - specify unwrap to', (t) => {
 })
 
 test('getEndowmentsForConfig - specify unwrap from, unwrap to', (t) => {
-  'use strict'
   // compartment.globalThis.document would error because 'this' value is not window
   const unwrapTo = {}
   const unwrapFrom = {}
@@ -402,7 +399,6 @@ test('getEndowmentsForConfig - specify unwrap from, unwrap to', (t) => {
 
 // eslint-disable-next-line ava/no-async-fn-without-await
 test('getEndowmentsForConfig - endowing bind of a function', async (t) => {
-  'use strict'
   const { getEndowmentsForConfig } = prepareTest()
   const sourceGlobal = {
     abc: function () {
@@ -427,7 +423,6 @@ test('getEndowmentsForConfig - endowing bind of a function', async (t) => {
 })
 
 test('getEndowmentsForConfig - ensure setTimeout calls dont trigger illegal invocation', (t) => {
-  'use strict'
   // compartment.globalThis.document would error because 'this' value is not window
   const { getEndowmentsForConfig } = prepareTest()
   const sourceGlobal = {
@@ -445,7 +440,6 @@ test('getEndowmentsForConfig - ensure setTimeout calls dont trigger illegal invo
 })
 
 test('copyWrappedGlobals - copy from prototype too', (t) => {
-  'use strict'
   const { copyWrappedGlobals } = prepareTest()
   const sourceProto = {
     onTheProto: function () {},
@@ -459,7 +453,6 @@ test('copyWrappedGlobals - copy from prototype too', (t) => {
 })
 
 test('getEndowmentsForConfig - allow redefine on properties', (t) => {
-  'use strict'
   const knownWritable = new Set(['x', 'y'])
   const { getEndowmentsForConfig } = prepareTest({ knownWritable })
   const sourceGlobal = {


### PR DESCRIPTION
fixes #1584 
Handles the case where a package needs to be allowed write to a global with define semantics

decided to go with `write+define` instead of `redefine` so that `write` is a common prefix for all write permissions we may wanna introduce.

- [ ] typescript is panicking about the Object reference
- [ ] The feature requires getEndowmentsForConfig to be called with all 4 arguments  
  The thing is, it could be a separate function that gets applied where getEndowmentsForConfig has been used but it would require access to the `allowRedefine` list so it can't be a separate function.
- [x] verify that the right references (unwrapTo unwrapFrom) are used and that the test emulates real use sufficiently
- [ ] Update the logic that produces knownWritableFields to use `.startsWith('write')`
