### PR TITLE
fix(react-native-lockdown): add types

### DIFF
--- a/packages/react-native-lockdown/.eslintrc.js
+++ b/packages/react-native-lockdown/.eslintrc.js
@@ -1,0 +1,26 @@
+// TODO: use types when we determine what types to use
+module.exports = {
+  extends: ['../../.config/eslintrc.typed-workspace'],
+  parserOptions: {
+    sourceType: 'script',
+    ecmaVersion: 2020,
+  },
+  env: {
+    browser: false,
+    es6: false,
+    node: true,
+  },
+  overrides: [
+    {
+      files: ['./test/**/*.js'],
+      rules: {
+        // use t.log()
+        'no-console': 'error',
+
+        // of dubious value
+        'ava/use-t-well': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['./types/*', '**/*.tsbuildinfo'],
+}

--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -18,8 +18,14 @@
   },
   "main": "./src/index.js",
   "exports": {
-    ".": "./src/index.js",
-    "./repair": "./src/repair.js",
+    ".": {
+      "types": "./types/types.d.ts",
+      "default": "./src/index.js"
+    },
+    "./repair": {
+      "types": "./types/repair.d.ts",
+      "default": "./src/repair.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/react-native-lockdown/src/lockdown-serializer.ts
+++ b/packages/react-native-lockdown/src/lockdown-serializer.ts
@@ -1,0 +1,59 @@
+/**
+ * Types for `lockdownSerializer()`
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Input serializer configuration for `lockdownSerializer()`.
+ *
+ * @privateRemarks
+ * This should be the same type as `metro-config`'s `SerializerConfigT`; we only
+ * need a tiny slice of types from `metro-config` and it is not worth it to add
+ * as a production dependency.
+ * @see {@link https://github.com/facebook/metro/blob/main/packages/metro-config/types/configTypes.d.ts}
+ */
+export interface LockdownSerializerConfig {
+  getPolyfills?: GetPolyfillsFn
+
+  getRunModuleStatement?: GetRunModuleStatementFn
+
+  [key: PropertyKey]: unknown
+}
+
+/**
+ * Options for `lockdownSerializer()`
+ */
+export interface LockdownSerializerOptions {
+  /**
+   * Whether to enable Hermes runtime support (otherwise JavaScript Core).
+   * Default is `true`
+   */
+  hermesRuntime?: boolean
+}
+
+/**
+ * Result of calling `lockdownSerializer()`.
+ *
+ * This will not be the same object as the provided
+ * {@link LockdownSerializerConfig}.
+ */
+export type LockedDownSerializerConfig = Omit<
+  LockdownSerializerConfig,
+  'getRunModuleStatement' | 'getPolyfills'
+> & {
+  getRunModuleStatement: GetRunModuleStatementFn
+  getPolyfills: GetPolyfillsFn
+}
+
+/**
+ * @see {@link https://metrobundler.dev/docs/configuration/#getrunmodulestatement}
+ */
+export type GetRunModuleStatementFn = (moduleId: number | string) => string
+
+/**
+ * @see {@link https://metrobundler.dev/docs/configuration/#getpolyfills}
+ */
+export type GetPolyfillsFn = (options: {
+  platform: string | null
+}) => ReadonlyArray<string>

--- a/packages/react-native-lockdown/src/repair.js
+++ b/packages/react-native-lockdown/src/repair.js
@@ -1,3 +1,5 @@
+/// <reference types="ses" />
+
 /**
  * Repair JS intrinsics
  *

--- a/packages/react-native-lockdown/src/tsconfig.json
+++ b/packages/react-native-lockdown/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../.config/tsconfig.src.json",
+  "compilerOptions": {
+    "outDir": "../types"
+  },
+  "include": ["*.js", "*.ts"]
+}

--- a/packages/react-native-lockdown/src/types.ts
+++ b/packages/react-native-lockdown/src/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Entry point for `types` conditional export
+ *
+ * @packageDocumentation
+ */
+
+export type * from './index.js'
+export type * from './lockdown-serializer.js'

--- a/packages/react-native-lockdown/test/tsconfig.json
+++ b/packages/react-native-lockdown/test/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../.config/tsconfig.test.json",
+  "include": ["."],
+  "references": [{ "path": "../src/tsconfig.json" }]
+}

--- a/packages/react-native-lockdown/test/unit/assertPolyfills.spec.js
+++ b/packages/react-native-lockdown/test/unit/assertPolyfills.spec.js
@@ -1,4 +1,10 @@
-const test = require('ava')
+'use strict'
+
+/**
+ * @import {TestFn} from 'ava'
+ */
+
+const test = /** @type {TestFn} */ (/** @type {unknown} */ (require('ava')))
 const path = require('node:path')
 const { assertPolyfills } = require('../../src/index')
 

--- a/packages/react-native-lockdown/test/unit/lockdownSerializer.spec.js
+++ b/packages/react-native-lockdown/test/unit/lockdownSerializer.spec.js
@@ -1,12 +1,20 @@
-const test = require('ava')
+'use strict'
+
+/**
+ * @import {TestFn} from 'ava'
+ * @import {LockdownSerializerConfig} from '../../src/lockdown-serializer.js'
+ */
+
+const test = /** @type {TestFn} */ (/** @type {unknown} */ (require('ava')))
 const path = require('node:path')
 const { lockdownSerializer } = require('../../src/index')
 
 // Test lockdownSerializer
 test('lockdownSerializer - default', (t) => {
+  /** @type {LockdownSerializerConfig} */
   const originalConfig = {}
   const config = lockdownSerializer({}, originalConfig)
-  const polyfills = config.getPolyfills({})
+  const polyfills = config.getPolyfills({ platform: null })
   const sesPath = require.resolve('ses/hermes')
   t.is(typeof config.getRunModuleStatement, 'function')
   t.is(typeof config.getPolyfills, 'function')
@@ -20,7 +28,7 @@ test('lockdownSerializer - hermes true', (t) => {
     getPolyfills: () => [],
   }
   const config = lockdownSerializer({ hermesRuntime: true }, originalConfig)
-  const polyfills = config.getPolyfills({})
+  const polyfills = config.getPolyfills({ platform: null })
   const sesPath = require.resolve('ses/hermes')
   t.true(polyfills.length > 1)
   t.true(polyfills.some((p) => p === sesPath))
@@ -28,11 +36,12 @@ test('lockdownSerializer - hermes true', (t) => {
 })
 
 test('lockdownSerializer - hermes false', (t) => {
+  /** @type {LockdownSerializerConfig} */
   const originalConfig = {
     getPolyfills: () => [],
   }
   const config = lockdownSerializer({ hermesRuntime: false }, originalConfig)
-  const polyfills = config.getPolyfills({})
+  const polyfills = config.getPolyfills({ platform: null })
   const sesPath = require.resolve('ses')
   t.true(polyfills.length > 1)
   t.true(polyfills.some((p) => p === sesPath && !p.includes('hermes')))
@@ -45,7 +54,7 @@ test('lockdownSerializer - with custom polyfills', (t) => {
     getPolyfills: () => [customPolyfill],
   }
   const config = lockdownSerializer({}, originalConfig)
-  const polyfills = config.getPolyfills({})
+  const polyfills = config.getPolyfills({ platform: null })
   const sesPath = require.resolve('ses/hermes')
   t.true(polyfills.includes(customPolyfill))
   t.true(polyfills.length > 1)
@@ -54,6 +63,7 @@ test('lockdownSerializer - with custom polyfills', (t) => {
 })
 
 test('lockdownSerializer - getRunModuleStatement for entry file', (t) => {
+  /** @type {LockdownSerializerConfig} */
   const originalConfig = {
     getRunModuleStatement: (id) => `__r(${id})`,
     getPolyfills: () => [],
@@ -70,6 +80,7 @@ test('lockdownSerializer - invalid getPolyfills', (t) => {
   const originalConfig = {
     getPolyfills: 'not-a-function',
   }
+  // @ts-expect-error bad type
   t.throws(() => lockdownSerializer({}, originalConfig), {
     instanceOf: Error,
     message: 'Invalid options: getPolyfills must be a function',
@@ -77,6 +88,7 @@ test('lockdownSerializer - invalid getPolyfills', (t) => {
 })
 
 test('lockdownSerializer - snapshot', (t) => {
+  /** @type {LockdownSerializerConfig} */
   const originalConfig = {
     getRunModuleStatement: (moduleId) => `customRun(${moduleId})`,
     getPolyfills: () => ['customPolyfill.js'],

--- a/packages/react-native-lockdown/tsconfig.json
+++ b/packages/react-native-lockdown/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../.config/tsconfig.workspace.json",
+  "references": [
+    { "path": "./src/tsconfig.json" },
+    { "path": "./test/tsconfig.json" }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,9 @@
     },
     {
       "path": "./packages/node"
+    },
+    {
+      "path": "./packages/react-native-lockdown"
     }
   ]
 }


### PR DESCRIPTION
This configures `@lavamoat/react-native-lockdown` to ship type declarations. A custom ESLint config is also provided.