### PR TITLE
feat(core): decouple writable store from root compartment global

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "lib:ses": "cp ../../node_modules/ses/dist/lockdown.umd.js ./lib/lockdown.umd.js",
     "lint:deps": "depcheck",
-    "test": "ava && npm run test:ses",
+    "test": "npm run test:ses && ava",
     "test:ses": "bash ./test/ses.sh"
   },
   "dependencies": {

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -44,6 +44,7 @@ function endowmentsToolkit({
     // public API
     getEndowmentsForConfig,
     copyWrappedGlobals,
+    endowAll,
     getBuiltinForConfig,
     createFunctionWrapper,
     // internals exposed for core
@@ -132,6 +133,39 @@ function endowmentsToolkit({
       unwrapTo,
       unwrapFrom,
       explicitlyBanned,
+      allowedWriteFields
+    )
+  }
+
+  /**
+   * Creates an object populated with all properties of the source, but applies
+   * all the wrapping and writable mapping
+   *
+   * @template {object} T Deep properties specified in the packagePolicy
+   * @param {T} sourceRef - Object from which to copy properties
+   * @param {object} unwrapTo - For getters and setters, when the this-value is
+   *   unwrapFrom, is replaced as unwrapTo
+   * @param {object} unwrapFrom - For getters and setters, the this-value to
+   *   replace (default: targetRef)
+   * @returns {Partial<T>} - The targetRef
+   */
+  function endowAll(sourceRef, unwrapTo, unwrapFrom) {
+    const proto = Object.getPrototypeOf(sourceRef)
+    if (proto !== null && proto !== Object.prototype) {
+      throw new Error(
+        `LavaMoat - endowAll does not support sourceRefs with custom prototype`
+      )
+    }
+    const whitelistedReads = Object.getOwnPropertyNames(sourceRef).sort(
+      (a, b) => a.length - b.length
+    )
+    const allowedWriteFields = knownWritableFields
+    return makeMinimalViewOfRef(
+      sourceRef,
+      whitelistedReads,
+      unwrapTo,
+      unwrapFrom,
+      [], // nothing is explicitly banned
       allowedWriteFields
     )
   }

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -1,6 +1,11 @@
 const test = require('ava')
 const endowmentsToolkit = require('../src/endowmentsToolkit.js')
 
+/**
+ * @param {Object} [options]
+ * @param {Set<string>} [options].knownWritable]
+ * @returns {ReturnType<typeof endowmentsToolkit>}
+ */
 function prepareTest({ knownWritable } = {}) {
   const { getEndowmentsForConfig, copyWrappedGlobals, endowAll } =
     endowmentsToolkit({

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -557,7 +557,7 @@ test('copyWrappedGlobals - copy from prototype too', (t) => {
   t.is(Object.keys(target).sort().join(), 'onTheObj,onTheProto,window')
 })
 
-test('copyWrappedGlobals+endowAll - ends up including fields from prototype too', (t) => {
+test('copyWrappedGlobals+endowAll - includes fields from source prototype', (t) => {
   'use strict'
   const { copyWrappedGlobals, endowAll } = prepareTest()
   const sourceProto = {


### PR DESCRIPTION
Tests contain an example of a new usage pattern. The change is backward compatible. 

Performance impact:
It's likely got a minimal negative impact on performance - one more copy is needed and writable fields are propagated through getters not directly.

Compatibility considerations:  
Old way of using it, if a field was not marked as writable and root wrote to it, the new field would be visible in new compartments created afterwards (if endowed). 