### PR TITLE
feat(webpack): update lockdown settings for better compatibility and …

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -93,15 +93,22 @@ class VirtualRuntimeModule extends RuntimeModule {
 const PLUGIN_NAME = 'LavaMoatPlugin'
 /** @satisfies {LockdownOptions} */
 const lockdownDefaults = /** @type {const} */ ({
-  // lets code observe call stack, but easier debuggability
+  // avoids freezing console (libraries like to patch it)
+  consoleTaming: 'unsafe',
+  // lets code observe call stack, easier debuggability
   errorTaming: 'unsafe',
   // shows the full call stack
   stackFiltering: 'verbose',
+  // avoid instrumenting for catching uncaught errors
+  errorTrapping: 'none',
+  unhandledRejectionTrapping: 'none',
   // prevents most common override mistake cases from tripping up users
   overrideTaming: 'severe',
   // preserves JS locale methods, to avoid confusing users
   // prevents aliasing: toLocaleString() to toString(), etc
   localeTaming: 'unsafe',
+  // leave it untamed for compatibility
+  regExpTaming: 'unsafe',
 })
 
 class LavaMoatPlugin {

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -99,9 +99,6 @@ const lockdownDefaults = /** @type {const} */ ({
   errorTaming: 'unsafe',
   // shows the full call stack
   stackFiltering: 'verbose',
-  // avoid instrumenting for catching uncaught errors
-  errorTrapping: 'none',
-  unhandledRejectionTrapping: 'none',
   // prevents most common override mistake cases from tripping up users
   overrideTaming: 'severe',
   // preserves JS locale methods, to avoid confusing users

--- a/packages/webpack/test/fixtures/main/webpack.config.js
+++ b/packages/webpack/test/fixtures/main/webpack.config.js
@@ -4,10 +4,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
 
 const defaultLmOptions = {
-  lockdown: {
-    errorTaming: 'unsafe',
-    consoleTaming: 'unsafe',
-  },
   policyLocation: path.resolve(__dirname, 'policy'),
   readableResourceIds: true,
   runChecks: true,


### PR DESCRIPTION
…easier debugging

This came up in integration with MM.

We might want to expand the defaults elsewhere. When error and console taming is unsafe, trapping errors is also unnecessary. 