### PR TITLE
chore(ci): change how project review workflow works

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,4 +1,4 @@
-name: Add non-draft PRs to PR review board
+name: Add new PR to review board
 
 permissions:
   issues: read
@@ -8,11 +8,12 @@ permissions:
 on:
   pull_request:
     types:
-      - ready_for_review
+      - opened
 
 jobs:
   add-to-project:
-    name: Add non-draft PRs to PR review board
+    name: Add new PR to review board
+    if: github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -10,13 +10,6 @@ on:
     types:
       - ready_for_review
 
-  workflow_dispatch:
-    inputs:
-      project-url:
-        description: 'Project URL to add PRs to'
-        required: true
-        default: https://github.com/orgs/LavaMoat/projects/7
-
 jobs:
   add-to-project:
     name: Add non-draft PRs to PR review board


### PR DESCRIPTION
This changes the project review workflow so that it _only triggers once, at time of PR creation_.

It does not trigger for Renovate-created PRs.

> Technically it _does_ trigger, but the job to add the PR to the project is skipped.

To support this, the PR review board has been modified to exclude "draft" PRs.

* * *

Ideally, we want to ensure that draft PRs do not clog up the review board. The reason for this change is mostly that _we cannot reliably keep a PR "in sync" with the review board_ depending on its draft status.  Further, attempting to add the same PR multiple times will result in a workflow error.  This sidesteps the issue by adding _all_ non-bot PRs to the review board, where we can easily filter out draft PRs.

* * *

The `workflow_dispatch` event was removed as it was only good for testing.