### PR TITLE
chore: update package versions

### DIFF
--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/react-native-lockdown",
-  "version": "0.0.1-beta.0",
+  "version": "0.0.1",
   "description": "LavaMoat React Native lockdown for running Hardened JavaScript in React Native apps",
   "repository": {
     "type": "git",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/webpack",
-  "version": "0.10.0-beta.0",
+  "version": "1.0.0",
   "description": "LavaMoat Webpack plugin for running dependencies in Compartments without eval",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] bump webpack from beta to `1.0.0`
- [x] update react-native-lockdown to `0.0.1` (drop the _beta_ hassle)