### PR TITLE
chore(eslint): use consistent type imports/exports in ts files

### DIFF
--- a/.config/eslintrc.typed-workspace.js
+++ b/.config/eslintrc.typed-workspace.js
@@ -38,6 +38,25 @@ module.exports = {
         {
           files: `./{src,test}/**/*.ts`,
           extends: ['plugin:@typescript-eslint/recommended-type-checked'],
+          rules: {
+            // this rule makes it so that when we export a type from a .ts file,
+            // we use the "export type" syntax
+            '@typescript-eslint/consistent-type-exports': [
+              'error',
+              { fixMixedExportsWithInlineTypeSpecifier: true },
+            ],
+
+            // this rule makes it so that when we import a type from a .ts file,
+            // we use the "import type" syntax
+            '@typescript-eslint/consistent-type-imports': [
+              'error',
+              {
+                disallowTypeAnnotations: true,
+                fixStyle: 'inline-type-imports',
+                prefer: 'type-imports',
+              },
+            ],
+          },
         },
         {
           files: `./{src,test}/**/*.js`,

--- a/.eslintignore
+++ b/.eslintignore
@@ -15,4 +15,5 @@ packages/viz/dist/**/*
 packages/viz/src/example-policies/**/*
 packages/yarn-plugin-allow-scripts/bundles
 packages/*/types
+packages/*/dist
 !/.github

--- a/packages/core/src/schema/ambient.ts
+++ b/packages/core/src/schema/ambient.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/consistent-type-imports, @typescript-eslint/no-namespace */
 
 /**
  * Because SES will barf if it encounters `import(...)`--even in comments--to

--- a/packages/core/src/schema/lavamoat-policy.v0-0-1.schema.ts
+++ b/packages/core/src/schema/lavamoat-policy.v0-0-1.schema.ts
@@ -1,4 +1,4 @@
-import { LavamoatModuleRecord } from '../moduleRecord'
+import { type LavamoatModuleRecord } from '../moduleRecord'
 
 /**
  * Schema for LavaMoat policy override files

--- a/packages/core/test/scenario.ts
+++ b/packages/core/test/scenario.ts
@@ -1,7 +1,10 @@
 import type { ExecutionContext } from 'ava'
-import { ModuleInitializer } from '../src/moduleRecord'
+import { type ModuleInitializer } from '../src/moduleRecord'
 import type { LavaMoatOpts } from '../src/options'
-import { LavaMoatPolicy, LavaMoatPolicyOverrides } from '../src/schema'
+import {
+  type LavaMoatPolicy,
+  type LavaMoatPolicyOverrides,
+} from '../src/schema'
 
 export type ScenarioType = 'truthy' | 'falsy' | 'deepEqual'
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -26,7 +26,7 @@ import type {
   ENDO_GLOBAL_POLICY_ITEM_WRITE,
   ENDO_POLICY_ITEM_ROOT,
 } from './constants.js'
-import { CompartmentMapToPolicyOptions } from './internal.js'
+import { type CompartmentMapToPolicyOptions } from './internal.js'
 
 /**
  * A loaded application which has not yet been executed

--- a/packages/node/test/stubs.d.ts
+++ b/packages/node/test/stubs.d.ts
@@ -4,6 +4,8 @@
 declare module 'lavamoat-core/test/util.js' {
   export interface PlatformRunScenarioOpts {
     // NOTE: this loads scenario.d.ts!
+    // ALSO: it cannot be replaced with an import statement because reasons
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     scenario: import('lavamoat-core/test/scenarios/scenario.js').NormalizedScenario<Result>
     runWithPrecompiledModules?: boolean
     log?: (...args: any[]) => void

--- a/packages/node/test/types.ts
+++ b/packages/node/test/types.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext } from 'ava'
 import type { LavaMoatPolicy } from 'lavamoat-core'
 import type { NestedDirectoryJSON } from 'memfs'
-import { ExecFileException } from 'node:child_process'
+import { type ExecFileException } from 'node:child_process'
 import type { Merge, RequireAtLeastOne, Simplify } from 'type-fest'
 import type { ScuttleGlobalThisOptions } from '../src/types.ts'
 

--- a/packages/node/test/unit/policy/types.ts
+++ b/packages/node/test/unit/policy/types.ts
@@ -1,10 +1,10 @@
 // FIXME: why did I have to add this? failing in CI
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 
-import { ReadNowPowers } from '@endo/compartment-mapper'
+import { type ReadNowPowers } from '@endo/compartment-mapper'
 import type { ExecutionContext } from 'ava'
 import type { LavaMoatPolicy } from 'lavamoat-core'
-import { Volume } from 'memfs/lib/volume.js'
+import { type Volume } from 'memfs/lib/volume.js'
 import type { Simplify } from 'type-fest'
 import type { GeneratePolicyOptions } from '../../../src/types.js'
 


### PR DESCRIPTION
This change configures ESLint to use the `typescript-eslint` rules [`consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) and [`consistent-type-exports`](https://typescript-eslint.io/rules/consistent-type-exports/).

In a nutshell, that means when we `import` or `export` _types_ from `.ts` sources, we use the `type` keyword so that it is clear we are only working with _types_ instead of values.

Applied fixes in second commit.
