### PR TITLE
chore: update release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,10 +17,12 @@
     },
     "packages/preinstall-always-fail": {},
     "packages/react-native-lockdown": {
-      "initial-version": "0.0.1"
+      "release-as": "0.0.1"
     },
     "packages/tofu": {},
-    "packages/webpack": {}
+    "packages/webpack": {
+      "release-as": "1.0.0"
+    }
   },
   "plugins": ["node-workspace"]
 }


### PR DESCRIPTION
* webpack release-as 1.0.0
* react-native-lockdown release-as 0.0.1

`release-as`
not in docs https://github.com/googleapis/release-please/blob/main/docs/cli.md
but its here https://github.com/googleapis/release-please/blob/main/schemas/config.json treat as ephemeral (can now be removed)