### PR TITLE
chore(react-native-lockdown): fix publish config

### DIFF
--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -45,6 +45,9 @@
   "devDependencies": {
     "@react-native/js-polyfills": "0.79.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "ava": {
     "files": [
       "test/**/*.spec.js"


### PR DESCRIPTION
Scoped packages are assumed private by npm, so any scoped package which should be public must have an appropriate `publishConfig` in its `package.json`.

I fudged this for the release.
