### PR TITLE
chore(ci): add ready-for-review workflow

### DIFF
--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     types:
       - ready_for_review
-      - synchronize # remove this
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     types:
       - ready_for_review
+      - synchronize # remove this
+
   workflow_dispatch:
     inputs:
       project-url:

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -1,0 +1,21 @@
+name: Add non-draft PRs to PR review board
+
+permissions:
+  issues: read
+  pull-requests: read
+  repository-projects: write
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+
+jobs:
+  add-to-project:
+    name: Add non-draft PRs to PR review board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1
+        with:
+          project-url: https://github.com/orgs/LavaMoat/projects/7
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     types:
       - ready_for_review
+  workflow_dispatch:
+    inputs:
+      project-url:
+        description: 'Project URL to add PRs to'
+        required: true
+        default: https://github.com/orgs/LavaMoat/projects/7
 
 jobs:
   add-to-project:

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1
         with:
           project-url: https://github.com/orgs/LavaMoat/projects/7
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PR_QUEUE_PAT }}


### PR DESCRIPTION
This (attempts) to add a workflow which appends all PRs _not_ in "draft" status to the project review board.