### PR TITLE
chore(ci): add a thing that updates coverage thresholds

### DIFF
--- a/.github/actions/coverage-threshold/action.yml
+++ b/.github/actions/coverage-threshold/action.yml
@@ -1,0 +1,43 @@
+name: 'Update Coverage Threshold'
+
+description: 'Updates the coverage thresholds for all packages having a test:cover script'
+
+outputs:
+  updated:
+    description: 'Whether or not the coverage thresholds were updated'
+    value: ${{ steps.check-updated.outputs.updated }}
+
+runs:
+  steps:
+    # test:cover should be using --check-coverage anyway, but this forces the issue;
+    # without it, coverage thresholds could decrease.
+    # we allow failures here because we're not running PR checks.
+    - id: check-coverage
+      run: |
+        npm run --workspaces --if-present test:cover -- --reporter=json-summary --check-coverage && echo "success=true" >> $GITHUB_OUTPUT || echo "success=false" >> $GITHUB_OUTPUT
+      shell: bash
+    - if: steps.check-coverage.outputs.success == 'true'
+      run: |
+        find packages/*/coverage -name coverage-summary.json -exec bash -c \
+          'jq ".total | map_values(.pct)" {} > $(dirname {})/../.c8rc' \;
+      shell: bash
+    - if: steps.check-coverage.outputs.success != 'true'
+      id: check-updated
+      run: |
+        echo "No coverage change due to error(s)."
+        echo "updated=false" >> $GITHUB_OUTPUT
+      shell: bash
+    - if: steps.check-coverage.outputs.success == 'true'
+      id: check-updated
+      run: |
+        UPDATED=$(git ls-files -mo -- packages/*/.c8rc)
+        if [ -n "$UPDATED" ]; then
+          echo "Updated/added files: $UPDATED"
+          echo "updated=true" >> $GITHUB_OUTPUT
+        else
+          echo "No coverage change."
+          echo "updated=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+  using: composite

--- a/.github/workflows/coverage-threshold.yml
+++ b/.github/workflows/coverage-threshold.yml
@@ -1,0 +1,34 @@
+name: Update Coverage Thresholds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+
+jobs:
+  update-coverage-thresholds:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: ./.github/actions/prepare
+      - id: coverage-threshold
+        uses: ./.github/actions/coverage-threshold
+      - if: steps.coverage-threshold.outputs.updated == 'true'
+        run: |
+          echo "Coverage thresholds updated"
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -n -m "chore: update coverage thresholds"
+      - if: steps.coverage-threshold.outputs.updated == 'true'
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+      - if: steps.coverage-threshold.outputs.updated != 'true'
+        run: echo "No coverage thresholds were updated"
+        shell: bash


### PR DESCRIPTION
For workspaces which have a `test:cover` script--presumably which uses `c8`--this automatically updates the `.c8rc` in each workspace if the coverage check passes. `.c8rc` controls the coverage threshold, which must pass on subsequent executions of `c8 --check-coverage`.

It is build as a scheduled or on-demand workflow which only works on the main branch.
I am not super enthusiastic about having commits automatically pushed to `main`. This is just one way to do it.

An alternative would be to automatically update `.c8rc` with the relevant contents of `coverage/coverage-summary.json` as a pre-commit hook; this is maybe a better idea, but we would likely want to write a custom JS script in lieu of `.github/actions/coverage-threshold/action.yml`.

The point is this: _if_ we want to maintain a high level of code coverage, we do not want it to ever drop. Developers will not remember to manually update the thresholds, so it should be automated. This is an experiment.