### PR TITLE
feat(core): relax scuttling by skipping intrinsics

### DIFF
--- a/packages/core/test/scenarios/scuttle.js
+++ b/packages/core/test/scenarios/scuttle.js
@@ -8,9 +8,9 @@ const one = () => {
   if (globalThis.getTrueGlobalThisForTestsOnly) {
     globalObject = globalThis.getTrueGlobalThisForTestsOnly()
   }
-  // this will throw if regex scuttling fails
-  if (globalObject.Float32Array) {
-    module.exports = globalObject.Math.PI
+  // this will throw if scuttling fails
+  if (globalObject.AAA) {
+    module.exports = globalObject.AAA
   }
 }
 
@@ -18,23 +18,19 @@ module.exports = [
   async (log = console.error.bind(console)) => {
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is scuttled to work',
+      context: { AAA: '111' },
       defineOne: one,
-      expectedResult: Math.PI,
+      expectedResult: '111',
       opts: {
         scuttleGlobalThis: {
           enabled: true,
           exceptions: [
             'WebAssembly',
             'process',
-            '/[0-9]+/',
-            'Set',
-            'Reflect',
-            'Object',
             'console',
-            'Array',
-            'RegExp',
-            'Date',
             'Math',
+            'Date',
+            'AAA',
           ],
         },
       },
@@ -45,6 +41,7 @@ module.exports = [
   async (log = console.error.bind(console)) => {
     const scenario = createScenarioFromScaffold({
       name: 'scuttle - host env global object is too scuttled to work',
+      context: { AAA: '111' },
       defineOne: one,
       opts: {
         scuttleGlobalThis: {
@@ -52,7 +49,10 @@ module.exports = [
           exceptions: [
             'WebAssembly',
             'process',
-            '/[0-9]+/' /*'Set', 'Reflect', 'Object', 'console', 'Array', 'RegExp', 'Date', 'Math'*/,
+            'console',
+            'Math',
+            'Date',
+            // 'AAA',
           ],
         },
       },

--- a/packages/core/test/scuttle.spec.js
+++ b/packages/core/test/scuttle.spec.js
@@ -1,6 +1,5 @@
 const test = require('ava')
 const { evaluateWithSourceUrl } = require('./util')
-const { scuttle } = require('../src/scuttle')
 
 const SCUTTLER_NAME_ERROR = {
   message:
@@ -18,8 +17,87 @@ const getPropsGroups = (g) => ({
         Object.getOwnPropertyDescriptor(g, p).writable
     )
     // remove hardcoded props scuttling ignores on purpose
-    .filter((p) => !['Compartment', 'Error', 'globalThis'].includes(p)),
+    .filter((p) => !avoidForLavaMoatCompatibility.includes(p)),
 })
+
+const { scuttle, avoidForLavaMoatCompatibility } = (function () {
+  function fakeCompartment() {
+    return {
+      globalThis: {
+        Infinity: globalThis['Infinity'],
+        undefined: globalThis['undefined'],
+        isFinite: globalThis['isFinite'],
+        isNaN: globalThis['isNaN'],
+        parseFloat: globalThis['parseFloat'],
+        parseInt: globalThis['parseInt'],
+        decodeURI: globalThis['decodeURI'],
+        decodeURIComponent: globalThis['decodeURIComponent'],
+        encodeURI: globalThis['encodeURI'],
+        encodeURIComponent: globalThis['encodeURIComponent'],
+        Array: globalThis['Array'],
+        ArrayBuffer: globalThis['ArrayBuffer'],
+        BigInt: globalThis['BigInt'],
+        BigInt64Array: globalThis['BigInt64Array'],
+        BigUint64Array: globalThis['BigUint64Array'],
+        Boolean: globalThis['Boolean'],
+        DataView: globalThis['DataView'],
+        EvalError: globalThis['EvalError'],
+        Float16Array: globalThis['Float16Array'],
+        Float32Array: globalThis['Float32Array'],
+        Float64Array: globalThis['Float64Array'],
+        Int8Array: globalThis['Int8Array'],
+        Int16Array: globalThis['Int16Array'],
+        Int32Array: globalThis['Int32Array'],
+        Map: globalThis['Map'],
+        Number: globalThis['Number'],
+        Object: globalThis['Object'],
+        Promise: globalThis['Promise'],
+        Proxy: globalThis['Proxy'],
+        RangeError: globalThis['RangeError'],
+        ReferenceError: globalThis['ReferenceError'],
+        Set: globalThis['Set'],
+        String: globalThis['String'],
+        SyntaxError: globalThis['SyntaxError'],
+        TypeError: globalThis['TypeError'],
+        Uint8Array: globalThis['Uint8Array'],
+        Uint8ClampedArray: globalThis['Uint8ClampedArray'],
+        Uint16Array: globalThis['Uint16Array'],
+        Uint32Array: globalThis['Uint32Array'],
+        URIError: globalThis['URIError'],
+        WeakMap: globalThis['WeakMap'],
+        WeakSet: globalThis['WeakSet'],
+        Iterator: globalThis['Iterator'],
+        AggregateError: globalThis['AggregateError'],
+        JSON: globalThis['JSON'],
+        Reflect: globalThis['Reflect'],
+        escape: globalThis['escape'],
+        unescape: globalThis['unescape'],
+        lockdown: globalThis['lockdown'],
+        harden: globalThis['harden'],
+      },
+    }
+  }
+  // set stub to globalThis so requiring scuttle.js works
+  globalThis.Compartment = fakeCompartment
+  // generate props to skip (same code as from scuttle.js)
+  const avoidForLavaMoatCompatibility = (function (
+    globalThisCompartment,
+    globalThis
+  ) {
+    return (
+      Object.getOwnPropertyNames(globalThisCompartment)
+        // skip all intrinsics that a Compartment already grants
+        .filter((a) => globalThisCompartment[a] === globalThis[a])
+        // support LM,SES exported APIs and polyfills that LM counts on
+        .concat(['Compartment', 'Error', 'globalThis'])
+    )
+  })(new Compartment().globalThis, globalThis)
+  // require scuttle.js
+  const { scuttle } = require('../src/scuttle')
+  // revert global object to its original state
+  globalThis.Compartment = undefined
+  return { scuttle, avoidForLavaMoatCompatibility }
+})()
 
 const err = (intrinsic) =>
   'LavaMoat - property "' +
@@ -68,27 +146,17 @@ test('scuttle - opts as object', (t) => {
 
 test('scuttle - exceptions', (t) => {
   const { vmGlobalThis } = evaluateWithSourceUrl('some-code', ';', {})
+  vmGlobalThis.AAA1 = vmGlobalThis.BBB1 = 111
   const { all, configurables } = getPropsGroups(vmGlobalThis)
   all.forEach((p) => vmGlobalThis[p])
   scuttle(vmGlobalThis, {
     enabled: true,
-    exceptions: ['/[a-zA-Z0-9]*Array/', 'RegExp'],
+    exceptions: ['/^(AAA|BBB)1$/', 'FinalizationRegistry', 'SharedArrayBuffer'],
   })
   const exceptions = [
-    'RegExp',
-    'Array',
-    'ArrayBuffer',
-    'Uint8Array',
-    'Int8Array',
-    'Uint16Array',
-    'Int16Array',
-    'Uint32Array',
-    'Int32Array',
-    'Float32Array',
-    'Float64Array',
-    'Uint8ClampedArray',
-    'BigUint64Array',
-    'BigInt64Array',
+    'AAA1',
+    'BBB1',
+    'FinalizationRegistry',
     'SharedArrayBuffer',
   ]
   exceptions.forEach((p) => vmGlobalThis[p])
@@ -133,9 +201,13 @@ test('scuttle - resilient', (t) => {
       ? t.throws(() => vmGlobalThis[p], { message: err(p) })
       : vmGlobalThis[p]
   )
-  t.throws(() => Object.defineProperty(vmGlobalThis, 'Array', { value: 111 }), {
-    message: 'Cannot redefine property: Array',
-  })
+  t.throws(
+    () =>
+      Object.defineProperty(vmGlobalThis, 'SharedArrayBuffer', { value: 111 }),
+    {
+      message: 'Cannot redefine property: SharedArrayBuffer',
+    }
+  )
   vmGlobalThis.Array = 1
   all.forEach((p) =>
     configurables.includes(p)


### PR DESCRIPTION
As agreed, we plan on relaxing scuttling by avoiding scuttling of properties that are the same as can be found within compartments. This is because scuttling such basic intrinsics makes the protecting environment too limited to function, especially given the fact they can be easily retrieved by creating a new Compartment.

What happens in this PR:

* The `avoidForLavaMoatCompatibility` variable now initializes at the top, and in addition to having 3 hardcoded props LavaMoat needs, it now also dynamically generates all the intrinsics a Compartment gives (by creating one) to add to this "do not scuttle" list.
  * Note that it filters out intrinsics that are not identical to those that live outside of Compartments, because if they are not the same, it means Compartments get a tamed version of them, so since the outer ones are more powerful, it still makes sense to scuttle them
* adjusted test scenarios
* specs needed extra care, because when requiring `scuttle.js`, it crashes for not having access to a Compartment via the globalThis, which is the case under specs environment. To address that, there's a new chunk of code that:
  * Sets a fake Compartment to the globalThis that returns the list of intrinsics
  * Generate the list of intrinsics to skip (the same way `scuttle.js` does) to use for tests
  * require `scuttle.js` (which would now work having Compartment set on the globalThis)
  * restore the state of globalThis by removing the fakeCompartment property from it
  * (this is all wrapped in an anon function to express how atomic this operation must be)
