### PR TITLE
chore(ci): cleanup release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,6 @@
       "package-name": "lavamoat-core"
     },
     "packages/git-safe-dependencies": {
-      "initial-version": "0.0.1",
       "package-name": "@lavamoat/git-safe-dependencies"
     },
     "packages/lavapack": {
@@ -28,8 +27,7 @@
       "package-name": "lavamoat"
     },
     "packages/node": {
-      "package-name": "@lavamoat/node",
-      "initial-version": "0.0.1"
+      "package-name": "@lavamoat/node"
     },
     "packages/preinstall-always-fail": {
       "package-name": "@lavamoat/preinstall-always-fail"


### PR DESCRIPTION
Follow-up to
- https://github.com/LavaMoat/LavaMoat/pull/1732

(config like `release-as` and `initial-version` is only needed as a one-off for that release, then no longer needed)