### PR TITLE
feat(webpack): defend webpack runtime from scuttling

### DIFF
--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -29,13 +29,16 @@ module.exports = {
        * @returns {string}
        */
       getDefensiveCodingPreamble() {
-        return `
-const {
-  setTimeout, clearTimeout,
-  setInterval, clearInterval,
-  document, self, location
-} = globalThis
-`
+        const globals = [
+          'setTimeout',
+          'clearTimeout',
+          'setInterval',
+          'clearInterval',
+          'document',
+          'self',
+          'location',
+        ]
+        return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};`
       },
       /**
        * Generates the LavaMoat runtime source code based on chunk configuration

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -34,6 +34,7 @@ module.exports = {
           'setTimeout', // LoadScriptRuntimeModule.js
           'clearTimeout', // LoadScriptRuntimeModule.js
           'document', // LoadScriptRuntimeModule.js, AutoPublicPathRuntimeModule.js
+          'trustedTypes', // GetTrustedTypesPolicyRuntimeModule.js
           'self',
         ]
         return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};`

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -30,13 +30,11 @@ module.exports = {
        */
       getDefensiveCodingPreamble() {
         const globals = [
-          'setTimeout',
-          'clearTimeout',
-          'setInterval',
-          'clearInterval',
-          'document',
+          'location', // AutoPublicPathRuntimeModule.js
+          'setTimeout', // LoadScriptRuntimeModule.js
+          'clearTimeout', // LoadScriptRuntimeModule.js
+          'document', // LoadScriptRuntimeModule.js, AutoPublicPathRuntimeModule.js
           'self',
-          'location',
         ]
         return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};`
       },

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -22,6 +22,22 @@ module.exports = {
 
     return {
       /**
+       * Generates the preamble that caches selected globals to protect runtime
+       * from scuttling. The set of cached globals is limited to ones known to
+       * be used by runtime modules for the sake of bundle size.
+       *
+       * @returns {string}
+       */
+      getDefensiveCodingPreamble() {
+        return `
+const {
+  setTimeout, clearTimeout,
+  setInterval, clearInterval,
+  document, self, location
+} = globalThis
+`
+      },
+      /**
        * Generates the LavaMoat runtime source code based on chunk configuration
        *
        * @param {Object} params - The parameters object


### PR DESCRIPTION
Addresses issues with webpack runtime modules using scuttled globals.
fixes: https://github.com/MetaMask/metamask-extension/issues/34300

caveats and considerations:
- [x] consider&decide: lavamoat runtime chunk got moved later in the runtime concatenation so that it can potentially tweak other runtime modules in the future; on the other hand, if we didn't need it to be so, we could have one runtime chunk be added without closure and share the scope caching
- [x] destructuring from globalThis is less repetetive, but more problematic if the fields are not there (eg. `location` in node.js) - I think we'll have to fall back to `var NAME = globalThis.NAME`