### PR TITLE
create @lavamoat/vog

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,39 @@ jobs:
               --workspace=packages/preinstall-always-fail
               --workspace=packages/yarn-plugin-allow-scripts
           - node-version: 18.x
+            workspaces: >-
+              --workspace=packages/aa
+              --workspace=packages/allow-scripts
+              --workspace=packages/browserify
+              --workspace=packages/core
+              --workspace=packages/git-safe-dependencies
+              --workspace=packages/lavamoat-node
+              --workspace=packages/lavapack
+              --workspace=packages/laverna
+              --workspace=packages/node
+              --workspace=packages/preinstall-always-fail
+              --workspace=packages/react-native-lockdown
+              --workspace=packages/tofu
+              --workspace=packages/types
+              --workspace=packages/webpack
+              --workspace=packages/yarn-plugin-allow-scripts
           - node-version: 20.x
+            workspaces: >-
+              --workspace=packages/aa
+              --workspace=packages/allow-scripts
+              --workspace=packages/browserify
+              --workspace=packages/core
+              --workspace=packages/git-safe-dependencies
+              --workspace=packages/lavamoat-node
+              --workspace=packages/lavapack
+              --workspace=packages/laverna
+              --workspace=packages/node
+              --workspace=packages/preinstall-always-fail
+              --workspace=packages/react-native-lockdown
+              --workspace=packages/tofu
+              --workspace=packages/types
+              --workspace=packages/webpack
+              --workspace=packages/yarn-plugin-allow-scripts
           - node-version: 22.x
           - node-version: 24.x
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3571,6 +3571,10 @@
       "resolved": "packages/types",
       "link": true
     },
+    "node_modules/@lavamoat/vog": {
+      "resolved": "packages/vog",
+      "link": true
+    },
     "node_modules/@lavamoat/webpack": {
       "resolved": "packages/webpack",
       "link": true
@@ -3842,6 +3846,37 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@opentf/cli-pbar": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@opentf/cli-pbar/-/cli-pbar-0.7.2.tgz",
+      "integrity": "sha512-1367ENsch7Ybs0dFMhTkPU3cQNETl/F9bETgJc1TeKUaZG61Fhs+rsIlm8eVtEd2qC3z0bYaZ3b5Bpehcr7C1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentf/cli-styles": "^0.15.0",
+        "@opentf/std": "^0.5.0"
+      }
+    },
+    "node_modules/@opentf/cli-styles": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@opentf/cli-styles/-/cli-styles-0.15.0.tgz",
+      "integrity": "sha512-7eETZJLNCyOq6sX4W5up8l1IdTu0sf1qDdsBJ2KHx9u4rh3drFmMgF1ZoZ92K9oCiqzKAGqpCCjuasnRWbNLOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentf/std": "^0.3.0"
+      }
+    },
+    "node_modules/@opentf/cli-styles/node_modules/@opentf/std": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentf/std/-/std-0.3.0.tgz",
+      "integrity": "sha512-8Dtm0NqgoRi30FAUORo74SEruw2t2YlICxUy9nRpozzpbORCu4drpcAUq4stLsUY0bGHmFSZfZGpdA3wFamcwg==",
+      "license": "MIT"
+    },
+    "node_modules/@opentf/std": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opentf/std/-/std-0.5.1.tgz",
+      "integrity": "sha512-WIK/3Zwg8t6XeI3CJEEbK6wrC/uPkR7dk2DNWAhXqfql7NBCPjTb4NdXNSyChqMRY1qk+6E4/l32MaXk9x7+zA==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4024,6 +4059,15 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/cli-spinner": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/cli-spinner/-/cli-spinner-0.2.3.tgz",
+      "integrity": "sha512-TMO6mWltW0lCu1de8DMRq9+59OP/tEjghS+rs8ZEQ2EgYP5yV3bGw0tS14TMyJGqFaoVChNvhkVzv9RC1UgX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/coffeescript": {
@@ -8270,6 +8314,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinner": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.10.tgz",
+      "integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -8619,7 +8672,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -21027,6 +21079,21 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "packages/vog": {
+      "name": "@lavamoat/vog",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@opentf/cli-pbar": "0.7.2",
+        "@types/cli-spinner": "0.2.3",
+        "cli-spinner": "0.2.10",
+        "consola": "3.4.2"
+      },
+      "engines": {
+        "node": "^22.6.0 || ^24.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "packages/webpack": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "npm run --workspaces --if-present build && npm run build:types",
     "build:types": "tsc -b",
-    "clean:types": "git clean -fx -e \"**/node_modules/**\" \"packages/*/types/*.d.ts*\" \"*.tsbuildinfo\" || tsc -b --clean",
+    "clean:types": "git clean -fx -e \"**/node_modules/**\" \"packages/*/types/*.d.ts*\" \"*.tsbuildinfo\"; tsc -b --clean",
     "lint": "npm run lint:eslint && npm run lint:deps && npm run lint:lockfile",
     "lint:commit": "commitlint",
     "lint:deps": "npm run --workspaces --if-present lint:deps",

--- a/packages/vog/.gitignore
+++ b/packages/vog/.gitignore
@@ -1,0 +1,3 @@
+src/*.map
+src/*.js
+src/*.d.ts

--- a/packages/vog/LICENSE
+++ b/packages/vog/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Consensys Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/vog/README.md
+++ b/packages/vog/README.md
@@ -1,0 +1,131 @@
+# @lavamoat/vog
+
+> CLI utilities for [LavaMoat][]
+
+## Motivation
+
+We want a simple package we can use across LavaMoat CLI tools for common CLI needs.
+
+This package is mostly a thin wrapper around a few CLI libraries:
+
+- [consola][] for logging, colors, prompts & basic formatting
+- [@opentf/cli-pbar][] for progress bars
+- [cli-spinner][] for spinners
+
+## Prerequisites
+
+**Node.js**: `^22.6.0 || ^24.0.0`
+
+**This package is ESM-only.**
+
+## Install
+
+```bash
+npm install @lavamoat/vog
+```
+
+## Usage
+
+### Logging
+
+`@lavamoat/vog` provides a pre-configured stderr-only logger (`log`) and the abililty to create custom loggers:
+
+```typescript
+import { log } from '@lavamoat/vog'
+
+// Basic logging
+log.info('Starting process...')
+log.warn('This is a warning')
+log.error('Something went wrong')
+
+// Debug logging (only shown when LAVAMOAT_DEBUG is set or log level has
+// been manually changed)
+log.debug('Debug information')
+
+// Create a custom logger
+const customLog = log.create({
+  level: LogLevels.debug,
+  stdout: process.stdout, // Override to use stdout instead of stderr
+})
+```
+
+#### Default Logger Behavior
+
+- **Always** logs to stderr
+- No timestamps or dates
+- Fancy formatting for human pleasure
+
+#### Environment Variables
+
+- `LAVAMOAT_DEBUG`: When set to any truthy value, sets the log level of the default logger to "debug".
+
+### Progress Bars
+
+Courtesy of [@opentf/cli-pbar][].
+
+```typescript
+import { progress } from '@lavamoat/vog'
+
+const pBar = new progress.ProgressBar()
+pBar.start({ total: 100 })
+pBar.update({ value: 50 })
+pBar.update({ value: 100 })
+pBar.stop()
+```
+
+### Spinners
+
+Courtesy of [cli-spinner][].
+
+```typescript
+import { spinner } from '@lavamoat/vog'
+
+const spin = new spinner.Spinner('processing.. %s')
+spin.setSpinnerString('|/-\\')
+spin.start()
+spin.stop()
+```
+
+### Utilities
+
+Access to [consola][]'s utility functions are re-exported—in full—from the entrypoint. This gives quick access to colors, ASCII box and tree creation, text alignment, and other formatting utilities:
+
+```typescript
+import { yellow, box, log } from '@lavamoat/vog'
+
+const warning = yellow('This is a warning')
+const boxedWarning = box(warning, 'WARNING!')
+
+log(boxedWarning)
+```
+
+## Development Notes
+
+This package is an example of a project configured to use Node.js's [type stripping][] facilities.
+
+- It requires the following settings enabled in `tsconfig.json`:
+
+  ```json
+  {
+    "compilerOptions": {
+      "rewriteRelativeImportExtensions": true,
+      "verbatimModuleSyntax": true,
+      "erasableSyntaxOnly": true
+    }
+  }
+  ```
+
+- `compilerOptions.outDir` of anything _other_ than `.` appears to be forbidden (lookup `ts(2878)`); the output files in `src/` must be siblings.
+- Relative imports must have the `.ts` extension.
+- [@types/cli-spinner][] is a production dependency, since we re-export the associated package in full.
+
+## License
+
+Copyright © 2025 Consensys, Inc. Licensed MIT
+
+[consola]: https://www.npmjs.com/package/consola
+[@opentf/cli-pbar]: https://www.npmjs.com/package/@opentf/cli-pbar
+[cli-spinner]: https://www.npmjs.com/package/cli-spinner
+[@types/cli-spinner]: https://www.npmjs.com/package/@types/cli-spinner
+[lavamoat]: https://github.com/lavamoat/lavamoat
+[type stripping]: https://nodejs.org/api/typescript.html#type-stripping

--- a/packages/vog/package.json
+++ b/packages/vog/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@lavamoat/vog",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "CLI utilities for LavaMoat",
+  "repository": {
+    "directory": "packages/vog",
+    "type": "git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git"
+  },
+  "homepage": "https://lavamoat.github.io",
+  "bugs": "https://github.com/LavaMoat/LavaMoat/issues",
+  "author": "LavaMoat Project",
+  "license": "MIT",
+  "engines": {
+    "node": "^22.6.0 || ^24.0.0",
+    "npm": ">=9.0.0"
+  },
+  "exports": {
+    ".": {
+      "default": "./src/index.js",
+      "types": "./src/index.d.ts"
+    },
+    "./log": {
+      "default": "./src/log.js",
+      "types": "./src/log.d.ts"
+    },
+    "./package.json": "./package.json",
+    "./progress": {
+      "default": "./src/progress.js",
+      "types": "./src/progress.d.ts"
+    },
+    "./spinner": {
+      "default": "./src/spinner.js",
+      "types": "./src/spinner.d.ts"
+    }
+  },
+  "directories": {
+    "test": "test"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "src/**/*",
+    "!*.tsbuildinfo",
+    "!tsconfig.json"
+  ],
+  "scripts": {
+    "lint:deps": "depcheck",
+    "test": "node --test --experimental-strip-types",
+    "test:cover": "c8 npm test"
+  },
+  "dependencies": {
+    "@opentf/cli-pbar": "0.7.2",
+    "@types/cli-spinner": "0.2.3",
+    "cli-spinner": "0.2.10",
+    "consola": "3.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vog/src/index.ts
+++ b/packages/vog/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Main entry point. Barrel re-exporting everything else
+ *
+ * @packageDocumentation
+ */
+
+export * from './log.ts'
+export * from './progress.ts'
+export * from './spinner.ts'
+export * from './util.ts'

--- a/packages/vog/src/log.ts
+++ b/packages/vog/src/log.ts
@@ -1,0 +1,60 @@
+/**
+ * Provides a {@link log nice logger}.
+ *
+ * @packageDocumentation
+ * @see {@link https://www.npmjs.com/package/consola consola}
+ */
+
+import { type ConsolaOptions, createConsola, LogLevels } from 'consola'
+
+const { freeze } = Object
+
+/**
+ * Default options for the default logger.
+ *
+ * Exported so that you can reuse it to create another instance.
+ */
+const defaultOptions = freeze({
+  level: process.env.LAVAMOAT_DEBUG ? LogLevels.debug : LogLevels.info,
+  formatOptions: {
+    timestamp: false,
+    date: false,
+  },
+  fancy: true,
+  stdout: process.stderr,
+} as const) satisfies Readonly<
+  Partial<
+    ConsolaOptions & {
+      fancy: boolean
+    }
+  >
+>
+
+/**
+ * This is the default logger.
+ *
+ * It will _only_ log to stderr; _never_ to stdout. If you want to log to
+ * stdout, you can use `const myLog = log.create({ stdout: process.stdout })` to
+ * create a new logger.
+ *
+ * Any log level _less than 2_ (starting with {@link LogLevels.warn}) will
+ * _always_ log to stderr—regardless of configuration.
+ */
+const log = createConsola({
+  level: process.env.LAVAMOAT_DEBUG ? LogLevels.debug : LogLevels.info,
+  formatOptions: {
+    timestamp: false,
+    date: false,
+  },
+  stdout: process.stderr,
+})
+
+export type Logger = typeof log
+
+export {
+  log as defaultLog,
+  defaultOptions as defaultLoggerOptions,
+  log,
+  LogLevels,
+  type ConsolaOptions,
+}

--- a/packages/vog/src/progress.ts
+++ b/packages/vog/src/progress.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-exports
+ * {@link https://www.npmjs.com/package/progress-estimator progress-estimator} as
+ * `progress`.
+ *
+ * @packageDocumentation
+ */
+
+export * as progress from '@opentf/cli-pbar'

--- a/packages/vog/src/spinner.ts
+++ b/packages/vog/src/spinner.ts
@@ -1,0 +1,7 @@
+/**
+ * Re-exports {@link https://www.npmjs.com/package/ora ora} as `spinner`.
+ *
+ * @packageDocumentation
+ */
+
+export * as spinner from 'cli-spinner'

--- a/packages/vog/src/tsconfig.json
+++ b/packages/vog/src/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "emitDeclarationOnly": false,
+    "erasableSyntaxOnly": true,
+    "module": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
+    "stripInternal": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["*.d.ts", "*.js"],
+  "extends": "../../../.config/tsconfig.src.json",
+  "include": ["*.ts"]
+}

--- a/packages/vog/src/util.ts
+++ b/packages/vog/src/util.ts
@@ -1,0 +1,15 @@
+/**
+ * Re-export {@link https://npm.im/consola consola}'s utility functions.
+ *
+ * This includes:
+ *
+ * - Colors
+ * - ANSI escape code stripping
+ * - Box drawing
+ * - Text alignment
+ * - Tree drawing
+ *
+ * @packageDocumentation
+ */
+
+export * from 'consola/utils'

--- a/packages/vog/test/log.test.ts
+++ b/packages/vog/test/log.test.ts
@@ -1,0 +1,247 @@
+import { createConsola, LogLevels } from 'consola'
+import { strict as assert } from 'node:assert'
+import { afterEach, beforeEach, describe, it, mock } from 'node:test'
+import {
+  type Logger,
+  defaultLog,
+  defaultLoggerOptions,
+  log,
+} from '../src/log.ts'
+
+describe('@lavamoat/vog: logging', () => {
+  let originalEnv: string | undefined
+  // why isn't the `Mock` type exported???
+  let stderrWriteMock: ReturnType<
+    typeof mock.method<typeof process.stderr, 'write'>
+  >
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = process.env.LAVAMOAT_DEBUG
+
+    // Mock stderr using Node.js test mocking API
+    stderrWriteMock = mock.method(process.stderr, 'write', () => true)
+  })
+
+  afterEach(() => {
+    // Restore original environment
+    if (originalEnv === undefined) {
+      delete process.env.LAVAMOAT_DEBUG
+    } else {
+      process.env.LAVAMOAT_DEBUG = originalEnv
+    }
+
+    // Restore all mocks
+    mock.restoreAll()
+  })
+
+  describe('exports', () => {
+    it('should export the expected members', () => {
+      assert.ok(log, 'log should be exported')
+      assert.ok(defaultLog, 'defaultLog should be exported')
+      assert.ok(defaultLoggerOptions, 'defaultLoggerOptions should be exported')
+      assert.ok(LogLevels, 'LogLevels should be exported')
+    })
+
+    it('should export log and defaultLog as the same instance', () => {
+      assert.strictEqual(
+        log,
+        defaultLog,
+        'log and defaultLog should be the same instance'
+      )
+    })
+  })
+
+  describe('defaultLoggerOptions', () => {
+    it('should have correct default options', () => {
+      assert.strictEqual(defaultLoggerOptions.level, LogLevels.info)
+      assert.strictEqual(defaultLoggerOptions.formatOptions.timestamp, false)
+      assert.strictEqual(defaultLoggerOptions.formatOptions.date, false)
+      assert.strictEqual(defaultLoggerOptions.fancy, true)
+      assert.strictEqual(defaultLoggerOptions.stdout, process.stderr)
+    })
+
+    it('should be frozen', () => {
+      assert.ok(Object.isFrozen(defaultLoggerOptions))
+    })
+
+    it('should respect LAVAMOAT_DEBUG environment variable', () => {
+      // Test with debug enabled - we can't easily test dynamic imports in this context
+      // so we'll test the logic directly
+      process.env.LAVAMOAT_DEBUG = '1'
+
+      // Test the same logic that's used in the module
+      const debugLevel = process.env.LAVAMOAT_DEBUG
+        ? LogLevels.debug
+        : LogLevels.info
+      assert.strictEqual(debugLevel, LogLevels.debug)
+
+      // Reset and test without debug
+      delete process.env.LAVAMOAT_DEBUG
+      const infoLevel = process.env.LAVAMOAT_DEBUG
+        ? LogLevels.debug
+        : LogLevels.info
+      assert.strictEqual(infoLevel, LogLevels.info)
+    })
+  })
+
+  describe('default logger instance', () => {
+    it('should be a consola instance', () => {
+      assert.ok(typeof log.info === 'function')
+      assert.ok(typeof log.warn === 'function')
+      assert.ok(typeof log.error === 'function')
+      assert.ok(typeof log.debug === 'function')
+    })
+
+    it('should log to stderr by default', () => {
+      log.info('test message')
+      assert.ok(stderrWriteMock.mock.calls.length > 0)
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(output.includes('test message'))
+    })
+
+    it('should have info level by default', () => {
+      // Reset mock calls
+      stderrWriteMock.mock.resetCalls()
+
+      log.debug('debug message')
+      log.info('info message')
+
+      // Debug should not appear (level is info), info should appear
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(!output.includes('debug message'))
+      assert.ok(output.includes('info message'))
+    })
+
+    it('should support different log levels', () => {
+      stderrWriteMock.mock.resetCalls()
+
+      log.error('error message')
+      log.warn('warn message')
+      log.info('info message')
+
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(output.includes('error message'))
+      assert.ok(output.includes('warn message'))
+      assert.ok(output.includes('info message'))
+    })
+
+    it('should create new logger instances with custom options', () => {
+      const customLog = log.create({
+        level: LogLevels.debug,
+        stdout: process.stdout,
+      })
+
+      assert.notStrictEqual(customLog, log)
+      assert.ok(typeof customLog.info === 'function')
+    })
+  })
+
+  describe('Logger type', () => {
+    it('should be compatible with consola logger', () => {
+      const testLogger: Logger = createConsola()
+      assert.ok(typeof testLogger.info === 'function')
+      assert.ok(typeof testLogger.warn === 'function')
+      assert.ok(typeof testLogger.error === 'function')
+      assert.ok(typeof testLogger.debug === 'function')
+    })
+  })
+
+  describe('environment variable behavior', () => {
+    it('should use debug level when LAVAMOAT_DEBUG is set', () => {
+      process.env.LAVAMOAT_DEBUG = 'true'
+
+      // Create a new consola instance with the same logic as the module
+      const testLog = createConsola({
+        level: process.env.LAVAMOAT_DEBUG ? LogLevels.debug : LogLevels.info,
+        formatOptions: {
+          timestamp: false,
+          date: false,
+        },
+        stdout: process.stderr,
+      })
+
+      stderrWriteMock.mock.resetCalls()
+      testLog.debug('debug test')
+
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(output.includes('debug test'))
+    })
+
+    it('should use info level when LAVAMOAT_DEBUG is not set', () => {
+      delete process.env.LAVAMOAT_DEBUG
+
+      // Create a new consola instance with the same logic as the module
+      const testLog = createConsola({
+        level: process.env.LAVAMOAT_DEBUG ? LogLevels.debug : LogLevels.info,
+        formatOptions: {
+          timestamp: false,
+          date: false,
+        },
+        stdout: process.stderr,
+      })
+
+      stderrWriteMock.mock.resetCalls()
+      testLog.debug('debug test')
+      testLog.info('info test')
+
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(!output.includes('debug test'))
+      assert.ok(output.includes('info test'))
+    })
+  })
+
+  describe('format options', () => {
+    it('should disable timestamp and date formatting', () => {
+      stderrWriteMock.mock.resetCalls()
+      log.info('timestamp test')
+
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      // Output should not contain timestamp patterns
+      assert.ok(
+        !/\d{4}-\d{2}-\d{2}/.test(output),
+        'Should not contain date pattern'
+      )
+      assert.ok(
+        !/\d{2}:\d{2}:\d{2}/.test(output),
+        'Should not contain time pattern'
+      )
+    })
+  })
+
+  describe('stderr output behavior', () => {
+    it('should always output to stderr regardless of log level', () => {
+      stderrWriteMock.mock.resetCalls()
+
+      log.error('error to stderr')
+      log.warn('warn to stderr')
+      log.info('info to stderr')
+
+      const output = stderrWriteMock.mock.calls
+        .map((call) => `${call.arguments[0]}`)
+        .join('')
+      assert.ok(output.includes('error to stderr'))
+      assert.ok(output.includes('warn to stderr'))
+      assert.ok(output.includes('info to stderr'))
+    })
+
+    it('should allow creating custom logger with stdout output', () => {
+      const customLog = log.create({ stdout: process.stdout })
+
+      // This test verifies the API works, actual stdout capture would be more complex
+      assert.ok(typeof customLog.info === 'function')
+    })
+  })
+})

--- a/packages/vog/test/tsconfig.json
+++ b/packages/vog/test/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
+    "module": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "rootDir": "..",
+    "strict": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  },
+  "extends": "../../../.config/tsconfig.test.json",
+  "include": ["."],
+  "references": [
+    {
+      "path": "../src/tsconfig.json"
+    }
+  ]
+}

--- a/packages/vog/tsconfig.json
+++ b/packages/vog/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../.config/tsconfig.workspace.json",
+  "files": [],
+  "references": [
+    {
+      "path": "./src/tsconfig.json"
+    },
+    {
+      "path": "./test/tsconfig.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
-  "files": [],
   "compilerOptions": {
     "allowJs": true
   },
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "files": [],
   // the workspaces which are consumed as libraries by other workspaces should
   // be first in this list
   "references": [
+    {
+      "path": "packages/vog"
+    },
     {
       "path": "packages/types"
     },
@@ -32,7 +35,7 @@
       "path": "packages/node"
     },
     {
-      "path": "./packages/react-native-lockdown"
+      "path": "packages/react-native-lockdown"
     }
   ]
 }


### PR DESCRIPTION
This creates `@lavamoat/vog` ~~(and subsequently adopts it in `@lavamoat/node`, though I should probably split that into a second PR)~~.

This is a general-purpose library for LavaMoat's CLI tools. It includes:

- Logger
- Progress bars
- Spinners
- Prompts
- Colors
- Other various formatting utils

Yes, [vog is a thing](https://en.wikipedia.org/wiki/Vog).

Currently, it is an ES module with TS sources, which may want to change. I would prefer to publish a dual-module package, but that would require adopting a tool like [tshy](https://npm.im/tshy) or [tsup](https://tsup.egoist.dev). Might not be a bad idea anyway, but I don't want to block this PR on that decision.

**UPDATE Sep 10 2025**: This package no longer targets #1593 and instead targets `main`. It only adds the package itself.  It uses `node:test` instead of AVA and leverages type-stripping. Changes outside the package are limited to:

- Update root `tsconfig.json` to build `vog`
- Update `clean:types` script to _always_ call `tsc -b --clean`, which should catch things that the `git` command would not (needed to clean `vog`)
- Lockfile update