### PR TITLE
chore(renovate): re-ignore paths that should be ignored

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,13 @@
     'group:linters', // group lint-related packages together
     'workarounds:typesNodeVersioning', // tracks node versions from engines field in package.json for @types/node
   ],
-  ignorePaths: ['packages/perf/trials/**/*'],
+  // providing this overrides `:ignoreModulesAndTests` which comes in thru `config:js-app` via `config:recommended`
+  ignorePaths: [
+    'packages/perf/trials/**/*',
+    '**/node_modules/**',
+    '**/example*/**',
+    '**/fixture*/**',
+  ],
   packageRules: [
     {
       // as long as we use CJS, everything owned by @sindresorhus should be in this list


### PR DESCRIPTION
Since we now use `ignorePaths`, it is not merged with the default set of ignored paths from the configs we extend. So we need to re-add the things to be ignored.