### PR TITLE
chore(ci): attempt to allow flaky macOS tests to re-run

### DIFF
--- a/.github/workflows/nodejs-macos.yml
+++ b/.github/workflows/nodejs-macos.yml
@@ -22,14 +22,14 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Build & Test
         uses: ./.github/actions/test
-  re-run:
+  rerun:
     name: Rerun flaky macOS tests
     needs: compatibility-test-macos
-    if: failure() && fromJSON(github.run_attempt) < 3
+    if: needs.compatibility-test-macos.result == 'failure' && fromJSON(github.run_attempt) < 3
     runs-on: macos-15
     steps:
       - env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
-        run: gh workflow run rerun.yml -F run_id=${{ github.run_id }} runner=macos-15
+        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} -f runner=macos-15

--- a/.github/workflows/nodejs-macos.yml
+++ b/.github/workflows/nodejs-macos.yml
@@ -22,3 +22,14 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Build & Test
         uses: ./.github/actions/test
+  re-run:
+    name: Rerun flaky macOS tests
+    needs: compatibility-test-macos
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: macos-15
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run rerun.yml -F run_id=${{ github.run_id }} runner=macos-15

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -18,5 +18,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run watch ${{ inputs.run_id }}
           gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'The ID of the workflow run to rerun'
+        required: true
+      runner:
+        description: 'The runner to use for the rerun'
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
The macOS tests fail regularly for unknown reasons.

This change should cause them to automatically retry twice before failing.

Ref: [this comment](https://github.com/orgs/community/discussions/67654#discussioncomment-8038649)
