### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,3 @@
-# adds everybody as a reviewer on all the PRs
-* @LavaMoat/devs
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*eslint*                @boneskull
-*release-please*        @boneskull
-.config/README.md       @boneskull
-.husky/**/*             @boneskull
-renovate*               @boneskull
-tsconfig*.json          @boneskull
+* @naugtur @boneskull @leotm @weizman


### PR DESCRIPTION
This removes `@LavaMoat/devs` from the `CODEOWNERS` file.  The problem is that if _anyone_ reviews a given PR, then the review request is considered "completed"; the other team members will no longer have an open review request.

Instead, we can add individual team members directly to all PRs. This eliminates the need for path-specific ownership (which we are too small to really need).
