### PR TITLE
chore: update release-please configuration

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,15 @@
 {
   "packages/aa": "4.3.2",
   "packages/allow-scripts": "3.3.3",
-  "packages/webpack": "0.10.0-beta.0",
   "packages/browserify": "18.1.6",
   "packages/core": "16.4.0",
   "packages/git-safe-dependencies": "0.2.2",
   "packages/lavapack": "7.0.9",
   "packages/laverna": "1.2.4",
   "packages/lavamoat-node": "9.0.9",
+  "packages/node": "0.2.0",
   "packages/preinstall-always-fail": "2.1.0",
+  "packages/react-native-lockdown": "0.0.1",
   "packages/tofu": "8.0.7",
-  "packages/node": "0.2.0"
+  "packages/webpack": "0.10.0-beta.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,5 @@
   "packages/preinstall-always-fail": "2.1.0",
   "packages/react-native-lockdown": "0.0.1",
   "packages/tofu": "8.0.7",
-  "packages/webpack": "0.10.0-beta.0"
+  "packages/webpack": "1.0.0"
 }

--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/react-native-lockdown",
-  "version": "0.0.1-beta.0",
+  "version": "0.0.1",
   "description": "LavaMoat React Native lockdown for running Hardened JavaScript in React Native apps",
   "repository": {
     "type": "git",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "packages": {
     "packages/aa": {},
     "packages/allow-scripts": {},
-    "packages/webpack": {},
     "packages/browserify": {},
     "packages/core": {},
     "packages/git-safe-dependencies": {
@@ -13,11 +12,15 @@
     "packages/lavapack": {},
     "packages/laverna": {},
     "packages/lavamoat-node": {},
-    "packages/preinstall-always-fail": {},
-    "packages/tofu": {},
     "packages/node": {
       "initial-version": "0.0.1"
-    }
+    },
+    "packages/preinstall-always-fail": {},
+    "packages/react-native-lockdown": {
+      "initial-version": "0.0.1"
+    },
+    "packages/tofu": {},
+    "packages/webpack": {}
   },
   "plugins": ["node-workspace"]
 }


### PR DESCRIPTION
- [x] close https://github.com/LavaMoat/LavaMoat/pull/1718
- [x] bump webpack from `0.10.0-beta.0` to `1.0.0` via release-please
- [x] update react-native-lockdown to `0.0.1` (drop the _beta_ hassle)
- [x] add react-native-lockdown to release-please with `0.0.1`
