### PR TITLE
feat(webpack): properly expose types for the plugin

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -18,8 +18,16 @@
     "npm": ">=7.0.0"
   },
   "main": "src/plugin.js",
+  "types": "types/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/plugin.d.ts",
+      "default": "./src/plugin.js"
+    }
+  },
   "files": [
-    "src"
+    "src",
+    "types"
   ],
   "keywords": [
     "webpack",

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -1,15 +1,9 @@
-import type { LavaMoatPolicy } from 'lavamoat-core'
+import type { LavaMoatPolicy, LavaMoatScuttleOpts } from 'lavamoat-core'
 import type { LockdownOptions } from 'ses'
 
-export interface ScuttlerObjectConfig {
-  enabled?: boolean
-  exceptions?: string[]
-  scuttlerName?: string
-}
+export type ScuttlerConfig = LavaMoatScuttleOpts | boolean | undefined
 
-export type ScuttlerConfig = ScuttlerObjectConfig | boolean | undefined
-
-export interface LavaMoatPluginOptions {
+export interface CompleteLavaMoatPluginOptions {
   generatePolicy?: boolean
   rootDir?: string
   policyLocation: string
@@ -26,3 +20,5 @@ export interface LavaMoatPluginOptions {
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp
 }
+
+export type LavaMoatPluginOptions = Partial<CompleteLavaMoatPluginOptions>

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -26,8 +26,16 @@ const {
 const { loadCanonicalNameMap } = require('@lavamoat/aa')
 
 /**
+ * This is jsdoc for reexport
+ *
+ * @typedef {import('./buildtime/types').LavaMoatPluginOptions} LavaMoatPluginOptions
+ */
+
+/**
+ * Just import
+ *
  * @import {LockdownOptions} from 'ses'
- * @import {LavaMoatPluginOptions, ScuttlerConfig} from './buildtime/types'
+ * @import {CompleteLavaMoatPluginOptions} from './buildtime/types'
  * @import {CanonicalNameMap} from '@lavamoat/aa'
  * @import {LavaMoatPolicy} from 'lavamoat-core'
  */
@@ -65,12 +73,6 @@ class VirtualRuntimeModule extends RuntimeModule {
   }
 }
 
-/**
- * @typedef {LavaMoatPluginOptions} LavaMoatPluginOptions
- *
- * @typedef {ScuttlerConfig} ScuttlerConfig
- */
-
 // =================================================================
 // Plugin code
 // =================================================================
@@ -91,10 +93,10 @@ const lockdownDefaults = /** @type {const} */ ({
 
 class LavaMoatPlugin {
   /**
-   * @param {Partial<LavaMoatPluginOptions>} [options]
+   * @param {LavaMoatPluginOptions} [options]
    */
   constructor(options = {}) {
-    /** @type {LavaMoatPluginOptions} */
+    /** @type {CompleteLavaMoatPluginOptions} */
     if (options.scuttleGlobalThis === true) {
       options.scuttleGlobalThis = { enabled: true }
     } else if (typeof options.scuttleGlobalThis === 'object') {
@@ -122,7 +124,7 @@ class LavaMoatPlugin {
   apply(compiler) {
     /**
      * @typedef {Object} Store
-     * @property {LavaMoatPluginOptions} options
+     * @property {CompleteLavaMoatPluginOptions} options
      * @property {WebpackError[]} [mainCompilationWarnings]
      * @property {(string | number)[]} chunkIds Array of chunk ids that have
      *   been processed.
@@ -572,7 +574,7 @@ class LavaMoatPlugin {
     )
   }
 }
-
-LavaMoatPlugin.exclude = EXCLUDE_LOADER
-
 module.exports = LavaMoatPlugin
+
+module.exports.LavaMoatPlugin = LavaMoatPlugin
+module.exports.exclude = EXCLUDE_LOADER

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -96,7 +96,6 @@ class LavaMoatPlugin {
    * @param {LavaMoatPluginOptions} [options]
    */
   constructor(options = {}) {
-    /** @type {CompleteLavaMoatPluginOptions} */
     if (options.scuttleGlobalThis === true) {
       options.scuttleGlobalThis = { enabled: true }
     } else if (typeof options.scuttleGlobalThis === 'object') {
@@ -107,6 +106,7 @@ class LavaMoatPlugin {
       }
     }
 
+    /** @type {CompleteLavaMoatPluginOptions} */
     this.options = {
       policyLocation: path.join('lavamoat', 'webpack'),
       lockdown: lockdownDefaults,

--- a/packages/webpack/src/runtime/runtime-namespace.ts
+++ b/packages/webpack/src/runtime/runtime-namespace.ts
@@ -1,5 +1,5 @@
-import { EndowmentsToolkitFactory, LavaMoatPolicy } from 'lavamoat-core'
-import { LavaMoatPluginOptions, ScuttlerConfig } from '../buildtime/types'
+import type { EndowmentsToolkitFactory, LavaMoatPolicy } from 'lavamoat-core'
+import type { LavaMoatPluginOptions, ScuttlerConfig } from '../buildtime/types'
 
 type DebugTools = {
   debugProxy: (target: any, source: object, hint: string) => void

--- a/packages/webpack/src/runtime/runtime-namespace.ts
+++ b/packages/webpack/src/runtime/runtime-namespace.ts
@@ -1,5 +1,5 @@
 import { EndowmentsToolkitFactory, LavaMoatPolicy } from 'lavamoat-core'
-import { LavaMoatPluginOptions, ScuttlerConfig } from '../plugin'
+import { LavaMoatPluginOptions, ScuttlerConfig } from '../buildtime/types'
 
 type DebugTools = {
   debugProxy: (target: any, source: object, hint: string) => void
@@ -7,7 +7,12 @@ type DebugTools = {
 
 type RequiredProperty<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export interface RuntimeNamespace {
-  scuttling: {scuttle: (globalThis: Record<string, unknown>, scuttleGlobalThis: ScuttlerConfig) => {}}
+  scuttling: {
+    scuttle: (
+      globalThis: Record<string, unknown>,
+      scuttleGlobalThis: ScuttlerConfig
+    ) => {}
+  }
   root: string
   idmap: [string, string[]][]
   ctxm: (string | number)[]

--- a/packages/webpack/tsconfig.json
+++ b/packages/webpack/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../.config/tsconfig.workspace.json",
+  "extends": "../../.config/tsconfig.src.json",
   "include": ["src", "src/ENUM.json"],
   "compilerOptions": {
     "lib": ["es2022"],


### PR DESCRIPTION
- fix scuttling config type
- wire up types in package.json
- get the right types exported



Damn this was tedious to get working on the default export.
All attempts to have a main types.ts file as the types entrypoint were unsuccessful because of that. 