### PR TITLE
fix(webpack): avoid scuttling the global Webpack uses for sharing chunks

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -260,7 +260,7 @@ class LavaMoatPlugin {
         // Adjust scuttling configuration to not scuttle webpack chunk loading facilities
         if (
           typeof STORE.options.scuttleGlobalThis === 'object' &&
-          STORE.options.scuttleGlobalThis.exceptions
+          Array.isArray(STORE.options.scuttleGlobalThis.exceptions)
         ) {
           STORE.options.scuttleGlobalThis.exceptions.push(
             compilation.outputOptions.chunkLoadingGlobal || 'webpackChunk'

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -110,12 +110,14 @@ class LavaMoatPlugin {
    */
   constructor(options = {}) {
     if (options.scuttleGlobalThis === true) {
-      options.scuttleGlobalThis = { enabled: true }
+      options.scuttleGlobalThis = { enabled: true, exceptions: [] }
     } else if (typeof options.scuttleGlobalThis === 'object') {
       options.scuttleGlobalThis = { ...options.scuttleGlobalThis }
       if (Array.isArray(options.scuttleGlobalThis.exceptions)) {
         options.scuttleGlobalThis.exceptions =
           options.scuttleGlobalThis.exceptions.map((e) => e.toString())
+      } else {
+        options.scuttleGlobalThis.exceptions = []
       }
     }
 
@@ -254,6 +256,16 @@ class LavaMoatPlugin {
             'LavaMoatPlugin: Concatenation of modules disabled - not compatible with LavaMoat wrapped modules.'
           )
         )
+
+        // Adjust scuttling configuration to not scuttle webpack chunk loading facilities
+        if (
+          typeof STORE.options.scuttleGlobalThis === 'object' &&
+          STORE.options.scuttleGlobalThis.exceptions
+        ) {
+          STORE.options.scuttleGlobalThis.exceptions.push(
+            compilation.outputOptions.chunkLoadingGlobal || 'webpackChunk'
+          )
+        }
 
         compilation.hooks.optimizeAssets.tap(PLUGIN_NAME, () => {
           // By the time assets are being optimized we should have finished.

--- a/packages/webpack/test/e2e-scuttle.spec.js
+++ b/packages/webpack/test/e2e-scuttle.spec.js
@@ -88,6 +88,7 @@ test(`webpack/scuttled - webpackChunk global is transparently added to exception
   t.notThrows(() => {
     t.context.globalThis.webpackChunkTEST
   }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
 })
 
 test(`webpack/scuttled - webpackChunk global is transparently added to exceptions even when not specified 1`, async (t) => {
@@ -96,6 +97,7 @@ test(`webpack/scuttled - webpackChunk global is transparently added to exception
   t.notThrows(() => {
     t.context.globalThis.webpackChunkTEST
   }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
 })
 
 test(`webpack/scuttled - webpackChunk global is transparently added to exceptions even when not specified 2`, async (t) => {
@@ -104,6 +106,7 @@ test(`webpack/scuttled - webpackChunk global is transparently added to exception
   t.notThrows(() => {
     t.context.globalThis.webpackChunkTEST
   }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
 })
 
 test(`webpack/scuttled - provided scuttlerName successfully invoked defined scuttlerFunc`, async (t) => {


### PR DESCRIPTION
If chunks are being loaded dynamically after scuttling happens, they will not work.
Since we're not prescribing anything about chunk structure and loading and already handle dynamic chunks, this is necessary to be the default.

I might consider ways to allow adding chunks but limit reading them from the outside of the bundle.