### PR TITLE
fix(webpack): add j to the list of harmless fields on __webpack_require__

### DIFF
--- a/packages/webpack/src/runtime/runtime.js
+++ b/packages/webpack/src/runtime/runtime.js
@@ -344,11 +344,11 @@ const lavamoatRuntimeWrapper = (resourceId, runtimeKit) => {
     // It's a case-by-case basis decision.
     // TODO: print a warning for other functions on the __webpack_require__ namespace that we're not supporting.
     //   It's probably best served at build time though - with runtimeRequirements or looking at the items in webpack runtime when adding lavamoat runtime.
-    // The following seem harmless and are used by default: ['O', 'n', 'd', 'o', 'r', 's', 't', 'b']
+    // The following seem harmless and are used by default: ['O', 'n', 'd', 'o', 'r', 's', 't', 'b', 'j']
     // To discover more, go to https://github.com/webpack/webpack/blob/main/lib/RuntimeGlobals.js and/or look at implementations here https://github.com/webpack/webpack/tree/main/lib/runtime/
     // Looking at the runtime chunk in the built bundle is probably the fastest way to learn what these do.
 
-    const supportedRuntimeItems = ['O', 'n', 'd', 'o', 'r', 's', 't', 'b']
+    const supportedRuntimeItems = ['O', 'n', 'd', 'o', 'r', 's', 't', 'b', 'j']
     for (const item of supportedRuntimeItems) {
       policyRequire[item] = harden(__webpack_require__[item])
     }


### PR DESCRIPTION
as documented here: https://github.com/webpack/webpack/blob/00a162b01901c9db8c1284d9b1541d04f953e8f2/lib/RuntimeGlobals.js#L363

I missed it the first time around. 

It seems to be used to figure out whether a chunk is loading under the runtime it was expecting to be loading when there's multiple distinct runtimes in a compilation. 