### PR TITLE
fix(webpack): undo the forced overwrite of parent and top references

### DIFF
--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -160,7 +160,7 @@ const installGlobalsForPolicy = (resourceId, packageCompartmentGlobal) => {
     )
     LAVAMOAT?.scuttling?.scuttle(
       theRealGlobalThis,
-      LAVAMOAT.options.scuttleGlobalThis
+      LAVAMOAT.options?.scuttleGlobalThis
     )
   } else {
     const endowments = getEndowmentsForConfig(

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -14,11 +14,7 @@ const {
   values,
 } = Object
 
-const {
-  lockdown,
-  Proxy,
-  Math, Date,
-} = globalThis
+const { lockdown, Proxy, Math, Date } = globalThis
 
 const warn = typeof console === 'object' ? console.warn : () => {}
 
@@ -35,9 +31,7 @@ if (LOCKDOWN_ON) {
 }
 
 // harden appears on globalThis only after lockdown is called
-const {
-  harden,
-} = globalThis
+const { harden } = globalThis
 
 const knownWritableFields = new Set()
 
@@ -148,7 +142,7 @@ const enforcePolicy = (specifier, referrerResourceId, wrappedRequire) => {
 const theRealGlobalThis = globalThis
 /** @type {any} */
 let rootCompartmentGlobalThis
-const globalAliases = ['window', 'self', 'global', 'globalThis', 'top', 'frames', 'parent']
+const globalAliases = ['window', 'self', 'global', 'globalThis', 'frames']
 /**
  * Installs globals for a specific policy resource.
  *
@@ -164,7 +158,10 @@ const installGlobalsForPolicy = (resourceId, packageCompartmentGlobal) => {
       rootCompartmentGlobalThis,
       globalAliases
     )
-    LAVAMOAT?.scuttling?.scuttle(theRealGlobalThis, LAVAMOAT.options.scuttleGlobalThis)
+    LAVAMOAT?.scuttling?.scuttle(
+      theRealGlobalThis,
+      LAVAMOAT.options.scuttleGlobalThis
+    )
   } else {
     const endowments = getEndowmentsForConfig(
       rootCompartmentGlobalThis,

--- a/packages/webpack/test/e2e-custom-globals.spec.js
+++ b/packages/webpack/test/e2e-custom-globals.spec.js
@@ -1,0 +1,89 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { scaffold, runScriptWithSES } = require('./scaffold.js')
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
+
+test.before(async (t) => {
+  // Test with allowed globals
+  const webpackConfigAllowed = makeConfig({
+    generatePolicy: false,
+    policy: {
+      resources: {
+        'globals-package': {
+          globals: {
+            console: true,
+            top: true,
+            parent: true,
+          },
+        },
+      },
+    },
+  })
+  const configAllowed = {
+    ...webpackConfigAllowed,
+    entry: {
+      app: './globals.js',
+    },
+    mode: 'development',
+  }
+
+  // Test with restricted globals
+  const webpackConfigRestricted = makeConfig({
+    generatePolicy: false,
+    policy: {
+      resources: {
+        'globals-package': {
+          globals: {
+            console: true,
+            top: false,
+            parent: false,
+          },
+        },
+      },
+    },
+  })
+  const configRestricted = {
+    ...webpackConfigRestricted,
+    entry: {
+      app: './globals.js',
+    },
+    mode: 'development',
+    target: 'web',
+  }
+
+  // Build both versions
+  await t.notThrowsAsync(async () => {
+    t.context.buildAllowed = await scaffold(configAllowed)
+  }, 'Expected the allowed globals build to succeed')
+
+  await t.notThrowsAsync(async () => {
+    t.context.buildRestricted = await scaffold(configRestricted)
+  }, 'Expected the restricted globals build to succeed')
+
+  t.context.bundleAllowed = t.context.buildAllowed.snapshot['/dist/app.js']
+  t.context.bundleRestricted =
+    t.context.buildRestricted.snapshot['/dist/app.js']
+})
+
+test('webpack/globals - allowing other realm names works', (t) => {
+  t.notThrows(() => {
+    runScriptWithSES(t.context.bundleAllowed, {
+      console,
+      top: {},
+      parent: {},
+    })
+  }, 'Should run without errors when globals are allowed')
+})
+
+test('webpack/globals - cannot reach disallowed realm references', (t) => {
+  t.throws(
+    () => {
+      runScriptWithSES(t.context.bundleRestricted, {
+        console,
+        top: {},
+        parent: {},
+      })
+    },
+    { message: /\.top should not be undefined/ },
+    'Should throw when globals are restricted'
+  )
+})

--- a/packages/webpack/test/fixtures/main/globals.js
+++ b/packages/webpack/test/fixtures/main/globals.js
@@ -1,0 +1,14 @@
+import { askMe } from 'globals-package'
+
+const values = askMe(['self', 'window', 'top', 'parent'])
+assert(!!values.self, 'Expected values.self to exist')
+assert(values.top !== undefined, 'values.top should not be undefined')
+assert(globalThis.top === values.top, 'globalThis.top should match values.top')
+assert(
+  globalThis.parent === values.parent,
+  'globalThis.parent should match values.parent'
+)
+assert(
+  values.window === values.self,
+  'globalThis.window should match values.self'
+)

--- a/packages/webpack/test/fixtures/main/node_modules/globals-package/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/globals-package/index.js
@@ -18,3 +18,9 @@ if(typeof self === 'undefined' || !self.console) {
 if(typeof global === 'undefined' || !global.console) {
   throw Error('global is missing')
 }
+
+module.exports = {
+  askMe(fields) {
+    return Object.fromEntries(fields.map(field => [field, globalThis[field]]))
+  }
+}


### PR DESCRIPTION
With https://github.com/LavaMoat/LavaMoat/pull/1659 needing more work because there's an expectation that `message.source === window.parent` etc. we need to stop forcefully overwriting parent and top.

In the future we'll provide a more narrow capability for postmessage. There's a few possible designs 