### PR TITLE
feat(webpack): prevent webpack from eliminating reexports and failing policy enforcement

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -250,7 +250,10 @@ class LavaMoatPlugin {
           // replacing generator with something returning an empty string could shave off some extra time, but is too invasive to seem worth it
         }
 
-        if (FORCED_CONFIG || STORE.options.diagnosticsVerbosity > 0) {
+        if (
+          FORCED_CONFIG.length > 0 ||
+          STORE.options.diagnosticsVerbosity > 0
+        ) {
           STORE.mainCompilationWarnings.push(
             new WebpackError(
               'LavaMoatPlugin: Following options had to be overriden for security: ' +

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -179,10 +179,10 @@ class LavaMoatPlugin {
     /** @type {string[]} */
     const FORCED_CONFIG = []
     if (compiler.options.optimization.concatenateModules) {
-      FORCED_CONFIG.push('concatenateModules: false')
+      FORCED_CONFIG.push('concatenateModules=true->false')
     }
     if (compiler.options.optimization.sideEffects) {
-      FORCED_CONFIG.push('sideEffects: false')
+      FORCED_CONFIG.push('sideEffects=true->false')
     }
     // Concatenation won't work with wrapped modules. Have to disable it.
     compiler.options.optimization.concatenateModules = false
@@ -251,8 +251,7 @@ class LavaMoatPlugin {
         }
 
         if (
-          FORCED_CONFIG.length > 0 ||
-          STORE.options.diagnosticsVerbosity > 0
+          FORCED_CONFIG.length > 0
         ) {
           STORE.mainCompilationWarnings.push(
             new WebpackError(

--- a/packages/webpack/test/e2e-main.spec.js
+++ b/packages/webpack/test/e2e-main.spec.js
@@ -23,7 +23,7 @@ test('webpack/main - dist shape', (t) => {
 })
 
 test('webpack/main - default warning gets printed', (t) => {
-  t.regex(t.context.build.stdout, /Concatenation of modules disabled/)
+  t.regex(t.context.build.stdout, /options had to be overriden.*concatenateModules/)
 })
 
 test('webpack/main - warns about excluded modules', (t) => {

--- a/packages/webpack/test/fixtures/main/webpack.config.js
+++ b/packages/webpack/test/fixtures/main/webpack.config.js
@@ -49,7 +49,9 @@ function makeConfig(lmOptions = {}) {
       }),
       new HtmlWebpackPlugin(),
     ],
-    optimization: {},
+    optimization: {
+      concatenateModules: true, // only here to trigger explicit warning about being set back to false
+    },
     resolve: {
       fallback: { crypto: false },
     },


### PR DESCRIPTION
Add one more config override `sideEffects: false` - that prevents webpack from messing up policy enforcement on packages dependencies