### PR TITLE
chore(aa): disable symlink perf test on all darwin

### DIFF
--- a/packages/aa/test/symlink-perf.spec.js
+++ b/packages/aa/test/symlink-perf.spec.js
@@ -39,7 +39,7 @@ test.after(async (t) => {
 })
 
 // FIXME: this test fails on darwin running in GH actions; diagnose and fix
-if (process.platform === 'darwin' && process.env.CI) {
+if (process.platform === 'darwin') {
   test.todo(
     '[bench] isSymlink is significantly faster than realpathSync in a naive microbenchmark [darwin]'
   )


### PR DESCRIPTION
The symlink perf test was disabled in CI on darwin, but it needs to be disabled on darwin regardless of CI env.

This was preventing a release thru the usual process (test first).
