### PR TITLE
feat(webpack): repairs for globals that need more than unwrap from core

### DIFF
--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -16,6 +16,7 @@ export interface CompleteLavaMoatPluginOptions {
   policy?: LavaMoatPolicy
   runChecks?: boolean
   isBuiltin: (specifier: string) => boolean
+  skipRepairs?: true | string[]
   scuttleGlobalThis?: ScuttlerConfig
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -110,12 +110,14 @@ class LavaMoatPlugin {
    */
   constructor(options = {}) {
     if (options.scuttleGlobalThis === true) {
-      options.scuttleGlobalThis = { enabled: true }
+      options.scuttleGlobalThis = { enabled: true, exceptions: [] }
     } else if (typeof options.scuttleGlobalThis === 'object') {
       options.scuttleGlobalThis = { ...options.scuttleGlobalThis }
       if (Array.isArray(options.scuttleGlobalThis.exceptions)) {
         options.scuttleGlobalThis.exceptions =
           options.scuttleGlobalThis.exceptions.map((e) => e.toString())
+      } else {
+        options.scuttleGlobalThis.exceptions = []
       }
     }
 
@@ -254,6 +256,16 @@ class LavaMoatPlugin {
             'LavaMoatPlugin: Concatenation of modules disabled - not compatible with LavaMoat wrapped modules.'
           )
         )
+
+        // Adjust scuttling configuration to not scuttle webpack chunk loading facilities
+        if (
+          typeof STORE.options.scuttleGlobalThis === 'object' &&
+          Array.isArray(STORE.options.scuttleGlobalThis.exceptions)
+        ) {
+          STORE.options.scuttleGlobalThis.exceptions.push(
+            compilation.outputOptions.chunkLoadingGlobal || 'webpackChunk'
+          )
+        }
 
         compilation.hooks.optimizeAssets.tap(PLUGIN_NAME, () => {
           // By the time assets are being optimized we should have finished.

--- a/packages/webpack/src/runtime/assemble.js
+++ b/packages/webpack/src/runtime/assemble.js
@@ -20,7 +20,7 @@ function removeMultilineComments(source) {
  */
 const assembleRuntime = (KEY, runtimeModules) => {
   let assembly = 'const LAVAMOAT = Object.create(null);'
-  runtimeModules.map(({ file, data, name, json, shimRequire }) => {
+  runtimeModules.map(({ file, data, name, json, rawSource, shimRequire }) => {
     let sourceString
     if (file) {
       sourceString = readFileSync(file, 'utf-8')
@@ -32,8 +32,13 @@ const assembleRuntime = (KEY, runtimeModules) => {
     if (json) {
       sourceString = `LAVAMOAT['${name}'] = (${sourceString});`
     }
+    if (rawSource) {
+      sourceString = rawSource
+    }
     if (shimRequire) {
       sourceString = readFileSync(require.resolve(shimRequire), 'utf-8')
+    }
+    if ((rawSource || shimRequire) && sourceString) {
       sourceString = removeMultilineComments(sourceString)
       sourceString = `;(()=>{
         const module = {exports: {}};
@@ -59,6 +64,7 @@ const assembleRuntime = (KEY, runtimeModules) => {
  * @property {unknown} [data]
  * @property {string} [name]
  * @property {boolean} [json]
+ * @property {string} [rawSource]
  * @property {string} [shimRequire]
  */
 

--- a/packages/webpack/src/runtime/repairs/index.js
+++ b/packages/webpack/src/runtime/repairs/index.js
@@ -1,3 +1,6 @@
-exports.repairs = {
-  MessageEvent: require.resolve('./messageevent'),
-}
+exports.repairs = [
+  {
+    target: ['MessageEvent', 'addEventListener'],
+    file: require.resolve('./messageevent'),
+  },
+]

--- a/packages/webpack/src/runtime/repairs/index.js
+++ b/packages/webpack/src/runtime/repairs/index.js
@@ -1,0 +1,3 @@
+exports.repairs = {
+  MessageEvent: require.resolve('./messageevent'),
+}

--- a/packages/webpack/src/runtime/repairs/messageevent.js
+++ b/packages/webpack/src/runtime/repairs/messageevent.js
@@ -46,8 +46,10 @@ exports.MessageEvent = (
   theRealGlobalThis,
   packageCompartmentGlobal
 ) => {
-  const originalListener = endowments.addEventListener
   const originalConstructor = endowments.MessageEvent
+  if (!originalConstructor) {
+    return
+  }
 
   /**
    * @param {string} type
@@ -62,7 +64,24 @@ exports.MessageEvent = (
   // WARNING: fidelity breaks down at MessageEvent.prototype.constructor,
   // which runs the original constructor and does not pin the resulting object
   // to a matching global in the WeakMap
-
+}
+/**
+ * Wraps the source getter on MessageEvent prototype with conversion from actual
+ * global to compartment global
+ *
+ * @param {{ [key: string]: any }} endowments
+ * @param {any} theRealGlobalThis
+ * @param {any} packageCompartmentGlobal
+ */
+exports.addEventListener = (
+  endowments,
+  theRealGlobalThis,
+  packageCompartmentGlobal
+) => {
+  const originalListener = endowments.addEventListener
+  if (!originalListener) {
+    return
+  }
   /**
    * @param {string} type
    * @param {function} listener

--- a/packages/webpack/src/runtime/repairs/messageevent.js
+++ b/packages/webpack/src/runtime/repairs/messageevent.js
@@ -1,0 +1,39 @@
+const { defineProperty } = Object
+const { call } = Function.prototype
+
+// TODO:
+// - implement wider support for messageable realms matching (parent, top, opener)
+// - once other realm reference are emulated, match and return the right references from the getter as well
+
+/**
+ * Wraps the source getter on MessageEvent prototype with conversion from actual
+ * global to compartment global
+ *
+ * @param {{ [key: string]: any }} endowments
+ * @param {any} theRealGlobalThis
+ * @param {any} packageCompartmentGlobal
+ */
+exports.MessageEvent = (
+  endowments,
+  theRealGlobalThis,
+  packageCompartmentGlobal
+) => {
+  const original = Object.getOwnPropertyDescriptor(
+    endowments['MessageEvent'].prototype,
+    'source'
+  )
+  if (original && original.get) {
+    const sourceGetter = call.bind(original.get)
+    defineProperty(endowments['MessageEvent'].prototype, 'source', {
+      ...original,
+      get() {
+        const w = sourceGetter(this)
+        if (w === theRealGlobalThis) {
+          return packageCompartmentGlobal
+        } else {
+          return w
+        }
+      },
+    })
+  }
+}

--- a/packages/webpack/src/runtime/repairs/messageevent.js
+++ b/packages/webpack/src/runtime/repairs/messageevent.js
@@ -84,12 +84,13 @@ exports.addEventListener = (
   }
   /**
    * @param {string} type
-   * @param {function} listener
+   * @param {(event: MessageEvent) => void} listener
    * @param {any} [options]
    */
   endowments.addEventListener = (type, listener, options) => {
     if (type === 'message') {
-      const wrappedListener = (/** @type {MessageEvent} */ event) => {
+      /** @type {typeof listener} */
+      const wrappedListener = (event) => {
         messageToGlobalMap.set(event, packageCompartmentGlobal)
         return listener.call(packageCompartmentGlobal, event)
       }

--- a/packages/webpack/src/runtime/repairsBuilder.js
+++ b/packages/webpack/src/runtime/repairsBuilder.js
@@ -5,8 +5,18 @@ const { repairs } = require('./repairs/index')
  * Combines the sources of only the repairs that are needed based on the policy
  *
  * @param {import('lavamoat-core').LavaMoatPolicy} policy
+ * @param {string[]} [skipRepairs]
  */
-exports.buildRepairs = (policy) => {
+exports.buildRepairs = (policy, skipRepairs) => {
+  const repairsAvailable =
+    Array.isArray(skipRepairs) && skipRepairs.length > 0
+      ? repairs.filter(
+          (repair) =>
+            !repair.target.some((target) => {
+              return skipRepairs.includes(target)
+            })
+        )
+      : repairs
   const allGlobalsInvolved = new Set()
   for (const resource of Object.values(policy.resources)) {
     if (resource.globals) {
@@ -16,7 +26,7 @@ exports.buildRepairs = (policy) => {
       }
     }
   }
-  const repairsToInclude = repairs.filter((repair) =>
+  const repairsToInclude = repairsAvailable.filter((repair) =>
     repair.target.some((target) => {
       return allGlobalsInvolved.has(target)
     })

--- a/packages/webpack/src/runtime/repairsBuilder.js
+++ b/packages/webpack/src/runtime/repairsBuilder.js
@@ -1,5 +1,5 @@
-const { repairs } = require('./repairs/index')
 const { readFileSync } = require('node:fs')
+const { repairs } = require('./repairs/index')
 
 /**
  * Combines the sources of only the repairs that are needed based on the policy
@@ -7,25 +7,22 @@ const { readFileSync } = require('node:fs')
  * @param {import('lavamoat-core').LavaMoatPolicy} policy
  */
 exports.buildRepairs = (policy) => {
-  const availableRepairs = new Set(Object.keys(repairs))
-  // iterate over policy resources and look through their globals. If a global is in availableRepairs, add it to the repairsNeeded set.
-  const repairsNeeded = new Set()
+  const allGlobalsInvolved = new Set()
   for (const resource of Object.values(policy.resources)) {
     if (resource.globals) {
       for (const global of Object.keys(resource.globals)) {
         const top = global.split('.')[0]
-        if (availableRepairs.has(top)) {
-          repairsNeeded.add(top)
-        }
+        allGlobalsInvolved.add(top)
       }
     }
   }
-  if (repairsNeeded.size === 0) {
-    return ''
-  }
-  return Array.from(repairsNeeded)
-    .map((/** @type {keyof typeof repairs} */ name) =>
-      readFileSync(repairs[name], 'utf8')
-    )
-    .join(';\n')
+  const repairsToInclude = repairs.filter((repair) =>
+    repair.target.some((target) => {
+      return allGlobalsInvolved.has(target)
+    })
+  )
+
+  return repairsToInclude
+    .map(({ file }) => readFileSync(file, 'utf8'))
+    .join(';\n;')
 }

--- a/packages/webpack/src/runtime/repairsBuilder.js
+++ b/packages/webpack/src/runtime/repairsBuilder.js
@@ -1,0 +1,31 @@
+const { repairs } = require('./repairs/index')
+const { readFileSync } = require('node:fs')
+
+/**
+ * Combines the sources of only the repairs that are needed based on the policy
+ *
+ * @param {import('lavamoat-core').LavaMoatPolicy} policy
+ */
+exports.buildRepairs = (policy) => {
+  const availableRepairs = new Set(Object.keys(repairs))
+  // iterate over policy resources and look through their globals. If a global is in availableRepairs, add it to the repairsNeeded set.
+  const repairsNeeded = new Set()
+  for (const resource of Object.values(policy.resources)) {
+    if (resource.globals) {
+      for (const global of Object.keys(resource.globals)) {
+        const top = global.split('.')[0]
+        if (availableRepairs.has(top)) {
+          repairsNeeded.add(top)
+        }
+      }
+    }
+  }
+  if (repairsNeeded.size === 0) {
+    return ''
+  }
+  return Array.from(repairsNeeded)
+    .map((/** @type {keyof typeof repairs} */ name) =>
+      readFileSync(repairs[name], 'utf8')
+    )
+    .join(';\n')
+}

--- a/packages/webpack/src/runtime/repairsBuilder.js
+++ b/packages/webpack/src/runtime/repairsBuilder.js
@@ -1,10 +1,12 @@
 const { readFileSync } = require('node:fs')
 const { repairs } = require('./repairs/index')
 
+/** @import {LavaMoatPolicy} from 'lavamoat-core' */
+
 /**
  * Combines the sources of only the repairs that are needed based on the policy
  *
- * @param {import('lavamoat-core').LavaMoatPolicy} policy
+ * @param {LavaMoatPolicy} policy
  * @param {string[]} [skipRepairs]
  */
 exports.buildRepairs = (policy, skipRepairs) => {

--- a/packages/webpack/src/runtime/runtime-namespace.ts
+++ b/packages/webpack/src/runtime/runtime-namespace.ts
@@ -24,5 +24,6 @@ export interface RuntimeNamespace {
   ENUM: Record<string, string>
   endowmentsToolkit: typeof EndowmentsToolkitFactory
   defaultExport: (...args: any[]) => unknown
+  repairs: Record<string, Function>
   debug: DebugTools | undefined
 }

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -101,9 +101,15 @@ module.exports = {
           ]
         } else {
           diag.rawDebug(2, `adding runtime for chunk ${currentChunkName}`)
-          const repairs = require('./repairsBuilder.js').buildRepairs(
-            policyData
-          )
+          let repairs
+          if (options.skipRepairs === true) {
+            repairs = ''
+          } else {
+            repairs = require('./repairsBuilder.js').buildRepairs(
+              policyData,
+              options.skipRepairs
+            )
+          }
 
           runtimeChunks = [
             // the string used to indicate root resource id

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -5,6 +5,7 @@ const path = require('node:path')
 
 /** @import {LavaMoatPluginOptions} from '../buildtime/types' */
 /** @import {LavaMoatPolicy} from 'lavamoat-core' */
+/** @import {RuntimeModule} from './assemble.js' */
 
 module.exports = {
   /**
@@ -77,6 +78,7 @@ module.exports = {
           externals,
         },
       }) {
+        /** @type {RuntimeModule[]} */
         let runtimeChunks = []
         if (
           currentChunkName &&
@@ -99,6 +101,9 @@ module.exports = {
           ]
         } else {
           diag.rawDebug(2, `adding runtime for chunk ${currentChunkName}`)
+          const repairs = require('./repairsBuilder.js').buildRepairs(
+            policyData
+          )
 
           runtimeChunks = [
             // the string used to indicate root resource id
@@ -161,6 +166,11 @@ module.exports = {
             {
               name: 'endowmentsToolkit',
               shimRequire: 'lavamoat-core/src/endowmentsToolkit.js',
+            },
+            // repairs
+            {
+              name: 'repairs',
+              rawSource: repairs,
             },
             // main lavamoat runtime
             {

--- a/packages/webpack/test/e2e-repairs.spec.js
+++ b/packages/webpack/test/e2e-repairs.spec.js
@@ -87,3 +87,36 @@ test('webpack/repairs - MessageEvent repair is not included when not in use', as
     'Expected MessageEvent repair to not be included in the bundle'
   )
 })
+
+test('webpack/repairs - MessageEvent repair is not included if skipped', async (t) => {
+  const webpackConfigAllowed = makeConfig({
+    generatePolicy: false,
+    skipRepairs: ['MessageEvent'],
+    policy: {
+      resources: {
+        'message-package': {
+          globals: {
+            console: true,
+            MessageEvent: true,
+          },
+        },
+      },
+    },
+  })
+  const webpackConfig = {
+    ...webpackConfigAllowed,
+    entry: {
+      app: './src/repairs.js',
+    },
+    mode: 'development',
+  }
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+  }, 'Expected the build to succeed')
+
+  t.false(
+    t.context.build.snapshot['/dist/app.js'].includes('exports.MessageEvent'),
+    'Expected MessageEvent repair to not be included in the bundle'
+  )
+})

--- a/packages/webpack/test/e2e-repairs.spec.js
+++ b/packages/webpack/test/e2e-repairs.spec.js
@@ -7,6 +7,12 @@ test('webpack/repairs - MessageEvent repair is applied when in use', async (t) =
     generatePolicy: false,
     policy: {
       resources: {
+        'another-message-package': {
+          globals: {
+            console: true,
+            MessageEvent: true,
+          },
+        },
         'message-package': {
           globals: {
             console: true,

--- a/packages/webpack/test/e2e-repairs.spec.js
+++ b/packages/webpack/test/e2e-repairs.spec.js
@@ -1,0 +1,80 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { scaffold, runScriptWithSES } = require('./scaffold.js')
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
+
+test('webpack/repairs - MessageEvent repair is applied when in use', async (t) => {
+  const webpackConfigAllowed = makeConfig({
+    generatePolicy: false,
+    policy: {
+      resources: {
+        'message-package': {
+          globals: {
+            console: true,
+            MessageEvent: true,
+          },
+        },
+      },
+    },
+  })
+  const webpackConfig = {
+    ...webpackConfigAllowed,
+    entry: {
+      app: './src/repairs.js',
+    },
+    mode: 'development',
+  }
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+  }, 'Expected the build to succeed')
+
+  const mock = `
+    globalThis.MessageEvent = class MessageEvent {
+      get source() {
+        return globalThis
+      }
+    };
+  `
+
+  t.true(
+    t.context.build.snapshot['/dist/app.js'].includes('exports.MessageEvent'),
+    'Expected MessageEvent repair to be included in the bundle'
+  )
+
+  t.notThrows(() => {
+    runScriptWithSES(mock + t.context.build.snapshot['/dist/app.js'], {
+      console,
+    })
+  }, 'Expected the script to run without throwing an error')
+})
+
+test('webpack/repairs - MessageEvent repair is not included when not in use', async (t) => {
+  const webpackConfigAllowed = makeConfig({
+    generatePolicy: false,
+    policy: {
+      resources: {
+        'message-package': {
+          globals: {
+            console: true,
+          },
+        },
+      },
+    },
+  })
+  const webpackConfig = {
+    ...webpackConfigAllowed,
+    entry: {
+      app: './src/repairs.js',
+    },
+    mode: 'development',
+  }
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+  }, 'Expected the build to succeed')
+
+  t.false(
+    t.context.build.snapshot['/dist/app.js'].includes('exports.MessageEvent'),
+    'Expected MessageEvent repair to not be included in the bundle'
+  )
+})

--- a/packages/webpack/test/e2e-repairs.spec.js
+++ b/packages/webpack/test/e2e-repairs.spec.js
@@ -42,9 +42,12 @@ test('webpack/repairs - MessageEvent repair is applied when in use', async (t) =
   )
 
   t.notThrows(() => {
-    runScriptWithSES(mock + t.context.build.snapshot['/dist/app.js'], {
-      console,
-    })
+    runScriptWithSES(
+      mock + '\n;\n' + t.context.build.snapshot['/dist/app.js'],
+      {
+        console,
+      }
+    )
   }, 'Expected the script to run without throwing an error')
 })
 

--- a/packages/webpack/test/e2e-scuttle.spec.js
+++ b/packages/webpack/test/e2e-scuttle.spec.js
@@ -11,11 +11,11 @@ const { default: ava } = require('ava')
  * @property {boolean} scuttler_func_called
  */
 
-const test = /** @type {import('ava').TestFn<ScuttlingTestContext>} */(ava)
+const test = /** @type {import('ava').TestFn<ScuttlingTestContext>} */ (ava)
 const path = require('node:path')
 // eslint-disable-next-line ava/no-import-test-files
 const { scaffold, runScriptWithSES } = require('./scaffold.js')
-const {makeConfig} = require('./fixtures/main/webpack.config.js')
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
 
 const err = (intrinsic) =>
   'LavaMoat - property "' +
@@ -36,9 +36,17 @@ async function scuttle(t, scuttleGlobalThis, globals) {
       app: './simple.js',
     },
   }
+  // force webpack into creating chunks so that testing chunkApp globals is possible
+  webpackConfig.optimization.runtimeChunk = 'single'
+  // specify the chunk global namefor tests
+  webpackConfig.output.chunkLoadingGlobal = 'webpackChunkTEST'
+
   await t.notThrowsAsync(async () => {
     t.context.build = await scaffold(webpackConfig)
-    t.context.bundle = t.context.build.snapshot['/dist/app.js']
+    // Load both chunks effectively
+    t.context.bundle =
+      t.context.build.snapshot['/dist/runtime.js'] +
+      t.context.build.snapshot['/dist/app.js']
     t.context.globalThis = runScriptWithSES(t.context.bundle, globals).context
   }, 'Expected the build to succeed')
 }
@@ -47,7 +55,7 @@ test(`webpack/scuttled - hosting globalThis's environment is not scuttled`, asyn
   await scuttle(t)
   t.notThrows(() => {
     const global = t.context.globalThis
-    Object.getOwnPropertyNames(global).forEach(name => global[name])
+    Object.getOwnPropertyNames(global).forEach((name) => global[name])
   }, 'Unexpected error in scenario')
 })
 
@@ -68,22 +76,53 @@ test(`webpack/scuttled - hosting globalThis's "Function" is scuttled`, async (t)
 })
 
 test(`webpack/scuttled - hosting globalThis's "Function" is scuttled excepted`, async (t) => {
-  await scuttle(t, {enabled: true, exceptions: ['Function']})
+  await scuttle(t, { enabled: true, exceptions: ['Function'] })
   t.notThrows(() => {
     t.is(new t.context.globalThis.Function('return 1')(), 1)
   }, 'Unexpected error in scenario')
 })
 
+test(`webpack/scuttled - webpackChunk global is transparently added to exceptions`, async (t) => {
+  await scuttle(t, { enabled: true, exceptions: ['Function'] })
+
+  t.notThrows(() => {
+    t.context.globalThis.webpackChunkTEST
+  }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
+})
+
+test(`webpack/scuttled - webpackChunk global is transparently added to exceptions even when not specified 1`, async (t) => {
+  await scuttle(t, { enabled: true })
+
+  t.notThrows(() => {
+    t.context.globalThis.webpackChunkTEST
+  }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
+})
+
+test(`webpack/scuttled - webpackChunk global is transparently added to exceptions even when not specified 2`, async (t) => {
+  await scuttle(t, true)
+
+  t.notThrows(() => {
+    t.context.globalThis.webpackChunkTEST
+  }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
+})
+
 test(`webpack/scuttled - provided scuttlerName successfully invoked defined scuttlerFunc`, async (t) => {
-  const scuttlerName = 'SCUTTLER';
-  await scuttle(t, {
-    enabled: true,
-    scuttlerName,
-  }, {
-    [scuttlerName]: (globalRef, scuttle) => {
-      t.context.scuttler_func_called = true
-      scuttle(globalRef)
+  const scuttlerName = 'SCUTTLER'
+  await scuttle(
+    t,
+    {
+      enabled: true,
+      scuttlerName,
+    },
+    {
+      [scuttlerName]: (globalRef, scuttle) => {
+        t.context.scuttler_func_called = true
+        scuttle(globalRef)
+      },
     }
-  })
-  t.true(t.context.scuttler_func_called);
+  )
+  t.true(t.context.scuttler_func_called)
 })

--- a/packages/webpack/test/fixtures/main/node_modules/another-message-package/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/another-message-package/index.js
@@ -1,0 +1,5 @@
+const event = new MessageEvent('message')
+
+if (event.source !== globalThis) {
+  throw new Error('MessageEvent source should be globalThis')
+}

--- a/packages/webpack/test/fixtures/main/node_modules/another-message-package/package.json
+++ b/packages/webpack/test/fixtures/main/node_modules/another-message-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "another-message-package",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/webpack/test/fixtures/main/node_modules/message-package/index.js
+++ b/packages/webpack/test/fixtures/main/node_modules/message-package/index.js
@@ -1,0 +1,5 @@
+const event = new MessageEvent('message')
+
+if (event.source !== globalThis) {
+  throw new Error('MessageEvent source should be globalThis')
+}

--- a/packages/webpack/test/fixtures/main/node_modules/message-package/package.json
+++ b/packages/webpack/test/fixtures/main/node_modules/message-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "message-package",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/webpack/test/fixtures/main/package.json
+++ b/packages/webpack/test/fixtures/main/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "another-message-package": "1.0.0",
     "commonjs-package": "1.0.0",
     "commonjs-quirks": "1.0.0",
     "dynamic-importer": "1.0.0",

--- a/packages/webpack/test/fixtures/main/package.json
+++ b/packages/webpack/test/fixtures/main/package.json
@@ -14,6 +14,7 @@
     "flag-package": "1.0.0",
     "globals-package": "1.0.0",
     "loader-hack": "1.0.0",
+    "message-package": "1.0.0",
     "nodejs-package": "1.0.0",
     "polyfill-package": "1.0.0",
     "prototype-poisoning-package": "1.0.0",

--- a/packages/webpack/test/fixtures/main/src/repairs.js
+++ b/packages/webpack/test/fixtures/main/src/repairs.js
@@ -1,0 +1,1 @@
+require('message-package')

--- a/packages/webpack/test/fixtures/main/src/repairs.js
+++ b/packages/webpack/test/fixtures/main/src/repairs.js
@@ -1,1 +1,2 @@
 require('message-package')
+require('another-message-package')

--- a/packages/webpack/test/fixtures/main/webpack.config.js
+++ b/packages/webpack/test/fixtures/main/webpack.config.js
@@ -4,10 +4,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
 
 const defaultLmOptions = {
-  lockdown: {
-    errorTaming: 'unsafe',
-    consoleTaming: 'unsafe',
-  },
   policyLocation: path.resolve(__dirname, 'policy'),
   readableResourceIds: true,
   runChecks: true,

--- a/packages/webpack/test/scaffold.js
+++ b/packages/webpack/test/scaffold.js
@@ -116,9 +116,12 @@ const defaultGlobals = () => ({
   URL,
 })
 
+
+/** @import {Context} from 'node:vm' */
+
 /**
  * @typedef {object} RunReturn
- * @property {import('vm').Context} context - VM context object
+ * @property {Context} context - VM context object
  * @property {any} result - Return value from the executed code
  */
 

--- a/packages/webpack/test/scaffold.js
+++ b/packages/webpack/test/scaffold.js
@@ -117,11 +117,17 @@ const defaultGlobals = () => ({
 })
 
 /**
+ * @typedef {object} RunReturn
+ * @property {import('vm').Context} context - VM context object
+ * @property {any} result - Return value from the executed code
+ */
+
+/**
  * Run a script in a new context, without SES
  *
  * @param {string} code
  * @param {Record<string, any>} globals
- * @returns {any}
+ * @returns {RunReturn}
  */
 function runScript(code, globals = defaultGlobals()) {
   if (typeof code !== 'string' || code === '') {
@@ -141,7 +147,7 @@ exports.runScript = runScript
  *
  * @param {string} bundle
  * @param {Record<string, any>} globals
- * @returns {any}
+ * @returns {RunReturn}
  */
 function runScriptWithSES(bundle, globals = defaultGlobals()) {
   if (typeof bundle !== 'string' || bundle === '') {


### PR DESCRIPTION
- fixes a silent failure in MM where `event.source` was the real `window` being compared with the compartment global
- introduces a general mechanism for including repairs into the bundle runtime only if needed (I was considering putting repairs in core, but then they would all go into the bundle)
- https://github.com/LavaMoat/LavaMoat/pull/1659 can be implemented as a repair