### PR TITLE
feat(webpack): PoC messageable realms

### DIFF
--- a/packages/webpack/test/fixtures/main/node_modules/postmessage-lib/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/postmessage-lib/index.js
@@ -1,0 +1,33 @@
+function mkNotify(target) {
+  
+  return function notify(message, targetOrigin = "*") {
+    if(!target) {
+      return console.error('target is not defined')
+    }
+    target.postMessage('🟢'+message, targetOrigin);
+  }
+}
+
+const tryAndReport = (examples) => {
+  for (const example of examples) {
+    try {
+      example()
+    } catch (e) {
+      console.error(e)
+      window?.parent?.postMessage('🛑 in iframe: '+e, '*')
+      window?.opener?.postMessage('🛑 in popup: '+e, '*')
+    }
+  }
+}
+
+module.exports = {
+  notifyParent: mkNotify(window.parent),
+  notifyTop: mkNotify(window.top),
+  notifyOpener: mkNotify(window.opener),
+  abuseGlobals: () => {
+    tryAndReport([
+      () => window.parent.alert('global capabilities leaked in .parent'),
+      () => window.parent.parent.alert('global capabilities leaked in parent.parent'),
+    ])
+  }
+};

--- a/packages/webpack/test/fixtures/main/node_modules/postmessage-lib/package.json
+++ b/packages/webpack/test/fixtures/main/node_modules/postmessage-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "postmessage-lib",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/webpack/test/fixtures/main/package.json
+++ b/packages/webpack/test/fixtures/main/package.json
@@ -16,6 +16,7 @@
     "loader-hack": "1.0.0",
     "nodejs-package": "1.0.0",
     "polyfill-package": "1.0.0",
+    "postmessage-lib": "1.0.0",
     "prototype-poisoning-package": "1.0.0",
     "resource-hack": "1.0.0",
     "side-effects-package": "1.0.0",

--- a/packages/webpack/test/fixtures/main/postmessage.js
+++ b/packages/webpack/test/fixtures/main/postmessage.js
@@ -1,0 +1,16 @@
+const {
+  notifyParent,
+  notifyTop,
+  notifyOpener,
+  abuseGlobals,
+} = require('postmessage-lib')
+
+abuseGlobals()
+
+notifyTop('Hello from the child frame')
+notifyParent('Hello from the child frame with target', 'http://localhost:8080')
+notifyOpener('Hello from the popup')
+
+if (window.opener) {
+  alert('I have an opener')
+}

--- a/packages/webpack/test/manual/postmessage/index.html
+++ b/packages/webpack/test/manual/postmessage/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <ul id="log"></ul>
+    <script>
+        window.addEventListener('message', function (e) {
+            console.log(e)
+            const li = document.createElement('li')
+            li.innerText = e.data;
+            document.getElementById('log').appendChild(li);
+        });
+
+        const w = window.open("./dist/index.html", "foo", "width=400,height=200");
+        setTimeout(() => {
+            w.close();
+        }, 10000);
+
+    </script>
+    <iframe id="iframe" src="./dist/index.html"></iframe>
+
+</body>
+
+</html>

--- a/packages/webpack/test/manual/postmessage/lavamoat/policy.json
+++ b/packages/webpack/test/manual/postmessage/lavamoat/policy.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "postmessage-lib": {
+      "globals": {
+        "console.error": true,
+        "opener": true,
+        "parent": true,
+        "top": true
+      }
+    }
+  }
+}

--- a/packages/webpack/test/manual/postmessage/run.sh
+++ b/packages/webpack/test/manual/postmessage/run.sh
@@ -1,0 +1,1 @@
+node --watch-path=./lavamoat --watch-path=../../../src --watch-path=../../fixtures test.js

--- a/packages/webpack/test/manual/postmessage/test.js
+++ b/packages/webpack/test/manual/postmessage/test.js
@@ -1,0 +1,59 @@
+// run this with node to produce the test build to disk
+const fs = require('node:fs')
+const path = require('node:path')
+const http = require('node:http')
+const { scaffold } = require('../../scaffold.js')
+const { makeConfig } = require('../../fixtures/main/webpack.config.js')
+const webpackConfig = makeConfig({
+  // generatePolicy: true,
+  policyLocation: path.resolve(__dirname, 'lavamoat'),
+})
+webpackConfig.entry = {
+  app: './postmessage.js',
+}
+webpackConfig.mode = 'development'
+webpackConfig.devtool = false
+
+const cache = new Set()
+function assertFolderFor(file) {
+  const folder = path.dirname(file)
+  if (cache.has(folder)) return
+  const target = folder.replace(/^\//, '')
+  fs.mkdirSync(path.join('.', target), { recursive: true })
+  cache.add(folder)
+}
+
+function writeFromSnapshot(snapshot) {
+  const files = Object.keys(snapshot)
+  for (const file of files) {
+    assertFolderFor(file)
+    fs.writeFileSync(path.join('.', file), snapshot[file])
+  }
+}
+
+scaffold(webpackConfig).then(({ stdout, snapshot }) => {
+  console.log(stdout)
+  writeFromSnapshot(snapshot)
+
+  const handler = async (req, res) => {
+    const filePath = path.join(
+      __dirname,
+      req.url === '/' ? 'index.html' : req.url
+    )
+    try {
+      const content = await fs.promises.readFile(filePath)
+      const ext = path.extname(filePath)
+      const contentType = ext === '.html' ? 'text/html' : 'text/javascript'
+      res.writeHead(200, { 'Content-Type': contentType })
+      res.end(content)
+    } catch (err) {
+      res.writeHead(404)
+      res.end('File not found')
+    }
+  }
+
+  const server = http.createServer(handler)
+  server.listen(8080, () => {
+    console.log('Server running at http://localhost:8080/')
+  })
+})


### PR DESCRIPTION
TODO:
- [ ] Decide what goes into core if any
- [ ] types
- [ ] do we want window.parent.parent? or more?
- [ ] what other fields should be emulated for best results? (assuming the candidates are only the fields that work for cross-origin realms)
- [ ] How does this pair with our intention to block creating realms by default in the future? In that case, would we even need it? Should it be made optionally pluggable for now (possible with how I build webpack runtime)?