### PR TITLE
feat(webpack): enable syntax checks by default, check prior to concatenation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ packages/viz/src/example-policies/**/*
 .yarn/**/*
 package-lock.json
 yarn.lock
+
+# ignore without the necessity to modify the file with ignore comments
+packages/webpack/test/fixtures/main/hack4.js

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -81,7 +81,7 @@ exports.wrapper = function wrapper({
     ','
   )}}))${optionalBinding}()`
   if (runChecks) {
-    validateSource(before + sesCompatibleSource + after)
+    validateSource(sesCompatibleSource)
   }
   return {
     before,

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -82,6 +82,7 @@ class LavaMoatPlugin {
       policyLocation: path.join('lavamoat', 'webpack'),
       lockdown: lockdownDefaults,
       isBuiltin: () => false,
+      runChecks: true,
       ...options,
     }
 
@@ -252,7 +253,7 @@ class LavaMoatPlugin {
          * @type {import('./buildtime/aa.js').IdentifierLookup}
          */
         let identifierLookup
-        const runChecks = this.options.runChecks || diag.level > 0
+        const runChecks = this.options.runChecks
 
         // Caveat: this might be called before the lookup map is ready if a plugin is running a child compilation or alike.
         // Note that in those cases wrapped code is not meant to run and policy will be empty.

--- a/packages/webpack/test/e2e-hack.spec.js
+++ b/packages/webpack/test/e2e-hack.spec.js
@@ -55,3 +55,20 @@ test('webpack/hack/fetch - cannot pollute prototypes', (t) => {
     { message: /Cannot add property polluted, object is not extensible/ }
   )
 })
+
+test('webpack/hack/mismatched-curlies', async (t) => {
+  t.plan(1)
+  try {
+    t.context.build = await scaffold({
+      ...webpackConfigDefault,
+      entry: {
+        hack4: './hack4.js',
+      },
+    })
+  } catch (err) {
+    t.assert(
+      err.compilationErrors[0].message.startsWith('E_VALIDATION'),
+      'Expected a validation error from erapper check'
+    )
+  }
+})

--- a/packages/webpack/test/fixtures/main/hack4.js
+++ b/packages/webpack/test/fixtures/main/hack4.js
@@ -1,0 +1,2 @@
+1<!--}-->1
+// evasive transform changes the meaning of the code


### PR DESCRIPTION
This follows advice from the Ottersec audit more closely but also solves for a situation when the plugin is running under lavamoat and `Function` is not in sloppy mode, so won't tolerate with statements. 

If running checks by default is a breaking change for someone, that's likely actually good for their project, so I'm not considering it a breaking change (while in beta)