### PR TITLE
chore(ci): bump GHA macOS image to 15 and run ava tests concurrently

### DIFF
--- a/.github/workflows/nodejs-macos.yml
+++ b/.github/workflows/nodejs-macos.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   compatibility-test-macos:
     name: Test macOS compatibility
-    runs-on: macOS-latest
+    runs-on: macos-15
     env:
       FORCE_COLOR: '1'
     steps:

--- a/packages/node/test/unit/scenario.spec.js
+++ b/packages/node/test/unit/scenario.spec.js
@@ -45,5 +45,5 @@ for await (const scenario of loadScenarios()) {
     continue
   }
 
-  test.serial(scenario.name ?? '(unknown scenario)', testScenario, scenario)
+  test(scenario.name ?? '(unknown scenario)', testScenario, scenario)
 }


### PR DESCRIPTION
- https://github.com/LavaMoat/LavaMoat/pull/1655#issuecomment-2880023170

our (i suspect `transform`) scenarios are flakey on macOS 14 in CI
when flakey, all scenarios timeout concurrently (ava default)

https://github.com/LavaMoat/LavaMoat/actions/runs/15007708025/job/42170295186

```
  Uncaught exception in test/unit/exec/execute.spec.js

  TypeError: Cannot read properties of undefined (reading 'default')
    at file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/@endo/evasive-transform/src/transform-ast.js:16:17
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:547:26)
    at async run (file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/ava/lib/worker/base.js:199:3)
    at async file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/ava/lib/worker/base.js:236:2

  › file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/@endo/evasive-transform/src/transform-ast.js:16:17
https://github.com/LavaMoat/LavaMoat/actions/runs/14764373374/job/41452423148
```

- https://github.com/LavaMoat/LavaMoat/actions/runs/14764373374/job/41452423148
- https://github.com/LavaMoat/LavaMoat/actions/runs/14893560582/job/41831214623

```
  Uncaught exception in test/unit/exec/execute.spec.js

  TypeError: Cannot read properties of undefined (reading 'default')
    at file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/@endo/module-source/src/transform-source.js:13:37
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:547:26)
    at async run (file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/ava/lib/worker/base.js:199:3)
    at async file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/ava/lib/worker/base.js:236:2

  › file:///Users/runner/work/LavaMoat/LavaMoat/node_modules/@endo/module-source/src/transform-source.js:13:37
```

`import babelTraverse from '@babel/traverse';` is `undefined` in
- `@endo/module-source/src/transform-source.js`
- `@endo/evasive-transform/src/transform-ast.js`

for some reason on macOS 14 (Darwin 23)
not macOS 15 (Darwin 24) locally

this simply bumps our CI to
https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
to solve the unknown problem we now have several clues about

if timeouts consist concurrently on macOS 15, then
- revert to `test.serial`
- figure why babelTraverse import is flakey on macOS 14/15