### PR TITLE
secret prototype repair for FF contentscript sandbox

### DIFF
--- a/packages/webpack/src/runtime/repairs/globalthis.js
+++ b/packages/webpack/src/runtime/repairs/globalthis.js
@@ -1,0 +1,71 @@
+const { getOwnPropertyNames } = Object
+
+/**
+ * Util for getting the prototype chain as an array includes the provided value
+ * in the result
+ *
+ * @param {any} value
+ * @returns {any[]}
+ */
+function getPrototypeChain(value) {
+  const protoChain = []
+  let current = value
+  while (
+    current &&
+    (typeof current === 'object' || typeof current === 'function')
+  ) {
+    protoChain.push(current)
+    current = Reflect.getPrototypeOf(current)
+  }
+  return protoChain
+}
+/**
+ * For odd sandboxing situations including Firefox contentscript environment,
+ * where the globalThis is a sandbox with a truncated prototype chain that
+ * magically inherits properties from a hidden part of the prototype chain.
+ *
+ * The globalRef is casted as a record because I don't want to add 10 extra
+ * lines of code to appease typescript
+ *
+ * @param {Record<string, any>} globalRef
+ */
+function elevateSecretPrototype(globalRef) {
+  if (
+    'window' in globalRef &&
+    typeof globalRef.window === 'object' &&
+    globalRef !== globalRef.window
+  ) {
+    const win = globalRef.window
+    const windowProtoChain = getPrototypeChain(win)
+    const globalProtoChain = getPrototypeChain(globalRef)
+    windowProtoChain.pop() // remove Object.prototype
+    // consider all properties on the prototype chain of window
+    // that are defined on window, but not on globalThis
+    const considerKeys = windowProtoChain.flatMap((proto) =>
+      getOwnPropertyNames(proto)
+    )
+
+    const globalKeys = new Set(
+      globalProtoChain.flatMap((proto) => getOwnPropertyNames(proto))
+    )
+
+    for (const key of considerKeys) {
+      // this condition looks self-contradictory, but it's actually explicitly testing for fields that are reachable on globalRef by explicit lookup but cannot be discovered as own properties on the prototype chain items.
+      if (
+        !globalKeys.has(key) &&
+        key in globalThis &&
+        typeof win[key] !== 'undefined'
+      ) {
+        try {
+          // Make a property that exists on the hidden prototype chain an own property of globalThis so that the regular logic of copying globals can find it.
+          // The try-catch exists to avoid errors if a property is a getter-setter pair that we didn't know existed.
+          // eslint-disable-next-line no-self-assign
+          globalRef[key] = globalRef[key]
+        } catch (e) {}
+      }
+    }
+  }
+  return globalRef
+}
+
+elevateSecretPrototype(globalThis)

--- a/packages/webpack/src/runtime/repairs/index.js
+++ b/packages/webpack/src/runtime/repairs/index.js
@@ -7,4 +7,8 @@ exports.repairs = [
     target: ['event'],
     file: require.resolve('./eventsetter'),
   },
+  {
+    target: ['globalThis'],
+    file: require.resolve('./globalthis'),
+  },
 ]

--- a/packages/webpack/src/runtime/repairsBuilder.js
+++ b/packages/webpack/src/runtime/repairsBuilder.js
@@ -19,7 +19,7 @@ exports.buildRepairs = (policy, skipRepairs) => {
             })
         )
       : repairs
-  const allGlobalsInvolved = new Set()
+  const allGlobalsInvolved = new Set(['globalThis'])
   for (const resource of Object.values(policy.resources)) {
     if (resource.globals) {
       for (const global of Object.keys(resource.globals)) {

--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -4,7 +4,7 @@
 /* global LOCKDOWN_SHIMS */
 /* global hardenIntrinsics */
 
-const { repairIntrinsics, } = globalThis
+const { repairIntrinsics } = globalThis
 
 const warn = typeof console === 'object' ? console.warn : () => {}
 
@@ -56,11 +56,14 @@ values(LAVAMOAT.policy.resources).forEach((resource) => {
   }
 })
 
-const { getEndowmentsForConfig, copyWrappedGlobals, getBuiltinForConfig } =
-  LAVAMOAT.endowmentsToolkit({
-    handleGlobalWrite: true,
-    knownWritableFields,
-  })
+const {
+  getEndowmentsForConfig,
+  copyWrappedGlobals,
+  getBuiltinForConfig,
+} = LAVAMOAT.endowmentsToolkit({
+  handleGlobalWrite: true,
+  knownWritableFields,
+})
 
 // These must match assumptions in the wrapper.js
 // sharedKeys are included in the runtime

--- a/packages/webpack/test/repairs-globalthis.spec.js
+++ b/packages/webpack/test/repairs-globalthis.spec.js
@@ -1,0 +1,84 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { runChunks } = require('./scaffold.js')
+const { readFileSync } = require('node:fs')
+
+function lyingGlobalThis() {
+  const hiddenProto = new Proxy(
+    Object.create({
+      addEventListener: function () {
+        return 42
+      },
+    }),
+    {
+      getPrototypeOf() {
+        return null
+      },
+    }
+  )
+  Object.setPrototypeOf(Object.getPrototypeOf(globalThis), hiddenProto)
+}
+
+function assertGlobalThisLies() {
+  if (!globalThis.addEventListener) {
+    throw Error('no addEventListener on globalThis')
+  }
+  let current = globalThis
+  while (current) {
+    if (Object.getOwnPropertyNames(current).includes('addEventListener')) {
+      throw Error(
+        'addEventListener should not be among discoverable properties before repair'
+      )
+    }
+    current = Object.getPrototypeOf(current)
+  }
+}
+
+function assertRepairWorks() {
+  if (!globalThis.addEventListener) {
+    throw Error('no addEventListener on globalThis after repair')
+  }
+  const props = Object.getOwnPropertyNames(globalThis)
+  if (!props.includes('addEventListener')) {
+    throw Error(
+      'addEventListener should be among discoverable properties after repair'
+    )
+  }
+  if (globalThis.addEventListener() !== 42) {
+    throw Error(
+      'addEventListener should be the one from hidden prototype, not replaced with the one from window'
+    )
+  }
+}
+
+test.before(() => {
+  // sanity check that our lyingGlobalThis setup is working as intended
+  runChunks([
+    lyingGlobalThis.toString(),
+    assertGlobalThisLies.toString(),
+    `
+    lyingGlobalThis()
+    assertGlobalThisLies()
+    `,
+  ])
+})
+
+test('repairs/globalthis - enables listing properties on hidden prototype in globalThis', (t) => {
+  const repair = readFileSync(
+    require.resolve('../src/runtime/repairs/globalthis')
+  )
+  // The repair relies on `window` prototype chain containing properties with names matching the ones secretly available on globalThis
+  t.notThrows(() =>
+    runChunks(
+      [
+        lyingGlobalThis.toString(),
+        assertRepairWorks.toString(),
+        'lyingGlobalThis()',
+        repair,
+        `assertRepairWorks()`,
+      ],
+      {
+        window: Object.create(EventTarget.prototype),
+      }
+    )
+  )
+})


### PR DESCRIPTION
This fixes the situation where in contentscript (see: https://dev.to/naugtur/the-missing-link-3ejk) the EventTarget methods are not possible to list by copyWrappedGlobals. But the fix is generic and will apply successfully to any such sandbox.