### PR TITLE
fix(vog): fix eslint/tseslint disagreement

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,6 @@ packages/yarn-plugin-allow-scripts/bundles
 packages/*/types
 packages/*/dist
 !/.github
+packages/vog/src/**/*.js
+packages/vog/src/**/*.d.ts
+packages/vog/src/**/*.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -135,7 +134,6 @@
       "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       },
@@ -152,7 +150,6 @@
       "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -172,7 +169,6 @@
       "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -187,7 +183,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -927,7 +922,6 @@
       "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.2"
@@ -942,7 +936,6 @@
       "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -4269,6 +4262,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
       "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4432,6 +4426,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5128,6 +5123,7 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-3.7.0.tgz",
       "integrity": "sha512-L0mSY0YXzDGRikNQIA6PlpdGna8jLMquliNXAW3QCp164TKbEigraw8GBNd+QFFsI23ous3xKufPNwvxI49R0w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
@@ -5683,6 +5679,7 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/plugin-git/-/plugin-git-2.6.8.tgz",
       "integrity": "sha512-6KIlEyzO1mMdiFBVlaVeuJLIPGZdqX9knJChzXMcc22oqXNJq4vp/SZA/+XSQNdRu/SHWrVykrjv9xDyCS4cCg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/semver": "^7.1.0",
         "@yarnpkg/fslib": "^2.10.4",
@@ -5982,6 +5979,7 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/plugin-pack/-/plugin-pack-3.2.0.tgz",
       "integrity": "sha512-5k4PqWQlF2mVfRU+wObzcv6Lu+3QeltJaAW8+EZf2N7Nz4oxcFRm8DSy/bO78NGPPt1d4OCJJkMaqPa4BRLNEw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@yarnpkg/fslib": "^2.10.2",
         "clipanion": "3.2.0-rc.4",
@@ -6023,6 +6021,7 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/plugin-patch/-/plugin-patch-3.2.5.tgz",
       "integrity": "sha512-mXR5Cluey7FqYRKt4LoJ45oOUnVdmK+Gdg2iZYnDwu38AJVyZOob959AgqYvgdzhs8lDfl7FlbmDOzc3E8HpTg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@yarnpkg/fslib": "^2.10.3",
         "@yarnpkg/libzip": "^2.3.0",
@@ -6358,6 +6357,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6482,6 +6482,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7781,6 +7782,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -8840,6 +8842,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10406,6 +10409,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11710,7 +11714,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -13525,6 +13528,7 @@
       "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -16616,6 +16620,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16725,6 +16730,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17709,6 +17715,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19474,7 +19481,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19639,6 +19647,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19707,6 +19716,7 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -20200,6 +20210,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20807,26 +20818,6 @@
         "node": "^18.0.0 || ^20.0.0 <20.15.0 || ^20.17.0 || ^22.5.1 || ^24.0.0"
       }
     },
-    "packages/browserify/node_modules/lavamoat-core": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/lavamoat-core/-/lavamoat-core-17.0.0.tgz",
-      "integrity": "sha512-/W3qpAY+EZySp2woCXrdtgFG9I5NIJu0G9WPPCr4pK11ForkZe3xG2ZtXzfhcompR0lotNpovYkVHOFo3O916w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "7.27.3",
-        "@lavamoat/types": "^0.1.0",
-        "json-stable-stringify": "1.3.0",
-        "lavamoat-tofu": "^8.0.11",
-        "merge-deep": "3.0.3",
-        "ses": "1.14.0"
-      },
-      "bin": {
-        "lavamoat-sort-policy": "src/policy-sort-cli.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
-      }
-    },
     "packages/core": {
       "name": "lavamoat-core",
       "version": "17.0.1",
@@ -20969,26 +20960,6 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 <20.15.0 || ^20.17.0 || ^22.5.1 || ^24.0.0"
-      }
-    },
-    "packages/lavamoat-node/node_modules/lavamoat-core": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/lavamoat-core/-/lavamoat-core-17.0.0.tgz",
-      "integrity": "sha512-/W3qpAY+EZySp2woCXrdtgFG9I5NIJu0G9WPPCr4pK11ForkZe3xG2ZtXzfhcompR0lotNpovYkVHOFo3O916w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "7.27.3",
-        "@lavamoat/types": "^0.1.0",
-        "json-stable-stringify": "1.3.0",
-        "lavamoat-tofu": "^8.0.11",
-        "merge-deep": "3.0.3",
-        "ses": "1.14.0"
-      },
-      "bin": {
-        "lavamoat-sort-policy": "src/policy-sort-cli.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "packages/lavapack": {

--- a/packages/vog/.depcheckrc.yml
+++ b/packages/vog/.depcheckrc.yml
@@ -1,0 +1,2 @@
+ignores:
+  - '@typescript-eslint/parser'

--- a/packages/vog/.eslintrc.cjs
+++ b/packages/vog/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: [
+    '../../.config/eslintrc.typed-workspace',
+  ],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2021,
+  },
+  env: {
+    browser: false,
+    es6: false,
+    node: true,
+  },
+  overrides: [{
+    files: ['./test/**/*.ts'],
+    rules:  {
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+    }
+  }]
+}

--- a/packages/vog/package.json
+++ b/packages/vog/package.json
@@ -18,21 +18,21 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.js",
+      "types": "./src/index.d.ts"
     },
     "./log": {
-      "import": "./dist/log.js",
-      "types": "./dist/log.d.ts"
+      "import": "./src/log.js",
+      "types": "./src/log.d.ts"
     },
     "./package.json": "./package.json",
     "./progress": {
-      "import": "./dist/progress.js",
-      "types": "./dist/progress.d.ts"
+      "import": "./src/progress.js",
+      "types": "./src/progress.d.ts"
     },
     "./spinner": {
-      "import": "./dist/spinner.js",
-      "types": "./dist/spinner.d.ts"
+      "import": "./src/spinner.js",
+      "types": "./src/spinner.d.ts"
     }
   },
   "directories": {
@@ -40,7 +40,6 @@
   },
   "files": [
     "CHANGELOG.md",
-    "dist/**/*",
     "src/**/*",
     "!*.tsbuildinfo",
     "!tsconfig.json"

--- a/packages/vog/src/tsconfig.json
+++ b/packages/vog/src/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "stripInternal": true,
     "target": "esnext",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "rootDir": ".."
   },
   "exclude": ["*.d.ts", "*.js"],
   "extends": "../../../.config/tsconfig.src.json",

--- a/packages/vog/test/tsconfig.json
+++ b/packages/vog/test/tsconfig.json
@@ -1,19 +1,17 @@
 {
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "erasableSyntaxOnly": true,
-    "exactOptionalPropertyTypes": true,
     "module": "NodeNext",
     "rewriteRelativeImportExtensions": true,
-    "rootDir": "..",
+    "exactOptionalPropertyTypes": true,
     "strict": true,
+    "stripInternal": true,
     "target": "esnext",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "rootDir": ".."
   },
   "extends": "../../../.config/tsconfig.test.json",
-  "include": ["."],
-  "references": [
-    {
-      "path": "../src/tsconfig.json"
-    }
-  ]
+  "include": ["*.ts", "../src/*.ts"]
 }


### PR DESCRIPTION
- The exports were wrong
- We needed a custom ESLint config file because ESM and also `node:test`
- Needed a `.depcheckrc.yml`
- Due to type-stripping, compiled files may not be output to a different directory. So it's either leave them in `src/` or move `test/` under `src/`. Sucks.