### PR TITLE
feat(webpack): document and officially release scuttling in webpack plugin

### DIFF
--- a/packages/core/src/options.js
+++ b/packages/core/src/options.js
@@ -1,20 +1,15 @@
 // @ts-check
 
 /**
- * Value of the {@link LavaMoatOpts.scuttleGlobalThis} option.
- *
- * @typedef LavaMoatScuttleOpts
- * @property {boolean} [enabled]
- * @property {string[]} [exceptions]
- * @property {string} [scuttlerName]
+ * @import {LavaMoatScuttleOpts} from './scuttle'
  */
 
 /**
  * Options for LavaMoat
  *
  * @typedef LavaMoatOpts
- * @property {LavaMoatScuttleOpts} [scuttleGlobalThis] Enable or disable
- *   scuttling of `globalThis`
+ * @property {LavaMoatScuttleOpts} [scuttleGlobalThis] Enable or disable scuttling of
+ *   `globalThis`
  * @property {string[]} [scuttleGlobalThisExceptions]
  * @property {boolean} [writeAutoPolicy] Automatically write a policy file
  * @property {boolean} [writeAutoPolicyDebug] Automatically write a debug policy

--- a/packages/core/src/scuttle.d.ts
+++ b/packages/core/src/scuttle.d.ts
@@ -1,9 +1,12 @@
 /**
  * Options for scuttling global properties
  */
-export interface ScuttleOpts {
+export type LavaMoatScuttleOpts = {
+  /** Whether scuttling is enabled or not. */
   enabled: boolean;
+  /** List of properties to exclude from scuttling. */
   exceptions?: Array<string | RegExp>;
+  /** Name of the scuttler function to use which is expected to be found as a property on the global object (e.g. if scuttlerName is 'x', scuttler function is obtained from globalThis['x']). */
   scuttlerName?: string;
 }
 
@@ -19,4 +22,4 @@ export interface GlobalRef {
  * @param globalRef The global object to scuttle
  * @param [opts] Options for scuttling
  */
-export function scuttle(globalRef: GlobalRef, opts?: ScuttleOpts | boolean): void;
+export function scuttle(globalRef: GlobalRef, opts?: LavaMoatScuttleOpts | boolean): void;

--- a/packages/core/src/scuttle.js
+++ b/packages/core/src/scuttle.js
@@ -1,18 +1,4 @@
-/**
- * @typedef {object} ScuttleOpts
- * @property {boolean} enabled - Whether scuttling is enabled or not.
- * @property {(string | RegExp)[]} exceptions - List of properties to exclude
- *   from scuttling.
- * @property {string} scuttlerName - Name of the scuttler function to use which
- *   is expected to be found as a property on the global object (e.g. if
- *   scuttlerName is 'x', scuttler function is obtained from globalThis['x']).
- */
-
-/**
- * @typedef {object} GlobalRef
- * @property {Record<string, any>} [globalThis] - Reference to the global
- *   object.
- */
+/** @import { LavaMoatScuttleOpts, GlobalRef } from './scuttle.d.ts' */
 
 const { Object, Array, Error, RegExp, Set, console, Proxy, Reflect } =
   globalThis
@@ -66,7 +52,7 @@ function generateInvokers(prop) {
  * create the root package compartment.
  *
  * @param {GlobalRef} globalRef - Reference to the global object.
- * @param {ScuttleOpts} opts - Scuttling options.
+ * @param {LavaMoatScuttleOpts} opts - Scuttling options.
  */
 function scuttle(globalRef, opts) {
   const scuttleOpts = generateScuttleOpts(globalRef, opts)
@@ -85,9 +71,9 @@ function scuttle(globalRef, opts) {
 
 /**
  * @param {GlobalRef} globalRef - Reference to the global object.
- * @param {ScuttleOpts | boolean} originalOpts - Scuttling options. Accepts
+ * @param {LavaMoatScuttleOpts | boolean} originalOpts - Scuttling options. Accepts
  *   `true` for backwards compatibility.
- * @returns {ScuttleOpts} - Final scuttling options.
+ * @returns {LavaMoatScuttleOpts} - Final scuttling options.
  */
 function generateScuttleOpts(globalRef, originalOpts = create(null)) {
   const defaultOpts = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,5 +6,6 @@ export * from './index'
 export type * from './moduleRecord'
 export type * from './options'
 export type * from './parseForPolicy'
+export type { LavaMoatScuttleOpts } from './scuttle.d.ts'
 export { E as EndowmentsToolkitFactory }
 

--- a/packages/core/test/util.js
+++ b/packages/core/test/util.js
@@ -290,7 +290,7 @@ function createScenarioFromScaffold({
   )
 
   if (!hasOwn(opts, 'scuttleGlobalThis')) {
-    opts.scuttleGlobalThis = {}
+    opts.scuttleGlobalThis = { enabled: false }
   }
 
   return {

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -18,9 +18,10 @@ The LavaMoat plugin takes an options object with the following properties (all o
 
 | Property                   | Description                                                                                                                                                                                                                                                                                                           | Default                  |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `scuttleGlobalThis`        | Configure scuttling of global object properties using `{ enabled: true, exceptions: ['globalName'] }` where exceptions specify which globals should not be scuttled. Removes access to potentially dangerous globals while preserving access to essential APIs.                                                       | `undefined`              |
 | `policyLocation`           | Directory to store policy files in.                                                                                                                                                                                                                                                                                   | `./lavamoat/webpack`     |
 | `generatePolicy`           | Whether to generate the `policy.json` file. Generated policy is used in the build immediately. `policy-override.json` is applied before bundling, if present.                                                                                                                                                         | `false`                  |
-| `generatePolicyOnly`       | Enables `generatePolicy` and skips finishing the build (useful if you only need to regenerate policy files)                                                                                                                                                                                                            | `false`                  |
+| `generatePolicyOnly`       | Enables `generatePolicy` and skips finishing the build (useful if you only need to regenerate policy files)                                                                                                                                                                                                           | `false`                  |
 | `emitPolicySnapshot`       | If enabled, emits the result of merging policy with overrides into the output directory of Webpack build for inspection. The file is not used by the bundle.                                                                                                                                                          | `false`                  |
 | `readableResourceIds`      | Boolean to decide whether to keep resource IDs human readable (possibly regardless of production/development mode). If `false`, they are replaced with a sequence of numbers. Keeping them readable may be useful for debugging when a policy violation error is thrown. By default, follows the Webpack config mode. | `(mode==='development')` |
 | `lockdown`                 | Configuration for [SES lockdown][]. Setting the option replaces defaults from LavaMoat.                                                                                                                                                                                                                               | reasonable defaults      |
@@ -110,6 +111,24 @@ Example: avoid wrapping CSS modules:
 ```
 
 See: `examples/webpack.config.js` for a complete example.
+
+### Scuttling GlobalThis
+
+With defense-in-depth in mind, you can also make the actual `globalThis` unusable in case a reference to it is accidentally made accessible for a package. When enabled, this feature removes access to all globals after their copies were captured and passed to Compartments in LavaMoat. You can specify exceptions to maintain access to specific globals that are deliberately used outside of LavaMoat.
+
+Configure scuttling using:
+
+```js
+new LavaMoatPlugin({
+  scuttleGlobalThis: {
+    enabled: true,
+    exceptions: [
+      'yourRequiredGlobal',
+      /RegExp matching globals that a webdriver depends on for running your tests/,
+    ], // list of globals that should remain accessible
+  },
+})
+```
 
 ### diagnosticsVerbosity
 

--- a/packages/webpack/src/buildtime/types.ts
+++ b/packages/webpack/src/buildtime/types.ts
@@ -8,8 +8,6 @@ export interface LavaMoatChunkRuntimeConfiguration {
   embeddedOptions?: Partial<Pick<CompleteLavaMoatPluginOptions, 'lockdown' | 'scuttleGlobalThis'>>
 }
 
-export type ScuttlerConfig = LavaMoatScuttleOpts | boolean | undefined
-
 export interface CompleteLavaMoatPluginOptions {
   generatePolicy?: boolean
   generatePolicyOnly?: boolean
@@ -25,7 +23,7 @@ export interface CompleteLavaMoatPluginOptions {
   runChecks?: boolean
   isBuiltin: (specifier: string) => boolean
   skipRepairs?: true | string[]
-  scuttleGlobalThis?: ScuttlerConfig
+  scuttleGlobalThis?: LavaMoatScuttleOpts
   debugRuntime?: boolean
   unlockedChunksUnsafe?: RegExp
   staticShims_experimental?: string[]

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -85,16 +85,22 @@ class LavaMoatPlugin {
    * @param {LavaMoatPluginOptions} [options]
    */
   constructor(options = {}) {
-    if (options.scuttleGlobalThis === true) {
-      options.scuttleGlobalThis = { enabled: true, exceptions: [] }
-    } else if (typeof options.scuttleGlobalThis === 'object') {
+    if (typeof options.scuttleGlobalThis === 'object') {
       options.scuttleGlobalThis = { ...options.scuttleGlobalThis }
       if (Array.isArray(options.scuttleGlobalThis.exceptions)) {
         options.scuttleGlobalThis.exceptions =
-          options.scuttleGlobalThis.exceptions.map((e) => e.toString())
+          options.scuttleGlobalThis.exceptions.map(
+            /**
+             * Convert exception to string
+             * @param {string | RegExp} e
+             * @returns {string}
+             */
+            (e) => e.toString())
       } else {
         options.scuttleGlobalThis.exceptions = []
       }
+    } else {
+      options.scuttleGlobalThis = { enabled: false }
     }
 
     /** @type {CompleteLavaMoatPluginOptions} */

--- a/packages/webpack/src/runtime/runtime-namespace.ts
+++ b/packages/webpack/src/runtime/runtime-namespace.ts
@@ -1,6 +1,6 @@
 import type { LavaMoatPolicy } from '@lavamoat/types'
-import type { EndowmentsToolkitFactory } from 'lavamoat-core'
-import type { LavaMoatPluginOptions, ScuttlerConfig } from '../buildtime/types'
+import type { EndowmentsToolkitFactory, LavaMoatScuttleOpts } from 'lavamoat-core'
+import type { LavaMoatPluginOptions } from '../buildtime/types'
 
 type DebugTools = {
   debugProxy: (target: any, source: object, hint: string) => void
@@ -11,7 +11,7 @@ export interface RuntimeNamespace {
   scuttling: {
     scuttle: (
       globalThis: Record<string, unknown>,
-      scuttleGlobalThis: ScuttlerConfig
+      scuttleGlobalThis?: LavaMoatScuttleOpts
     ) => {}
   }
   root: string

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -219,10 +219,7 @@ const LOCKDOWN_SHIMS = [];`
         // options to turn on scuttling
         { name: 'options', data: embeddedOptions, json: true },
         // scuttling module, if needed
-        ...((typeof embeddedOptions?.scuttleGlobalThis === 'boolean' &&
-          embeddedOptions.scuttleGlobalThis === true) ||
-        (typeof embeddedOptions?.scuttleGlobalThis === 'object' &&
-          embeddedOptions.scuttleGlobalThis.enabled === true)
+        ...(embeddedOptions?.scuttleGlobalThis?.enabled === true
           ? [
               {
                 name: 'scuttling',


### PR DESCRIPTION
types diverged again into two separate ones on conflict resolution with @lavamoat/types work. Fixing it. 
I'm also using the opportunity that it was not documented earlier to skip exposing the deprecated boolean-only scuttling.