### PR TITLE
fix(webpack): adapt scuttling config for runtime regardless of where it comes from

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -87,20 +87,6 @@ class LavaMoatPlugin {
   constructor(options = {}) {
     if (typeof options.scuttleGlobalThis === 'object') {
       options.scuttleGlobalThis = { ...options.scuttleGlobalThis }
-      if (Array.isArray(options.scuttleGlobalThis.exceptions)) {
-        options.scuttleGlobalThis.exceptions =
-          options.scuttleGlobalThis.exceptions.map(
-            /**
-             * Convert exception to string
-             *
-             * @param {string | RegExp} e
-             * @returns {string}
-             */
-            (e) => e.toString()
-          )
-      } else {
-        options.scuttleGlobalThis.exceptions = []
-      }
     } else {
       options.scuttleGlobalThis = { enabled: false }
     }
@@ -261,16 +247,6 @@ class LavaMoatPlugin {
               'LavaMoatPlugin: Following options had to be overriden for security: ' +
                 FORCED_CONFIG.join(', ')
             )
-          )
-        }
-
-        // Adjust scuttling configuration to not scuttle webpack chunk loading facilities
-        if (
-          typeof STORE.options.scuttleGlobalThis === 'object' &&
-          Array.isArray(STORE.options.scuttleGlobalThis.exceptions)
-        ) {
-          STORE.options.scuttleGlobalThis.exceptions.push(
-            compilation.outputOptions.chunkLoadingGlobal || 'webpackChunk'
           )
         }
 
@@ -564,6 +540,9 @@ class LavaMoatPlugin {
                     contextModuleIds: STORE.contextModuleIds,
                     externals: STORE.externals,
                   },
+                  chunkLoaderName:
+                    compilation.outputOptions.chunkLoadingGlobal ||
+                    'webpackChunk',
                 })
 
                 // Add the runtime modules to the chunk, which handles

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -541,7 +541,7 @@ class LavaMoatPlugin {
                     externals: STORE.externals,
                   },
                   chunkLoaderName:
-                    compilation.outputOptions.chunkLoadingGlobal ||
+                    compilation.outputOptions.chunkLoadingGlobal ??
                     'webpackChunk',
                 })
 

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -1,6 +1,7 @@
 const { RUNTIME_KEY } = require('../ENUM.json')
 const diag = require('../buildtime/diagnostics.js')
 const { assembleRuntime, prepareSource } = require('./assemble.js')
+const { adjustScuttleConfig } = require('./scuttlingConf.js')
 const path = require('node:path')
 
 const { RuntimeModule } = require('webpack')
@@ -283,6 +284,8 @@ const LOCKDOWN_SHIMS = [];`
        *   configuration
        * @param {LavaMoatRuntimeIdentifiers} params.identifiers Object
        *   containing module identifier mappings
+       * @param {string} params.chunkLoaderName The name of the global that
+       *   loads chunks
        * @returns {VirtualRuntimeModule[]} The assembled runtime source code
        */
       getLavaMoatRuntimeModules({
@@ -291,6 +294,7 @@ const LOCKDOWN_SHIMS = [];`
         chunkIds,
         policyData,
         identifiers,
+        chunkLoaderName,
       }) {
         const currentChunkName = currentChunk.name
 
@@ -338,6 +342,16 @@ const LOCKDOWN_SHIMS = [];`
               ),
             }
           }
+        }
+
+        if (runtimeConfiguration.embeddedOptions?.scuttleGlobalThis) {
+          runtimeConfiguration.embeddedOptions.scuttleGlobalThis =
+            adjustScuttleConfig(
+              runtimeConfiguration.embeddedOptions.scuttleGlobalThis,
+              {
+                chunkLoaderName,
+              }
+            )
         }
 
         // flesh out the modules for runtimeConfiguration

--- a/packages/webpack/src/runtime/scuttlingConf.js
+++ b/packages/webpack/src/runtime/scuttlingConf.js
@@ -1,0 +1,29 @@
+/** @import {LavaMoatScuttleOpts} from 'lavamoat-core' */
+
+/**
+ * @param {LavaMoatScuttleOpts} scuttleGlobalThis
+ * @param {Object} [options]
+ * @param {string} [options.chunkLoaderName='webpackChunk'] The name of the global that loads chunks
+ * @returns {LavaMoatScuttleOpts}
+ */
+exports.adjustScuttleConfig = (
+  scuttleGlobalThis,
+  { chunkLoaderName = 'webpackChunk' } = {}
+) => {
+  scuttleGlobalThis = { ...scuttleGlobalThis }
+  if (Array.isArray(scuttleGlobalThis.exceptions)) {
+    scuttleGlobalThis.exceptions = scuttleGlobalThis.exceptions.map(
+      /**
+       * Convert regex to string
+       *
+       * @param {string | RegExp} e
+       * @returns {string}
+       */
+      (e) => e.toString()
+    )
+  } else {
+    scuttleGlobalThis.exceptions = []
+  }
+  scuttleGlobalThis.exceptions.push(chunkLoaderName)
+  return scuttleGlobalThis
+}

--- a/packages/webpack/test/e2e-scuttle.spec.js
+++ b/packages/webpack/test/e2e-scuttle.spec.js
@@ -129,6 +129,7 @@ test(`webpack/scuttled - webpackChunk global is transparently added to exception
   await scuttleViaRuntimeConf(t, { enabled: true, exceptions: ['Function'] })
 
   t.notThrows(() => {
+    // accessing the field, if scuttled, will call the getter that throws
     t.context.globalThis.webpackChunkTEST
   }, 'Unexpected error in scenario')
   t.truthy(t.context.globalThis.webpackChunkTEST)

--- a/packages/webpack/test/e2e-scuttle.spec.js
+++ b/packages/webpack/test/e2e-scuttle.spec.js
@@ -50,6 +50,40 @@ async function scuttle(t, scuttleGlobalThis, globals) {
     t.context.globalThis = runScriptWithSES(t.context.bundle, globals).context
   }, 'Expected the build to succeed')
 }
+async function scuttleViaRuntimeConf(t, scuttleGlobalThis, globals) {
+  const webpackConfigDefault = makeConfig({
+    generatePolicy: true,
+    diagnosticsVerbosity: 1,
+    policyLocation: path.resolve(__dirname, 'fixtures/main/policy-scuttling'),
+    runtimeConfigurationPerChunk_experimental: (/*chunk*/) => {
+      return {
+        embeddedOptions: {
+          scuttleGlobalThis,
+        },
+      }
+    }
+
+  })
+  const webpackConfig = {
+    ...webpackConfigDefault,
+    entry: {
+      app: './simple.js',
+    },
+  }
+  // force webpack into creating chunks so that testing chunkApp globals is possible
+  webpackConfig.optimization.runtimeChunk = 'single'
+  // specify the chunk global namefor tests
+  webpackConfig.output.chunkLoadingGlobal = 'webpackChunkTEST'
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+    // Load both chunks effectively
+    t.context.bundle =
+      t.context.build.snapshot['/dist/runtime.js'] +
+      t.context.build.snapshot['/dist/app.js']
+    t.context.globalThis = runScriptWithSES(t.context.bundle, globals).context
+  }, 'Expected the build to succeed')
+}
 
 test(`webpack/scuttled - hosting globalThis's environment is not scuttled`, async (t) => {
   await scuttle(t)
@@ -84,6 +118,15 @@ test(`webpack/scuttled - hosting globalThis's "Function" is scuttled excepted`, 
 
 test(`webpack/scuttled - webpackChunk global is transparently added to exceptions`, async (t) => {
   await scuttle(t, { enabled: true, exceptions: ['Function'] })
+
+  t.notThrows(() => {
+    t.context.globalThis.webpackChunkTEST
+  }, 'Unexpected error in scenario')
+  t.truthy(t.context.globalThis.webpackChunkTEST)
+})
+
+test(`webpack/scuttled - webpackChunk global is transparently added to exceptions when configuration comes from runtimeConfigurationPerChunk`, async (t) => {
+  await scuttleViaRuntimeConf(t, { enabled: true, exceptions: ['Function'] })
 
   t.notThrows(() => {
     t.context.globalThis.webpackChunkTEST


### PR DESCRIPTION
There was a bug that caused scuttling config to not be processed if it came from `runtimeConfigurationPerChunk` callback instead of the main plugin options. 
Refactored scuttling config processing to happen after it has been obtained.