### PR TITLE
chore: update release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,15 +35,13 @@
       "package-name": "@lavamoat/preinstall-always-fail"
     },
     "packages/react-native-lockdown": {
-      "package-name": "@lavamoat/react-native-lockdown",
-      "release-as": "0.0.1"
+      "package-name": "@lavamoat/react-native-lockdown"
     },
     "packages/tofu": {
       "package-name": "lavamoat-tofu"
     },
     "packages/webpack": {
-      "package-name": "@lavamoat/webpack",
-      "release-as": "1.0.0"
+      "package-name": "@lavamoat/webpack"
     }
   },
   "plugins": ["node-workspace"]


### PR DESCRIPTION
Part 2 of
- https://github.com/LavaMoat/LavaMoat/pull/1720

* remove ephemeral webpack 'release-as' config, now v1.0.0 released
* remove ephemeral react-native-lockdown 'release-as' config, now v0.0.1 released