### PR TITLE
chore(renovate): add packages/*test to ignored paths

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,7 @@
     '**/node_modules/**',
     '**/example*/**',
     '**/fixture*/**',
+    'packages/*/test/**',
   ],
   packageRules: [
     {


### PR DESCRIPTION
`lavamoat-node/test/projects/*` is a problem
