### PR TITLE
fix(webpack): MessageEvent repair should not prevent further overrides

### DIFF
--- a/packages/webpack/src/runtime/repairs/messageevent.js
+++ b/packages/webpack/src/runtime/repairs/messageevent.js
@@ -29,7 +29,8 @@ if (original && original.get) {
         return w
       }
     },
-    configurable: false,
+    // left configurable because replacing it with original is impossible after and we 
+    // want to allow further wrapping (eg by Snow)
   })
 }
 


### PR DESCRIPTION
This fixes an unfortunate clash with Snow. The two overrides should stack correctly, because this repair is added first and it replaces window with compartmentGlobalThis if suitable, meanwhile Snow is replacing windows it recognizes with proxies that prevent setting fields. Snow will not recognize compartmentGlobalThis as a window it has a proxy for and return it as-is.