### PR TITLE
fix(react-native-lockdown): add vendor directory when creating tarball

### DIFF
--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -31,6 +31,7 @@
   "files": [
     "CHANGELOG.md",
     "src",
+    "vendor",
     "types",
     "!*.tsbuildinfo"
   ],


### PR DESCRIPTION
before

```log
➜  react-native-lockdown git:(leotm/fix-add-vendor-directory-to-tarball) npm pack
npm notice
npm notice 📦  @lavamoat/react-native-lockdown@0.0.1
npm notice Tarball Contents
npm notice 689B CHANGELOG.md
npm notice 1.1kB LICENSE
npm notice 4.9kB README.md
npm notice 1.3kB package.json
npm notice 6.5kB src/index.js
npm notice 1.6kB src/lockdown-serializer.ts
npm notice 2.2kB src/repair.js
npm notice 138B src/tsconfig.json
npm notice 161B src/types.ts
npm notice Tarball Details
npm notice name: @lavamoat/react-native-lockdown
npm notice version: 0.0.1
npm notice filename: lavamoat-react-native-lockdown-0.0.1.tgz
npm notice package size: 6.9 kB
npm notice unpacked size: 18.6 kB
npm notice shasum: 1b2d39df47c78248de8d57ff6ea0d91564a405d9
npm notice integrity: sha512-pX8Nj4+oEgVSC[...]UA0sXtIhZfePg==
npm notice total files: 9
npm notice
lavamoat-react-native-lockdown-0.0.1.tgz
```

after

```log
➜  react-native-lockdown git:(leotm/fix-add-vendor-directory-to-tarball) npm pack
npm notice
npm notice 📦  @lavamoat/react-native-lockdown@0.0.1
npm notice Tarball Contents
npm notice 689B CHANGELOG.md
npm notice 1.1kB LICENSE
npm notice 4.9kB README.md
npm notice 1.3kB package.json
npm notice 6.5kB src/index.js
npm notice 1.6kB src/lockdown-serializer.ts
npm notice 2.2kB src/repair.js
npm notice 138B src/tsconfig.json
npm notice 161B src/types.ts
npm notice 471.8kB vendor/ses-hermes.cjs
npm notice 471.8kB vendor/ses.cjs
npm notice Tarball Details
npm notice name: @lavamoat/react-native-lockdown
npm notice version: 0.0.1
npm notice filename: lavamoat-react-native-lockdown-0.0.1.tgz
npm notice package size: 227.7 kB
npm notice unpacked size: 962.2 kB
npm notice shasum: a7d4ca6f31bd32e9b6744590e8f9b9af6554647e
npm notice integrity: sha512-gY80XkzYa1A6l[...]YJo6hv7y+3dWw==
npm notice total files: 11
npm notice
lavamoat-react-native-lockdown-0.0.1.tgz
```

nb: `vendor` directory being replaced by <s>`ses@1.13.2`</s> `ses@1.14.0` when its out

nb: `yarn cache clean` is a _must_ locally testing .tgz's with same name in yarn v1 repos
