### PR TITLE
feat(webpack): static shims for runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17483,6 +17483,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@babel/parser": "7.28.3",
         "@lavamoat/aa": "^4.3.4",
         "browser-resolve": "2.0.0",
         "json-stable-stringify": "1.3.0",
@@ -17507,6 +17508,34 @@
       },
       "peerDependencies": {
         "webpack": "^5.80.2"
+      }
+    },
+    "packages/webpack/node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "packages/webpack/node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "packages/yarn-plugin-allow-scripts": {

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -29,7 +29,7 @@ The LavaMoat plugin takes an options object with the following properties (all o
 | `diagnosticsVerbosity`     | Number property to represent diagnostics output verbosity. A larger number means more overwhelming diagnostics output.                                                                                                                                                                                                | `0`                      |
 | `debugRuntime`             | Only for local debugging use - Enables debugging tools that help detect gaps in generated policy and add missing entries to overrides                                                                                                                                                                                 | `false`                  |
 | `policy`                   | The LavaMoat policy object (if not loading from file; see `policyLocation`)                                                                                                                                                                                                                                           | `undefined`              |
-| `staticShims_experimental` | Standalone JS files to be added to the runtime chunk before lavamoat runtime starts and executes lockdown.                                                                                                                                                                                        | `undefined`              |
+| `staticShims_experimental` | Standalone JS files to be added to the runtime chunk before lavamoat runtime starts and executes lockdown.                                                                                                                                                                                                            | `undefined`              |
 
 ```js
 const LavaMoatPlugin = require('@lavamoat/webpack')
@@ -63,26 +63,20 @@ module.exports = {
   plugins: [
     new LavaMoatPlugin({
       staticShims_experimental: [
-        'package-name', 
-        path.join(__dirname, './local/file.js')
-      ]
+        'package-name', // a package whose main export is a built standalone script
+        path.join(__dirname, './local/file.js'),
+      ],
     }),
   ],
 }
 ```
 
-The static shims are executed in order before any other code runs.
-A shim can also run code between the repair and harden phases of SES lockdown. To do that, assign a synchronous function to LOCKDOWN_SHIM variable that exists in the scope of the shim.
-It's the only way to polyfill functionality on intrinsics.
-
-> [!IMPORTANT]
-> You must _assign_ to `LOCKDOWN_SHIM` without re-declaring it.
+The static shims are executed between the repair and harden phases of SES lockdown.
+It's the only way to polyfill functionality on intrinsics or run any privileged code outside of LavaMoat protections.
 
 ```js
-// lockdown-shim.js
-LOCKDOWN_SHIM = () => {
+// resolvers-shim.js
   Promise.withResolvers = ...
-}
 ```
 
 ### Excluding modules

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -75,6 +75,9 @@ The static shims are executed in order before any other code runs.
 A shim can also run code between the repair and harden phases of SES lockdown. To do that, assign a synchronous function to LOCKDOWN_SHIM variable that exists in the scope of the shim.
 It's the only way to polyfill functionality on intrinsics.
 
+> [!IMPORTANT]
+> You must _assign_ to `LOCKDOWN_SHIM` without re-declaring it.
+
 ```js
 // lockdown-shim.js
 LOCKDOWN_SHIM = () => {

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -29,7 +29,7 @@ The LavaMoat plugin takes an options object with the following properties (all o
 | `diagnosticsVerbosity`     | Number property to represent diagnostics output verbosity. A larger number means more overwhelming diagnostics output.                                                                                                                                                                                                | `0`                      |
 | `debugRuntime`             | Only for local debugging use - Enables debugging tools that help detect gaps in generated policy and add missing entries to overrides                                                                                                                                                                                 | `false`                  |
 | `policy`                   | The LavaMoat policy object (if not loading from file; see `policyLocation`)                                                                                                                                                                                                                                           | `undefined`              |
-| `staticShims` | Standalone JS files to be added to the runtime chunk before lavamoat runtime starts and executes lockdown.                                                                                                                                                                                        | `undefined`              |
+| `staticShims_experimental` | Standalone JS files to be added to the runtime chunk before lavamoat runtime starts and executes lockdown.                                                                                                                                                                                        | `undefined`              |
 
 ```js
 const LavaMoatPlugin = require('@lavamoat/webpack')
@@ -62,7 +62,7 @@ const path = require('path')
 module.exports = {
   plugins: [
     new LavaMoatPlugin({
-      staticShims: [
+      staticShims_experimental: [
         'package-name', 
         path.join(__dirname, './local/file.js')
       ]

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -45,6 +45,7 @@
     "webpack": "^5.80.2"
   },
   "dependencies": {
+    "@babel/parser": "7.28.3",
     "@lavamoat/aa": "^4.3.4",
     "browser-resolve": "2.0.0",
     "json-stable-stringify": "1.3.0",

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -20,7 +20,7 @@ export interface CompleteLavaMoatPluginOptions {
   scuttleGlobalThis?: ScuttlerConfig
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp
-  staticShims?: string[]
+  staticShims_experimental?: string[]
 }
 
 export type LavaMoatPluginOptions = Partial<CompleteLavaMoatPluginOptions>

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -3,7 +3,8 @@ import type { LockdownOptions } from 'ses'
 import type { Chunk } from 'webpack'
 export interface LavaMoatChunkRuntimeConfiguration {
   mode: 'safe' | 'unlocked_unsafe'
-  staticShims?: string[]
+  staticShims?: string[],
+  embeddedOptions?: Partial<Pick<CompleteLavaMoatPluginOptions, 'lockdown' | 'scuttleGlobalThis'>>
 }
 
 export type ScuttlerConfig = LavaMoatScuttleOpts | boolean | undefined

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -20,6 +20,7 @@ export interface CompleteLavaMoatPluginOptions {
   scuttleGlobalThis?: ScuttlerConfig
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp
+  staticShims?: string[]
 }
 
 export type LavaMoatPluginOptions = Partial<CompleteLavaMoatPluginOptions>

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -1,5 +1,10 @@
 import type { LavaMoatPolicy, LavaMoatScuttleOpts } from 'lavamoat-core'
 import type { LockdownOptions } from 'ses'
+import type { Chunk } from 'webpack'
+export interface LavaMoatChunkRuntimeConfiguration {
+  mode: 'safe' | 'unlocked_unsafe'
+  staticShims?: string[]
+}
 
 export type ScuttlerConfig = LavaMoatScuttleOpts | boolean | undefined
 
@@ -21,6 +26,7 @@ export interface CompleteLavaMoatPluginOptions {
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp
   staticShims_experimental?: string[]
+  runtimeConfigurationPerChunk_experimental?: (chunk: Chunk) => LavaMoatChunkRuntimeConfiguration
 }
 
 export type LavaMoatPluginOptions = Partial<CompleteLavaMoatPluginOptions>

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -7,7 +7,6 @@ const assert = require('node:assert')
 
 const {
   WebpackError,
-  RuntimeModule,
   Compilation,
   sources: { RawSource },
 } = require('webpack')
@@ -56,35 +55,6 @@ const POLICY_SNAPSHOT_FILENAME = 'policy-snapshot.json'
 const { wrapGenerator } = require('./buildtime/generator.js')
 const { sesEmitHook, sesPrefixFiles } = require('./buildtime/emitSes.js')
 const EXCLUDE_LOADER = path.join(__dirname, './excludeLoader.js')
-
-class VirtualRuntimeModule extends RuntimeModule {
-  /**
-   * @param {Object} options - The options for the VirtualRuntimeModule.
-   * @param {string} options.name - The name of the module.
-   * @param {string} options.source - The source code of the module.
-   * @param {number} [options.stage] - The stage of runtime. One of
-   *   RuntimeModule.STAGE_*.
-   * @param {boolean} [options.withoutClosure] - Make the source code run
-   *   outside the closure for a runtime module
-   */
-  constructor({
-    name,
-    source,
-    stage = RuntimeModule.STAGE_NORMAL,
-    withoutClosure = false,
-  }) {
-    super(name, stage)
-    this.withoutClosure = withoutClosure
-    this.virtualSource = `;${source};`
-  }
-  shouldIsolate() {
-    return !this.withoutClosure
-  }
-
-  generate() {
-    return this.virtualSource
-  }
-}
 
 // =================================================================
 // Plugin code
@@ -474,11 +444,7 @@ class LavaMoatPlugin {
         const onceForChunkSet = new WeakSet()
         const chunkRuntimeWarningsDedupe = new Set()
 
-        const {
-          getLavaMoatRuntimeSource,
-          getDefensiveCodingPreamble,
-          getStaticShims,
-        } = runtimeBuilder({
+        const { getLavaMoatRuntimeModules } = runtimeBuilder({
           options: STORE.options,
         })
 
@@ -527,8 +493,8 @@ class LavaMoatPlugin {
                   'runtimeOptimizedPolicy',
                 ])
 
-                const lavaMoatRuntime = getLavaMoatRuntimeSource({
-                  currentChunkName: chunk.name,
+                const lavaMoatRuntimeModules = getLavaMoatRuntimeModules({
+                  currentChunk: chunk,
                   chunkIds: STORE.chunkIds,
                   policyData: STORE.runtimeOptimizedPolicy,
                   identifiers: {
@@ -540,46 +506,11 @@ class LavaMoatPlugin {
                   },
                 })
 
-                const defensivePreamble = getDefensiveCodingPreamble()
-
-                compilation.addRuntimeModule(
-                  chunk,
-                  new VirtualRuntimeModule({
-                    name: 'LavaMoat/defensive',
-                    source: defensivePreamble,
-                    stage: RuntimeModule.STAGE_NORMAL, // before all other runtime modules
-                    withoutClosure: true, // run in the scope of the runtime closure
-                  })
-                )
-
-                if (
-                  STORE.options.staticShims_experimental &&
-                  Array.isArray(STORE.options.staticShims_experimental)
-                ) {
-                  const staticShimsWrapped = getStaticShims(
-                    STORE.options.staticShims_experimental
-                  )
-
-                  compilation.addRuntimeModule(
-                    chunk,
-                    new VirtualRuntimeModule({
-                      name: 'LavaMoat/staticShims_experimental',
-                      source: staticShimsWrapped,
-                      stage: RuntimeModule.STAGE_BASIC, // after Normal
-                    })
-                  )
-                }
-
                 // Add the runtime modules to the chunk, which handles
                 // the runtime logic for wrapping with lavamoat.
-                compilation.addRuntimeModule(
-                  chunk,
-                  new VirtualRuntimeModule({
-                    name: 'LavaMoat/runtime',
-                    source: lavaMoatRuntime,
-                    stage: RuntimeModule.STAGE_TRIGGER, // after all other stages
-                  })
-                )
+                lavaMoatRuntimeModules.forEach((module) => {
+                  compilation.addRuntimeModule(chunk, module)
+                })
 
                 // set.add(RuntimeGlobals.onChunksLoaded); // TODO: develop an understanding of what this line does and why it was a part of the runtime setup for module federation
 

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -553,17 +553,17 @@ class LavaMoatPlugin {
                 )
 
                 if (
-                  STORE.options.staticShims &&
-                  Array.isArray(STORE.options.staticShims)
+                  STORE.options.staticShims_experimental &&
+                  Array.isArray(STORE.options.staticShims_experimental)
                 ) {
                   const staticShimsWrapped = getStaticShims(
-                    STORE.options.staticShims
+                    STORE.options.staticShims_experimental
                   )
 
                   compilation.addRuntimeModule(
                     chunk,
                     new VirtualRuntimeModule({
-                      name: 'LavaMoat/staticShims',
+                      name: 'LavaMoat/staticShims_experimental',
                       source: staticShimsWrapped,
                       stage: RuntimeModule.STAGE_BASIC, // after Normal
                     })

--- a/packages/webpack/src/runtime/assemble.js
+++ b/packages/webpack/src/runtime/assemble.js
@@ -70,7 +70,7 @@ function prepareSource(specifier) {
 
 /**
  * @param {string} KEY
- * @param {RuntimeFragment[]} runtimeModules
+ * @param {readonly RuntimeFragment[]} runtimeModules
  * @returns {string}
  */
 const assembleRuntime = (KEY, runtimeModules) => {

--- a/packages/webpack/src/runtime/assemble.js
+++ b/packages/webpack/src/runtime/assemble.js
@@ -2,6 +2,10 @@ const { readFileSync } = require('node:fs')
 const { parse } = require('@babel/parser')
 
 /**
+ * Webpack adds a multiline comment in front of every line of the runtime code.
+ * They break actually-multiline comments as a result. This is a necessary step
+ * to prevent a runtime error in development mode.
+ *
  * @param {string} source
  * @returns {string}
  */

--- a/packages/webpack/src/runtime/assemble.js
+++ b/packages/webpack/src/runtime/assemble.js
@@ -66,7 +66,7 @@ function prepareSource(specifier) {
 
 /**
  * @param {string} KEY
- * @param {RuntimeModule[]} runtimeModules
+ * @param {RuntimeFragment[]} runtimeModules
  * @returns {string}
  */
 const assembleRuntime = (KEY, runtimeModules) => {
@@ -103,7 +103,7 @@ const assembleRuntime = (KEY, runtimeModules) => {
 }
 
 /**
- * @typedef RuntimeModule
+ * @typedef RuntimeFragment
  * @property {string} [file]
  * @property {unknown} [data]
  * @property {string} [name]

--- a/packages/webpack/src/runtime/assemble.js
+++ b/packages/webpack/src/runtime/assemble.js
@@ -1,17 +1,68 @@
 const { readFileSync } = require('node:fs')
+const { parse } = require('@babel/parser')
 
 /**
  * @param {string} source
  * @returns {string}
  */
 function removeMultilineComments(source) {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '')
+  try {
+    const ast = parse(source, { sourceType: 'script' })
+    return (ast.comments || [])
+      .filter((c) => c.type === 'CommentBlock')
+      .reverse()
+      .reduce(
+        (src, { start, end }) => src.slice(0, start) + src.slice(end),
+        source
+      )
+  } catch (e) {
+    throw Error(
+      `Failed to remove multiline comments. \n ${e} \n___________\n ${source}\n___________`
+    )
+  }
 }
-
 // Runtime modules are not being built nor wrapped by webpack, so I rolled my own tiny concatenator.
 // It's using a shared namespace technique instead of scoping `exports` variables
 // to avoid confusing anyone into believing it's actually CJS.
 // Criticism will only be accepted in a form of working PR with less total lines and less magic.
+
+/**
+ * Loads the source code for a given module specifier.
+ *
+ * @param {string} specifier - The module specifier to load.
+ * @returns {string} The loaded source code.
+ */
+function loadSource(specifier) {
+  return readFileSync(require.resolve(specifier), 'utf-8')
+}
+
+/**
+ * Wraps the source code for a given module in a function that simulates the
+ * CommonJS module system.
+ *
+ * @param {string} sourceString - The source code to wrap.
+ * @param {string} [name] - The name of the module.
+ * @returns {string} The wrapped source code.
+ */
+function shimSource(sourceString, name = 'unknown') {
+  return `;(()=>{
+        const module = {exports: {}};
+        const exports = module.exports;
+          ${removeMultilineComments(sourceString)}
+        ;
+        LAVAMOAT['${name}'] = module.exports;
+      })();`
+}
+
+/**
+ * Prepares the source code for a given module specifier.
+ *
+ * @param {string} specifier - The module specifier to prepare.
+ * @returns {string} The prepared source code.
+ */
+function prepareSource(specifier) {
+  return removeMultilineComments(loadSource(specifier))
+}
 
 /**
  * @param {string} KEY
@@ -24,29 +75,22 @@ const assembleRuntime = (KEY, runtimeModules) => {
     let sourceString
     if (file) {
       sourceString = readFileSync(file, 'utf-8')
-      sourceString = removeMultilineComments(sourceString)
+    }
+    if (rawSource) {
+      sourceString = rawSource
     }
     if (data) {
       sourceString = JSON.stringify(data)
     }
     if (json) {
       sourceString = `LAVAMOAT['${name}'] = (${sourceString});`
-    }
-    if (rawSource) {
-      sourceString = rawSource
-    }
-    if (shimRequire) {
-      sourceString = readFileSync(require.resolve(shimRequire), 'utf-8')
-    }
-    if ((rawSource || shimRequire) && sourceString) {
-      sourceString = removeMultilineComments(sourceString)
-      sourceString = `;(()=>{
-        const module = {exports: {}};
-        const exports = module.exports;
-          ${sourceString}
-        ;
-        LAVAMOAT['${name}'] = module.exports;
-      })();`
+    } else {
+      if (shimRequire) {
+        sourceString = loadSource(shimRequire)
+      }
+      if ((file || rawSource || shimRequire) && sourceString) {
+        sourceString = shimSource(sourceString, name)
+      }
     }
     if (sourceString) {
       assembly += `\n;/*${name}*/;\n${sourceString}`
@@ -68,4 +112,4 @@ const assembleRuntime = (KEY, runtimeModules) => {
  * @property {string} [shimRequire]
  */
 
-module.exports = { assembleRuntime }
+module.exports = { assembleRuntime, prepareSource, removeMultilineComments }

--- a/packages/webpack/src/runtime/lavamoat.d.ts
+++ b/packages/webpack/src/runtime/lavamoat.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="ses" />
 
 declare const LAVAMOAT: import('./runtime-namespace.js').RuntimeNamespace
+declare const LOCKDOWN_SHIMS: Array<() => void>

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -1,5 +1,4 @@
 /// <reference path="./lavamoat.d.ts" />
-/* global LAVAMOAT */
 /* global Compartment */
 const {
   keys,
@@ -23,7 +22,13 @@ const warn = typeof console === 'object' ? console.warn : () => {}
 // It was previously useful for sub-compilations running an incomplete bundle as part of the build, but currently that is being skipped. We might go back to it for the sake of build time security if it's deemed worthwihile in absence of lockdown.
 const LOCKDOWN_ON = typeof lockdown !== 'undefined'
 if (LOCKDOWN_ON) {
-  lockdown(LAVAMOAT.options.lockdown)
+  repairIntrinsics(LAVAMOAT.options.lockdown)
+
+  LOCKDOWN_SHIMS.forEach((shim) => {
+    shim()
+  })
+
+  hardenIntrinsics()
 } else {
   warn(
     'LavaMoatPlugin: runtime execution started without SES present, switching to no-op.'

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -3,20 +3,8 @@
 /* global LAVAMOAT */
 /* global LOCKDOWN_SHIMS */
 /* global hardenIntrinsics */
-const {
-  keys,
-  create,
-  freeze,
-  assign,
-  defineProperty,
-  defineProperties,
-  getOwnPropertyDescriptors,
-  fromEntries,
-  entries,
-  values,
-} = Object
 
-const { repairIntrinsics, Proxy, Math, Date } = globalThis
+const { repairIntrinsics, } = globalThis
 
 const warn = typeof console === 'object' ? console.warn : () => {}
 
@@ -37,6 +25,21 @@ if (LOCKDOWN_ON) {
     'LavaMoatPlugin: runtime execution started without SES present, switching to no-op.'
   )
 }
+
+const {
+  keys,
+  create,
+  freeze,
+  assign,
+  defineProperty,
+  defineProperties,
+  getOwnPropertyDescriptors,
+  fromEntries,
+  entries,
+  values,
+} = Object
+
+const { Proxy, Math, Date } = globalThis
 
 // harden appears on globalThis only after lockdown is called
 const { harden } = globalThis

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -1,5 +1,8 @@
 /// <reference path="./lavamoat.d.ts" />
 /* global Compartment */
+/* global LAVAMOAT */
+/* global LOCKDOWN_SHIMS */
+/* global hardenIntrinsics */
 const {
   keys,
   create,
@@ -13,14 +16,14 @@ const {
   values,
 } = Object
 
-const { lockdown, Proxy, Math, Date } = globalThis
+const { repairIntrinsics, Proxy, Math, Date } = globalThis
 
 const warn = typeof console === 'object' ? console.warn : () => {}
 
 // Avoid running any wrapped code or using compartment if lockdown was not called.
 // This is for when the bundle ends up running despite SES being missing.
 // It was previously useful for sub-compilations running an incomplete bundle as part of the build, but currently that is being skipped. We might go back to it for the sake of build time security if it's deemed worthwihile in absence of lockdown.
-const LOCKDOWN_ON = typeof lockdown !== 'undefined'
+const LOCKDOWN_ON = typeof repairIntrinsics !== 'undefined'
 if (LOCKDOWN_ON) {
   repairIntrinsics(LAVAMOAT.options.lockdown)
 

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -3,9 +3,53 @@ const diag = require('../buildtime/diagnostics.js')
 const { assembleRuntime, prepareSource } = require('./assemble.js')
 const path = require('node:path')
 
-/** @import {LavaMoatPluginOptions} from '../buildtime/types' */
+const { RuntimeModule } = require('webpack')
+
+class VirtualRuntimeModule extends RuntimeModule {
+  /**
+   * @param {Object} options - The options for the VirtualRuntimeModule.
+   * @param {string} options.name - The name of the module.
+   * @param {string} options.source - The source code of the module.
+   * @param {number} [options.stage] - The stage of runtime. One of
+   *   RuntimeModule.STAGE_*.
+   * @param {boolean} [options.withoutClosure] - Make the source code run
+   *   outside the closure for a runtime module
+   */
+  constructor({
+    name,
+    source,
+    stage = RuntimeModule.STAGE_NORMAL,
+    withoutClosure = false,
+  }) {
+    super(name, stage)
+    this.withoutClosure = withoutClosure
+    this.virtualSource = `;${source};`
+  }
+  shouldIsolate() {
+    return !this.withoutClosure
+  }
+
+  generate() {
+    return this.virtualSource
+  }
+}
+
+/** @import {LavaMoatPluginOptions, LavaMoatChunkRuntimeConfiguration} from '../buildtime/types' */
 /** @import {LavaMoatPolicy} from 'lavamoat-core' */
-/** @import {RuntimeModule} from './assemble.js' */
+/** @import {RuntimeFragment} from './assemble.js' */
+/** @import {Chunk} from 'webpack' */
+
+/**
+ * @typedef {Object} LavaMoatRuntimeIdentifiers
+ * @property {string} root - Root identifier
+ * @property {[string, (string | number)[]][]} identifiersForModuleIds - Module
+ *   ID to identifier mappings
+ * @property {(string | number)[]} unenforceableModuleIds - IDs of modules that
+ *   cannot be enforced
+ * @property {(string | number)[]} [contextModuleIds] - Context module IDs
+ * @property {Record<string | number, string>} [externals] - External module
+ *   configurations
+ */
 
 module.exports = {
   /**
@@ -21,43 +65,42 @@ module.exports = {
       lockdown: options.lockdown,
     }
 
-    return {
-      /**
-       * Generates the preamble that caches selected globals to protect runtime
-       * from scuttling. The set of cached globals is limited to ones known to
-       * be used by runtime modules for the sake of bundle size.
-       *
-       * @returns {string}
-       */
-      getDefensiveCodingPreamble() {
-        const globals = [
-          'location', // AutoPublicPathRuntimeModule.js
-          'setTimeout', // LoadScriptRuntimeModule.js
-          'clearTimeout', // LoadScriptRuntimeModule.js
-          'document', // LoadScriptRuntimeModule.js, AutoPublicPathRuntimeModule.js
-          'trustedTypes', // GetTrustedTypesPolicyRuntimeModule.js
-          'self',
-        ]
-        return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};
+    /**
+     * Generates the preamble that caches selected globals to protect runtime
+     * from scuttling. The set of cached globals is limited to ones known to be
+     * used by runtime modules for the sake of bundle size.
+     *
+     * @returns {string}
+     */
+    function getDefensiveCodingPreamble() {
+      const globals = [
+        'location', // AutoPublicPathRuntimeModule.js
+        'setTimeout', // LoadScriptRuntimeModule.js
+        'clearTimeout', // LoadScriptRuntimeModule.js
+        'document', // LoadScriptRuntimeModule.js, AutoPublicPathRuntimeModule.js
+        'trustedTypes', // GetTrustedTypesPolicyRuntimeModule.js
+        'self',
+      ]
+      return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};
 const LOCKDOWN_SHIMS = [];`
-      },
+    }
 
+    /**
+     * Prepares the static shims to be included in the runtime chunk.
+     *
+     * @param {string[]} dependencies - The module specifiers to prepare.
+     * @returns {string} The prepared runtime dependencies source.
+     */
+    function getStaticShims(dependencies) {
       /**
-       * Prepares the static shims to be included in the runtime chunk.
+       * Wraps static shim source code to capture the lockdown shim it sets (if
+       * any) Makes LOCKDOWN_SHIMS unreachable in its scope and freezes so no
+       * other runtime modules can add any new shims to it.
        *
-       * @param {string[]} dependencies - The module specifiers to prepare.
-       * @returns {string} The prepared runtime dependencies source.
+       * @param {string} source - The source code to wrap.
+       * @returns {string} The wrapped source code.
        */
-      getStaticShims(dependencies) {
-        /**
-         * Wraps static shim source code to capture the lockdown shim it sets
-         * (if any) Makes LOCKDOWN_SHIMS unreachable in its scope and freezes so
-         * no other runtime modules can add any new shims to it.
-         *
-         * @param {string} source - The source code to wrap.
-         * @returns {string} The wrapped source code.
-         */
-        const shimWrap = (source) => `;{
+      const shimWrap = (source) => `;{
           let LOCKDOWN_SHIM;((LOCKDOWN_SHIMS)=>{
             ${source}
           ;
@@ -67,184 +110,276 @@ const LOCKDOWN_SHIMS = [];`
           };
         }`
 
-        const shims = dependencies.map((dep) => {
-          const source = prepareSource(dep)
-          try {
-            new Function(source)
-          } catch (e) {
-            throw new Error(
-              `LavaMoatPlugin: Static shim ${dep} is not valid JS`,
-              { cause: e }
-            )
-          }
-          return shimWrap(source)
-        })
+      const shims = dependencies.map((dep) => {
+        const source = prepareSource(dep)
+        try {
+          new Function(source)
+        } catch (e) {
+          throw new Error(
+            `LavaMoatPlugin: Static shim ${dep} is not valid JS`,
+            { cause: e }
+          )
+        }
+        return shimWrap(source)
+      })
 
-        return `${shims.join('\n')}
+      return `${shims.join('\n')}
         Object.freeze(LOCKDOWN_SHIMS);`
-      },
+    }
 
+    function getUnlockedRuntime() {
+      /** @type {RuntimeFragment[]} */
+      const runtimeFragments = [
+        {
+          name: 'ENUM',
+          file: require.resolve('../ENUM.json'),
+          json: true,
+        },
+        {
+          name: 'runtime',
+          file: require.resolve('./runtimeUnlocked.js'),
+        },
+      ]
+
+      const unlockedRuntime = assembleRuntime(RUNTIME_KEY, runtimeFragments)
+
+      return unlockedRuntime
+    }
+
+    /**
+     * Generates the LavaMoat runtime source code based on chunk configuration
+     *
+     * @param {Object} params - The parameters object
+     * @param {(string | number)[]} params.chunkIds - Array of chunk identifiers
+     * @param {LavaMoatPolicy} params.policyData - LavaMoat security policy
+     *   configuration
+     * @param {LavaMoatRuntimeIdentifiers} params.identifiers - Object
+     *   containing module identifier mappings
+     * @returns {string} The assembled runtime source code
+     */
+    function getLavaMoatRuntimeSource({
+      chunkIds,
+      policyData,
+      identifiers: {
+        root,
+        identifiersForModuleIds,
+        unenforceableModuleIds,
+        contextModuleIds,
+        externals,
+      },
+    }) {
+      let repairs
+      if (options.skipRepairs === true) {
+        repairs = ''
+      } else {
+        repairs = require('./repairsBuilder.js').buildRepairs(
+          policyData,
+          options.skipRepairs
+        )
+      }
+
+      /** @type {RuntimeFragment[]} */
+      const runtimeFragments = [
+        // the string used to indicate root resource id
+        {
+          name: 'root',
+          data: root,
+          json: true,
+        },
+        // a mapping used to look up resource ids by module id
+        {
+          name: 'idmap',
+          data: identifiersForModuleIds,
+          json: true,
+        },
+        // list of ids of modules to skip in policy enforcement
+        {
+          name: 'unenforceable',
+          data: unenforceableModuleIds,
+          json: true,
+        },
+        // list of known context modules
+        {
+          name: 'ctxm',
+          data: contextModuleIds || null,
+          json: true,
+        },
+        // known chunk ids
+        {
+          name: 'kch',
+          data: chunkIds,
+          json: true,
+        },
+        // a record of module ids that are externals and need to be enforced as builtins
+        {
+          name: 'externals',
+          data: externals || null,
+          json: true,
+        },
+        // options to turn on scuttling
+        { name: 'options', data: runtimeOptions, json: true },
+        // scuttling module, if needed
+        (typeof runtimeOptions?.scuttleGlobalThis === 'boolean' &&
+          runtimeOptions.scuttleGlobalThis === true) ||
+        (typeof runtimeOptions?.scuttleGlobalThis === 'object' &&
+          runtimeOptions.scuttleGlobalThis.enabled === true)
+          ? {
+              name: 'scuttling',
+              shimRequire: 'lavamoat-core/src/scuttle.js',
+            }
+          : {},
+        // the policy itself
+        { name: 'policy', data: policyData, json: true },
+        // enum for keys to match the generated ones in wrapper
+        {
+          name: 'ENUM',
+          file: require.resolve('../ENUM.json'),
+          json: true,
+        },
+        // endowments module
+        {
+          name: 'endowmentsToolkit',
+          shimRequire: 'lavamoat-core/src/endowmentsToolkit.js',
+        },
+        // repairs
+        {
+          name: 'repairs',
+          rawSource: repairs,
+        },
+        // main lavamoat runtime
+        {
+          name: 'runtime',
+          file: require.resolve('./runtime.js'),
+        },
+      ]
+
+      if (options.debugRuntime) {
+        // optional debug helpers
+        runtimeFragments.push({
+          name: 'debug',
+          shimRequire: path.join(__dirname, 'debug.js'),
+        })
+      }
+
+      const lavaMoatRuntime = assembleRuntime(RUNTIME_KEY, runtimeFragments)
+      const size = lavaMoatRuntime.length / 1024
+      diag.rawDebug(
+        2,
+        `Total LavaMoat runtime and policy data size: ${size.toFixed(0)}KB (before minification)`
+      )
+
+      return lavaMoatRuntime
+    }
+
+    return {
       /**
        * Generates the LavaMoat runtime source code based on chunk configuration
        *
        * @param {Object} params - The parameters object
-       * @param {string | undefined} params.currentChunkName - The webpack chunk
-       *   object
+       * @param {Chunk} params.currentChunk - The webpack chunk
        * @param {(string | number)[]} params.chunkIds - Array of chunk
        *   identifiers
        * @param {LavaMoatPolicy} params.policyData - LavaMoat security policy
        *   configuration
-       * @param {Object} params.identifiers - Object containing module
-       *   identifier mappings
-       * @param {string} params.identifiers.root - Root identifier
-       * @param {[string, (string | number)[]][]} params.identifiers.identifiersForModuleIds
-       *   - Module ID to identifier mappings
-       *
-       * @param {(string | number)[]} params.identifiers.unenforceableModuleIds
-       *   - IDs of modules that cannot be enforced
-       *
-       * @param {(string | number)[]} [params.identifiers.contextModuleIds] -
-       *   Context module IDs
-       * @param {Record<string | number, string>} [params.identifiers.externals]
-       *   - External module configurations
-       *
-       * @returns {string} The assembled runtime source code
+       * @param {LavaMoatRuntimeIdentifiers} params.identifiers - Object
+       *   containing module identifier mappings
+       * @returns {VirtualRuntimeModule[]} The assembled runtime source code
        */
-      getLavaMoatRuntimeSource({
-        currentChunkName,
+      getLavaMoatRuntimeModules({
+        currentChunk,
         chunkIds,
         policyData,
-        identifiers: {
-          root,
-          identifiersForModuleIds,
-          unenforceableModuleIds,
-          contextModuleIds,
-          externals,
-        },
+        identifiers,
       }) {
-        /** @type {RuntimeModule[]} */
-        let runtimeChunks = []
+        const currentChunkName = currentChunk.name
+
+        const lavamoatRuntimeModules = [
+          new VirtualRuntimeModule({
+            name: 'LavaMoat/defensive',
+            source: getDefensiveCodingPreamble(),
+            stage: RuntimeModule.STAGE_NORMAL, // before all other runtime modules
+            withoutClosure: true, // run in the scope of the runtime closure
+          }),
+        ]
+
+        /** @type {LavaMoatChunkRuntimeConfiguration} */
+        let runtimeConfiguration = {
+          mode: 'safe',
+          staticShims: options.staticShims_experimental,
+        }
+
+        // plugin options decide the mode
         if (
+          options.unlockedChunksUnsafe &&
           currentChunkName &&
-          options.unlockedChunksUnsafe?.test(currentChunkName)
+          options.unlockedChunksUnsafe.test(currentChunkName)
         ) {
-          diag.rawDebug(
-            1,
-            `adding UNLOCKED runtime for chunk ${currentChunkName}`
-          )
-          runtimeChunks = [
-            {
-              name: 'ENUM',
-              file: require.resolve('../ENUM.json'),
-              json: true,
-            },
-            {
-              name: 'runtime',
-              file: require.resolve('./runtimeUnlocked.js'),
-            },
-          ]
-        } else {
-          diag.rawDebug(2, `adding runtime for chunk ${currentChunkName}`)
-          let repairs
-          if (options.skipRepairs === true) {
-            repairs = ''
-          } else {
-            repairs = require('./repairsBuilder.js').buildRepairs(
-              policyData,
-              options.skipRepairs
-            )
-          }
-
-          runtimeChunks = [
-            // the string used to indicate root resource id
-            {
-              name: 'root',
-              data: root,
-              json: true,
-            },
-            // a mapping used to look up resource ids by module id
-            {
-              name: 'idmap',
-              data: identifiersForModuleIds,
-              json: true,
-            },
-            // list of ids of modules to skip in policy enforcement
-            {
-              name: 'unenforceable',
-              data: unenforceableModuleIds,
-              json: true,
-            },
-            // list of known context modules
-            {
-              name: 'ctxm',
-              data: contextModuleIds || null,
-              json: true,
-            },
-            // known chunk ids
-            {
-              name: 'kch',
-              data: chunkIds,
-              json: true,
-            },
-            // a record of module ids that are externals and need to be enforced as builtins
-            {
-              name: 'externals',
-              data: externals || null,
-              json: true,
-            },
-            // options to turn on scuttling
-            { name: 'options', data: runtimeOptions, json: true },
-            // scuttling module, if needed
-            (typeof runtimeOptions?.scuttleGlobalThis === 'boolean' &&
-              runtimeOptions.scuttleGlobalThis === true) ||
-            (typeof runtimeOptions?.scuttleGlobalThis === 'object' &&
-              runtimeOptions.scuttleGlobalThis.enabled === true)
-              ? {
-                  name: 'scuttling',
-                  shimRequire: 'lavamoat-core/src/scuttle.js',
-                }
-              : {},
-            // the policy itself
-            { name: 'policy', data: policyData, json: true },
-            // enum for keys to match the generated ones in wrapper
-            {
-              name: 'ENUM',
-              file: require.resolve('../ENUM.json'),
-              json: true,
-            },
-            // endowments module
-            {
-              name: 'endowmentsToolkit',
-              shimRequire: 'lavamoat-core/src/endowmentsToolkit.js',
-            },
-            // repairs
-            {
-              name: 'repairs',
-              rawSource: repairs,
-            },
-            // main lavamoat runtime
-            {
-              name: 'runtime',
-              file: require.resolve('./runtime.js'),
-            },
-          ]
-
-          if (options.debugRuntime) {
-            // optional debug helpers
-            runtimeChunks.push({
-              name: 'debug',
-              shimRequire: path.join(__dirname, 'debug.js'),
-            })
+          runtimeConfiguration = {
+            mode: 'unlocked_unsafe',
           }
         }
-        const lavaMoatRuntime = assembleRuntime(RUNTIME_KEY, runtimeChunks)
-        const size = lavaMoatRuntime.length / 1024
-        diag.rawDebug(
-          2,
-          `Total LavaMoat runtime and policy data size: ${size.toFixed(0)}KB (before minification)`
-        )
+        if (options.runtimeConfigurationPerChunk_experimental) {
+          const chunkConfig =
+            options.runtimeConfigurationPerChunk_experimental(currentChunk)
+          if (chunkConfig) {
+            runtimeConfiguration = {
+              mode: chunkConfig.mode || runtimeConfiguration.mode,
+              staticShims:
+                chunkConfig.staticShims || runtimeConfiguration.staticShims,
+            }
+          }
+        }
 
-        return lavaMoatRuntime
+        // flesh out the modules for runtimeConfiguration
+        switch (runtimeConfiguration.mode) {
+          case 'unlocked_unsafe':
+            diag.rawDebug(
+              1,
+              `adding UNLOCKED runtime for chunk ${currentChunkName}`
+            )
+
+            lavamoatRuntimeModules.push(
+              new VirtualRuntimeModule({
+                name: 'LavaMoat/runtime',
+                source: getUnlockedRuntime(),
+                stage: RuntimeModule.STAGE_TRIGGER, // after all other stages
+              })
+            )
+            break
+          case 'safe':
+            diag.rawDebug(2, `adding runtime for chunk ${currentChunkName}`)
+            lavamoatRuntimeModules.push(
+              new VirtualRuntimeModule({
+                name: 'LavaMoat/runtime',
+                source: getLavaMoatRuntimeSource({
+                  chunkIds,
+                  policyData,
+                  identifiers,
+                }),
+                stage: RuntimeModule.STAGE_TRIGGER, // after all other stages
+              })
+            )
+            break
+        }
+
+        if (
+          runtimeConfiguration.staticShims &&
+          Array.isArray(runtimeConfiguration.staticShims)
+        ) {
+          const staticShimsWrapped = getStaticShims(
+            runtimeConfiguration.staticShims
+          )
+
+          lavamoatRuntimeModules.push(
+            new VirtualRuntimeModule({
+              name: 'LavaMoat/staticShims',
+              source: staticShimsWrapped,
+              stage: RuntimeModule.STAGE_BASIC, // after Normal
+            })
+          )
+        }
+
+        return lavamoatRuntimeModules
       },
     }
   },

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -95,15 +95,11 @@ const LOCKDOWN_SHIMS = [];`
        * @param {string} source - The source code to wrap.
        * @returns {string} The wrapped source code.
        */
-      const shimWrap = (source) => `;{
-          let LOCKDOWN_SHIM;((LOCKDOWN_SHIMS)=>{
+      const shimWrap = (source) => `
+          LOCKDOWN_SHIMS.push((LOCKDOWN_SHIMS)=>{
             ${source}
           ;
-          })();
-          if(typeof LOCKDOWN_SHIM === 'function') {
-            LOCKDOWN_SHIMS.push(LOCKDOWN_SHIM)
-          };
-        }`
+          })`
 
       const shims = dependencies.map((dep) => {
         const source = prepareSource(dep)

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -119,8 +119,8 @@ const LOCKDOWN_SHIMS = [];`
     }
 
     function getUnlockedRuntime() {
-      /** @type {RuntimeFragment[]} */
-      const runtimeFragments = [
+      /** @satisfies {RuntimeFragment[]} */
+      const runtimeFragments = /** @type {const} */([
         {
           name: 'ENUM',
           file: require.resolve('../ENUM.json'),
@@ -130,7 +130,7 @@ const LOCKDOWN_SHIMS = [];`
           name: 'runtime',
           file: require.resolve('./runtimeUnlocked.js'),
         },
-      ]
+      ])
 
       const unlockedRuntime = assembleRuntime(RUNTIME_KEY, runtimeFragments)
 

--- a/packages/webpack/test/assemble.spec.js
+++ b/packages/webpack/test/assemble.spec.js
@@ -152,3 +152,22 @@ test('removes multiple comments in nested closures', (t) => {
 })();`
   t.is(removeMultilineComments(input), expected)
 })
+
+test('handles lone surrogates in comments', (t) => {
+  const input = `const a = /* comment with \uD800 high surrogate */ 5; const b = /* \uDC00 low surrogate */ 6;`
+  const expected = `const a =  5; const b =  6;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles surrogate pairs in and around comments', (t) => {
+  const input = `const x = /* \uD800\uDC00 surrogate pair in comment */ "\uD800\uDC00"; /* comment */ const y = '\uD800'; /* \uD800 */ const z = '\uDC00';`
+  const expected = `const x =  "\uD800\uDC00";  const y = '\uD800';  const z = '\uDC00';`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles non-BMP characters in comments', (t) => {
+  // Using a mathematical symbol outside BMP: 𝄞 (U+1D11E, MUSICAL SYMBOL G CLEF)
+  const input = `const music = /* 𝄞 musical clef comment 𝄞 */ "𝄞";`
+  const expected = `const music =  "𝄞";`
+  t.is(removeMultilineComments(input), expected)
+})

--- a/packages/webpack/test/assemble.spec.js
+++ b/packages/webpack/test/assemble.spec.js
@@ -1,0 +1,154 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { removeMultilineComments } = require('../src/runtime/assemble')
+
+test('preserves comments inside string literals', (t) => {
+  const input = `const str = "This is a /* not a comment */ string";`
+  const expected = `const str = "This is a /* not a comment */ string";`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves comments inside template literals', (t) => {
+  const input = `const template = \`This is /* not a comment */ in template\`;`
+  const expected = `const template = \`This is /* not a comment */ in template\`;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves comment-like patterns in regex literals', (t) => {
+  const input = `const regex = /\\/\\*.*?\\*\\//g;`
+  const expected = `const regex = /\\/\\*.*?\\*\\//g;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes actual comments between code', (t) => {
+  const input = `const a = 5; /* comment */ const b = 10;`
+  const expected = `const a = 5;  const b = 10;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes multiline comments', (t) => {
+  const input = `const a = 5;
+/* This is a
+   multiline
+   comment */
+const b = 10;`
+  const expected = `const a = 5;
+
+const b = 10;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles nested comment syntax correctly', (t) => {
+  const input = `/* outer /* inner */ const a = 5;`
+  const expected = ` const a = 5;`
+  t.is(removeMultilineComments(input), expected)
+  // Note: JS doesn't support nested comments, so /* inner */ ends the comment
+})
+
+test('preserves URL strings with /* patterns', (t) => {
+  const input = `const url = "https://example.com/*";`
+  const expected = `const url = "https://example.com/*";`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves glob patterns', (t) => {
+  const input = `const pattern = "glob/pattern/*.js";`
+  const expected = `const pattern = "glob/pattern/*.js";`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes comments in mathematical expressions', (t) => {
+  const input = `const result = 5 /* multiplied by */ * /* two */ 2;`
+  const expected = `const result = 5  *  2;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves JSON strings with comment-like content', (t) => {
+  const input = `const json = '{"pattern": "/*", "glob": "*.js"}';`
+  const expected = `const json = '{"pattern": "/*", "glob": "*.js"}';`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles multiple comments on same line', (t) => {
+  const input = `const a = /* first */ 5 /* second */ + /* third */ 3;`
+  const expected = `const a =  5  +  3;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves single-line // comments', (t) => {
+  const input = `const a = 5; // this is a single line comment`
+  const expected = `const a = 5; // this is a single line comment`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes JSDoc comments', (t) => {
+  const input = `/**
+ * This is a JSDoc comment
+ * @param {string} x
+ */
+function foo(x) {}`
+  const expected = `
+function foo(x) {}`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles edge case with division and pointer-like syntax', (t) => {
+  const input = `const x = a / /* comment */ b;`
+  const expected = `const x = a /  b;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('preserves escaped characters in strings', (t) => {
+  const input = `const str = "This is \\"/* not a comment */\\" string";`
+  const expected = `const str = "This is \\"/* not a comment */\\" string";`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles comment at start of file', (t) => {
+  const input = `/* comment at start */const a = 5;`
+  const expected = `const a = 5;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles comment at end of file', (t) => {
+  const input = `const a = 5;/* comment at end */`
+  const expected = `const a = 5;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('handles empty comment', (t) => {
+  const input = `const a = /**/ 5;`
+  const expected = `const a =  5;`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes multiline comment inside function closure', (t) => {
+  const input = `const fn = (function() {
+  /* This is a multiline
+     comment inside
+     a closure */
+  return 42;
+})();`
+  const expected = `const fn = (function() {
+  
+  return 42;
+})();`
+  t.is(removeMultilineComments(input), expected)
+})
+
+test('removes multiple comments in nested closures', (t) => {
+  const input = `const result = (function outer() {
+  /* outer comment */
+  return (function inner() {
+    /* inner comment */
+    return 5;
+  })();
+})();`
+  const expected = `const result = (function outer() {
+  
+  return (function inner() {
+    
+    return 5;
+  })();
+})();`
+  t.is(removeMultilineComments(input), expected)
+})

--- a/packages/webpack/test/e2e-static-shims.spec.js
+++ b/packages/webpack/test/e2e-static-shims.spec.js
@@ -7,7 +7,6 @@ test('webpack/static-shims - bundle runs and uses static shims', async (t) => {
   const webpackConfig = makeConfig({
     inlineLockdown: /app/,
     staticShims_experimental: [
-      path.join(__dirname, 'fixtures/static-shims/shim-before.js'),
       path.join(__dirname, 'fixtures/static-shims/shim-lockdown.js'),
     ],
   })
@@ -35,7 +34,6 @@ test('webpack/static-shims - staticShims via runtimeConfigurationPerChunk_experi
       if (chunk.name === 'app') {
         return {
           staticShims: [
-            path.join(__dirname, 'fixtures/static-shims/shim-before.js'),
             path.join(__dirname, 'fixtures/static-shims/shim-lockdown.js'),
           ],
         }

--- a/packages/webpack/test/e2e-static-shims.spec.js
+++ b/packages/webpack/test/e2e-static-shims.spec.js
@@ -3,7 +3,7 @@ const { scaffold, runScript } = require('./scaffold.js')
 const { makeConfig } = require('./fixtures/main/webpack.config.js')
 const path = require('node:path')
 
-test.before(async (t) => {
+test('webpack/static-shims - bundle runs and uses static shims', async (t) => {
   const webpackConfig = makeConfig({
     inlineLockdown: /app/,
     staticShims_experimental: [
@@ -13,21 +13,62 @@ test.before(async (t) => {
   })
   webpackConfig.mode = 'development'
 
-  await t.notThrowsAsync(async () => {
-    t.context.build = await scaffold(webpackConfig)
-  }, 'Expected the build to succeed')
-  t.context.bundle = t.context.build.snapshot['/dist/app.js']
-})
+  const build = await scaffold(webpackConfig)
 
-test('webpack/static-shims - bundle runs and uses static shims', (t) => {
   t.notThrows(() => {
+    // TODO: switch to runChunks
     runScript(
-      t.context.bundle +
+      build.snapshot['/dist/app.js'] +
         `
     ;;
-      assert(globalThis.SHIM_WORKS, 'expected basic shim to work');
-      assert(globalThis.Promise.LOCKDOWN_SHIM_WORKS, 'expected lockdown shim to work');
+      if(!globalThis.SHIM_WORKS) throw new Error('expected basic shim to work');
+      if(!globalThis.Promise.LOCKDOWN_SHIM_WORKS) throw new Error('expected lockdown shim to work');
 `
     )
   })
+})
+
+test('webpack/static-shims - staticShims via runtimeConfigurationPerChunk_experimental', async (t) => {
+  const webpackConfig = makeConfig({
+    inlineLockdown: /app/,
+    runtimeConfigurationPerChunk_experimental: (chunk) => {
+      if (chunk.name === 'app') {
+        return {
+          staticShims: [
+            path.join(__dirname, 'fixtures/static-shims/shim-before.js'),
+            path.join(__dirname, 'fixtures/static-shims/shim-lockdown.js'),
+          ],
+        }
+      }
+    },
+  })
+  webpackConfig.entry.bpp = './simple.js'
+  webpackConfig.mode = 'development'
+
+  const build = await scaffold(webpackConfig)
+
+  t.notThrows(() => {
+    // TODO: switch to runChunks
+    runScript(
+      build.snapshot['/dist/app.js'] +
+        `
+    ;;
+      if(!globalThis.SHIM_WORKS) throw new Error('expected basic shim to work');
+      if(!globalThis.Promise.LOCKDOWN_SHIM_WORKS) throw new Error('expected lockdown shim to work');
+`
+    )
+  })
+  t.throws(
+    () => {
+      // TODO: switch to runChunks
+      runScript(
+        build.snapshot['/dist/bpp.js'] +
+          `
+    ;;
+      if(!globalThis.SHIM_WORKS) throw new Error('expected basic shim to work');
+`
+      )
+    },
+    { message: 'expected basic shim to work' }
+  )
 })

--- a/packages/webpack/test/e2e-static-shims.spec.js
+++ b/packages/webpack/test/e2e-static-shims.spec.js
@@ -1,0 +1,33 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { scaffold, runScript } = require('./scaffold.js')
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
+const path = require('path')
+
+test.before(async (t) => {
+  const webpackConfig = makeConfig({
+    inlineLockdown: /app/,
+    staticShims: [
+      path.join(__dirname, 'fixtures/static-shims/shim-before.js'),
+      path.join(__dirname, 'fixtures/static-shims/shim-lockdown.js'),
+    ],
+  })
+  webpackConfig.mode = 'development'
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+  }, 'Expected the build to succeed')
+  t.context.bundle = t.context.build.snapshot['/dist/app.js']
+})
+
+test('webpack/static-shims - bundle runs and uses static shims', (t) => {
+  t.notThrows(() => {
+    runScript(
+      t.context.bundle +
+        `
+    ;;
+      assert(globalThis.SHIM_WORKS, 'expected basic shim to work');
+      assert(globalThis.Promise.LOCKDOWN_SHIM_WORKS, 'expected lockdown shim to work');
+`
+    )
+  })
+})

--- a/packages/webpack/test/e2e-static-shims.spec.js
+++ b/packages/webpack/test/e2e-static-shims.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 test.before(async (t) => {
   const webpackConfig = makeConfig({
     inlineLockdown: /app/,
-    staticShims: [
+    staticShims_experimental: [
       path.join(__dirname, 'fixtures/static-shims/shim-before.js'),
       path.join(__dirname, 'fixtures/static-shims/shim-lockdown.js'),
     ],

--- a/packages/webpack/test/e2e-static-shims.spec.js
+++ b/packages/webpack/test/e2e-static-shims.spec.js
@@ -1,7 +1,7 @@
 const test = /** @type {import('ava').TestFn} */ (require('ava'))
 const { scaffold, runScript } = require('./scaffold.js')
 const { makeConfig } = require('./fixtures/main/webpack.config.js')
-const path = require('path')
+const path = require('node:path')
 
 test.before(async (t) => {
   const webpackConfig = makeConfig({

--- a/packages/webpack/test/fixtures/static-shims/shim-before.js
+++ b/packages/webpack/test/fixtures/static-shims/shim-before.js
@@ -1,1 +1,0 @@
-globalThis.SHIM_WORKS = true;

--- a/packages/webpack/test/fixtures/static-shims/shim-before.js
+++ b/packages/webpack/test/fixtures/static-shims/shim-before.js
@@ -1,0 +1,1 @@
+globalThis.SHIM_WORKS = true;

--- a/packages/webpack/test/fixtures/static-shims/shim-lockdown.js
+++ b/packages/webpack/test/fixtures/static-shims/shim-lockdown.js
@@ -1,0 +1,4 @@
+LOCKDOWN_SHIM = function addSESGlobals() {
+  // Prove it's possible to shim between repairs and hardening
+  globalThis.Promise.LOCKDOWN_SHIM_WORKS = true
+}

--- a/packages/webpack/test/fixtures/static-shims/shim-lockdown.js
+++ b/packages/webpack/test/fixtures/static-shims/shim-lockdown.js
@@ -1,4 +1,2 @@
-LOCKDOWN_SHIM = function addSESGlobals() {
-  // Prove it's possible to shim between repairs and hardening
-  globalThis.Promise.LOCKDOWN_SHIM_WORKS = true
-}
+globalThis.SHIM_WORKS = true;
+globalThis.Promise.LOCKDOWN_SHIM_WORKS = true;

--- a/packages/webpack/test/scaffold.js
+++ b/packages/webpack/test/scaffold.js
@@ -116,7 +116,6 @@ const defaultGlobals = () => ({
   URL,
 })
 
-
 /** @import {Context} from 'node:vm' */
 
 /**


### PR DESCRIPTION
Adds an option to do vetted shims inbetween lockdown phases and including files before things start.

Useful for:
- polyfills to intrinsics / vetted shims
- including Snow with the runtime and setting it up

Could also expose:
- a way to run after lockdown 
- a way to define a per-compartment custom repair
But I'm not sure If I want those to be webpack specific.

I think none of this should be webpack specific. 

I just convinced myself to mark this feature as experimental.
