### PR TITLE
feat(tofu): enable deep dependency analysis of ES modules

### DIFF
--- a/packages/tofu/test/inspectEsmImports.spec.js
+++ b/packages/tofu/test/inspectEsmImports.spec.js
@@ -29,22 +29,47 @@ testInspect(
   export * as name3 from "package12";
   export { name4 } from "package13";
   export { default as name5 } from "package14";
+  import defaultExport4, { namedExport } from "package15";
+  import { "kebab-case" as kebabCase } from "package16";
+  export { "with-hyphen" as withHyphen } from "package17";
+  export * from 'package18';
   export const foo = "bar";
 `,
   [
-    'package01',
-    'package02',
-    'package03',
-    'package04',
-    'package05',
-    'package06/path/to/specific/un-exported/file',
-    'package07',
-    'package08',
-    'package09',
-    'package10',
-    'package12',
-    'package13',
-    'package14',
+    'package01', // default import - no keypath
+    'package02', // namespace import - no keypath
+    'package03.export1', // named import - keypath
+    'package04.export2', // named import with alias - keypath with original name
+    'package05.export3', // multiple named imports - keypath for each
+    'package05.export4',
+    'package06/path/to/specific/un-exported/file.export5', // named imports with path - keypath
+    'package06/path/to/specific/un-exported/file.export6',
+    'package07.export7', // named imports with alias - keypath
+    'package07.export8',
+    'package08', // default import - no keypath
+    'package09', // default + namespace import - no keypath
+    'package10', // side-effect import - no keypath
+    'package12', // namespace re-export - no keypath
+    'package13.name4', // named re-export - keypath
+    'package14', // default re-export - no keypath
+    'package15', // mixed default + named import - module for default
+    'package15.namedExport', // mixed default + named import - keypath for named
+    'package16.kebab-case', // string literal named import - keypath with string literal
+    'package17.with-hyphen', // string literal named re-export - keypath with string literal
+    'package18', // export * from - no keypath
+  ]
+)
+
+testInspect(
+  'esm - named imports and re-exports with keypaths',
+  {},
+  `
+  import { read } from 'fs';
+  import { read as read4 } from 'fs';
+  export { read as read5 } from 'fs';
+`,
+  [
+    'fs.read', // all three statements refer to same export, deduplicated to one
   ]
 )
 


### PR DESCRIPTION
This makes `lavamoat-tofu` generate exports like `fs.readFile` when encountering `import {readFile} from 'fs'`; previously it would only generate `fs`.
