### PR TITLE
chore(renovate): group all Endo-related updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,5 +61,9 @@
       matchUpdateTypes: ['major'],
       enabled: false,
     },
+    {
+      matchPackageNames: ['@endo/*', 'ses'],
+      groupName: 'endo',
+    },
   ],
 }


### PR DESCRIPTION
This ensures we update all of them at once, since they are typically released all at once.
