### PR TITLE
fix(deps): add @babel/types override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@babel/types": "7.27.3",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@endo/compartment-mapper": "1.6.2",
@@ -1906,17 +1907,6 @@
         "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@endo/module-source/node_modules/@babel/types": {
-      "version": "7.26.10",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "watch:types": "tsc -b --watch"
   },
   "devDependencies": {
+    "@babel/types": "7.27.3",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@endo/compartment-mapper": "1.6.2",
@@ -70,6 +71,7 @@
     "typescript": "5.8.3"
   },
   "overrides": {
+    "@babel/types": "$@babel/types",
     "@endo/compartment-mapper": "$@endo/compartment-mapper",
     "@types/node": "$@types/node",
     "cross-spawn": "7.0.6",


### PR DESCRIPTION
It appears the latest version of `@babel/types` is different enough from the version consumed by `@babel/traverse` that some things are no longer compatible. Forcing `@babel/types` into the latest version (as we have pinned) should make this problem go away.

Example error:

```
packages/tofu/src/findGlobals.js:93:18 - error TS2345: Argument of type 'NodePath<Identifier>' is not assignable to parameter of type 'NodePath<Identifier | ThisExpression>'.
  Type 'Identifier' is not assignable to type 'Identifier | ThisExpression'.
    Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Identifier' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Identifier'.
      Types of property 'decorators' are incompatible.
        Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Decorator[] | null | undefined' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Decorator[] | null | undefined'.
          Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Decorator[]' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Decorator[]'.
            Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Decorator' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Decorator'.
              Types of property 'expression' are incompatible.
                Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Expression' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Expression'.
                  Type 'ArrayExpression' is not assignable to type 'Expression'.
                    Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").ArrayExpression' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").ArrayExpression'.
                      Types of property 'elements' are incompatible.
                        Type '(import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").SpreadElement | import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Expression | null)[]' is not assignable to type '(import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").SpreadElement | import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Expression | null)[]'.
                          Type 'import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").SpreadElement | import("/Users/boneskull/projects/lavamoat/lavamoat/node_modules/@babel/types/lib/index").Expression | null' is not assignable to type 'import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").SpreadElement | import("/Users/boneskull/projects/lavamoat/lavamoat/packages/tofu/node_modules/@babel/types/lib/index").Expression | null'.
                            Type 'ArrayExpression' is not assignable to type 'SpreadElement | Expression | null'.

93       saveGlobal(path)
                    ~~~~
```
