### PR TITLE
chore(renovate): remove deprecated config option

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,5 +62,4 @@
       enabled: false,
     },
   ],
-  transitiveRemediation: true,
 }


### PR DESCRIPTION
`transitiveRemediation` is no longer supported

Ref: #1693