### PR TITLE
chore(renovate): ignore perf/trials

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
     'group:linters', // group lint-related packages together
     'workarounds:typesNodeVersioning', // tracks node versions from engines field in package.json for @types/node
   ],
+  ignorePaths: ['packages/perf/trials/**/*'],
   packageRules: [
     {
       // as long as we use CJS, everything owned by @sindresorhus should be in this list


### PR DESCRIPTION
These are test fixtures and we should probably just leave them as-is.