### PR TITLE
fix(core): noSharedPrototype case in copyWrappedGlobals must include non-enumerable properties

### DIFF
--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -449,6 +449,11 @@ test('copyWrappedGlobals - support other realm prototype chains', (t) => {
   const { copyWrappedGlobals } = prepareTest()
   const forkedProto = Object.create(null)
   forkedProto.hasOwnProperty = () => true
+  forkedProto.legitimateValue = 1
+  Object.defineProperty(forkedProto, 'aNonEnumerableValue', {
+    value: 2,
+    enumerable: false,
+  })
 
   const sourceProto = Object.create(forkedProto)
   sourceProto.onTheProto = function () {}
@@ -460,7 +465,7 @@ test('copyWrappedGlobals - support other realm prototype chains', (t) => {
   // Error: Lavamoat - unable to find common prototype between Compartment and globalRef
   copyWrappedGlobals(source, target, ['window'])
 
-  t.is(Object.keys(target).sort().join(), 'onTheObj,onTheProto,window')
+  t.is(Object.getOwnPropertyNames(target).sort().join(), 'aNonEnumerableValue,legitimateValue,onTheObj,onTheProto,window')
 })
 
 test('copyWrappedGlobals - copy from prototype too', (t) => {
@@ -469,10 +474,14 @@ test('copyWrappedGlobals - copy from prototype too', (t) => {
   const sourceProto = {
     onTheProto: function () {},
   }
+  Object.defineProperty(sourceProto, 'aNonEnumerableValue', {
+    value: 2,
+    enumerable: false,
+  })
   const source = Object.create(sourceProto)
   source.onTheObj = function () {}
   const target = Object.create(null)
   copyWrappedGlobals(source, target, ['window'])
 
-  t.is(Object.keys(target).sort().join(), 'onTheObj,onTheProto,window')
+  t.is(Object.getOwnPropertyNames(target).sort().join(), 'aNonEnumerableValue,onTheObj,onTheProto,window')
 })


### PR DESCRIPTION
- applies the filtering on the descriptor instead of sloppily making a copy of the source object instead.