### PR TITLE
fix(core): transfer prototype over to a wraped function

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -256,7 +256,7 @@ function endowmentsToolkit({
       // dont attempt to extend a getter or trigger a setter
       if (!('value' in targetPropDesc)) {
         throw new Error(
-          `unable to copy on to targetRef, targetRef has a getter at "${nextPart}"`
+          `unable to copy on to targetRef, targetRef has a getter at "${currentPath}"`
         )
       }
       // value must be extensible (cant write properties onto it)
@@ -264,7 +264,7 @@ function endowmentsToolkit({
       const valueType = typeof targetValue
       if (valueType !== 'object' && valueType !== 'function') {
         throw new Error(
-          `unable to copy on to targetRef, targetRef value is not an obj or func "${nextPart}"`
+          `unable to copy on to targetRef, targetRef value is not an obj or func at "${currentPath}"`
         )
       }
     }
@@ -751,6 +751,12 @@ function defaultCreateFunctionWrapper(sourceValue, unwrapTest, unwrapTo) {
     newValue,
     Object.getOwnPropertyDescriptors(sourceValue)
   )
+  // Global functions can have static fields on a prototype. eg. Uint8Array.from
+  if (
+    Reflect.getPrototypeOf(newValue) !== Reflect.getPrototypeOf(sourceValue)
+  ) {
+    Object.setPrototypeOf(newValue, Reflect.getPrototypeOf(sourceValue))
+  }
   return newValue
 }
 

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -507,3 +507,18 @@ test('copyWrappedGlobals - copy from prototype too', (t) => {
 
   t.is(Object.getOwnPropertyNames(target).sort().join(), 'aNonEnumerableValue,onTheObj,onTheProto,window')
 })
+
+test('copyWrappedGlobals - static methods on wrapped functions', (t) => {
+  'use strict'
+  const { copyWrappedGlobals } = prepareTest()
+  
+  const source = {
+    Array,
+    Uint8Array
+  }
+  const target = Object.create(null)
+  copyWrappedGlobals(source, target)
+
+  t.is(typeof target.Array.from, 'function')
+  t.is(typeof target.Uint8Array.from, 'function')
+})


### PR DESCRIPTION
Impact:

finding out what static properties on function prototypes could start working now.

```js
const getPrototypeChain = function getPrototypeChain(value) {
  const protoChain = []
  let current = value
  while (
    current &&
    (typeof current === 'object' || typeof current === 'function')
  ) {
    protoChain.push(current)
    current = Reflect.getPrototypeOf(current)
  }
  return protoChain
}

const allHorrors = getPrototypeChain(globalThis)
  .flatMap((glob) => Reflect.ownKeys(glob))
  .filter(
    (k) =>
      typeof globalThis[k] === 'function' &&
      Object.getPrototypeOf(globalThis[k]) !== Function.prototype
  )
  .filter((k) => !k.startsWith('SVG')) // browser has a lot of SVG classes that match this

console.log('All horrors:', allHorrors.length, allHorrors.join(','))

const statics = new Set(
  allHorrors.flatMap((name) => {
    return Reflect.ownKeys(Object.getPrototypeOf(globalThis[name])).map((k) =>
      String(k)
    )
  })
)

console.log(statics.size, Array.from(statics).join(','))
```


<details>
<summary>Node.js results</summary>
All horrors: 30 AggregateError,EvalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError,Uint8Array,Int8Array,Uint16Array,Int16Array,Uint32Array,Int32Array,Float32Array,Float64Array,Uint8ClampedArray,BigUint64Array,BigInt64Array,Buffer,AbortSignal,BroadcastChannel,MessagePort,File,Performance,PerformanceMark,PerformanceMeasure,PerformanceResourceTiming,MessageEvent,WebSocket,CustomEvent
17 length,name,prototype,captureStackTrace,prepareStackTrace,stackTraceLimit,of,from,Symbol(Symbol.species),BYTES_PER_ELEMENT,Symbol(nodejs.event_target),defaultMaxListeners,Symbol(kIsNodeEventTarget),NONE,CAPTURING_PHASE,AT_TARGET,BUBBLING_PHASE
</details>

<details>
<summary>Chromium results</summary>

All horrors: 472 AggregateError,EvalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError,Uint8Array,Int8Array,Uint16Array,Int16Array,Uint32Array,Int32Array,BigUint64Array,BigInt64Array,Uint8ClampedArray,Float32Array,Float64Array,webkitRTCPeerConnection,webkitMediaStream,WebKitCSSMatrix,XMLHttpRequestUpload,XMLHttpRequestEventTarget,XMLHttpRequest,XMLDocument,Worker,WindowControlsOverlayGeometryChangeEvent,WindowControlsOverlay,Window,WheelEvent,WebSocket,WebGLVertexArrayObject,WebGLTransformFeedback,WebGLTexture,WebGLSync,WebGLShader,WebGLSampler,WebGLRenderbuffer,WebGLQuery,WebGLProgram,WebGLFramebuffer,WebGLContextEvent,WebGLBuffer,WaveShaperNode,VisualViewport,VisibilityStateEntry,VirtualKeyboardGeometryChangeEvent,ViewTimeline,VTTCue,UIEvent,TrustedTypePolicyFactory,TransitionEvent,TrackEvent,TouchEvent,ToggleEvent,TextUpdateEvent,TextTrackList,TextTrackCue,TextTrack,TextFormatUpdateEvent,TextEvent,Text,TaskSignal,TaskPriorityChangeEvent,TaskController,TaskAttributionTiming,SubmitEvent,StylePropertyMap,StorageEvent,StereoPannerNode,StaticRange,SourceBufferList,SourceBuffer,ShadowRoot,SecurityPolicyViolationEvent,ScrollTimeline,ScriptProcessorNode,ScreenOrientation,Screen,Range,RadioNodeList,RTCTrackEvent,RTCSctpTransport,RTCPeerConnectionIceEvent,RTCPeerConnectionIceErrorEvent,RTCPeerConnection,RTCIceTransport,RTCErrorEvent,RTCError,RTCDtlsTransport,RTCDataChannelEvent,RTCDTMFToneChangeEvent,RTCDTMFSender,PromiseRejectionEvent,ProgressEvent,Profiler,ProcessingInstruction,PopStateEvent,PointerEvent,PictureInPictureWindow,PictureInPictureEvent,PerformanceScriptTiming,PerformanceResourceTiming,PerformancePaintTiming,PerformanceNavigationTiming,PerformanceMeasure,PerformanceMark,PerformanceLongTaskTiming,PerformanceLongAnimationFrameTiming,PerformanceEventTiming,PerformanceElementTiming,Performance,PannerNode,PageTransitionEvent,OverconstrainedError,OscillatorNode,OffscreenCanvas,OfflineAudioContext,OfflineAudioCompletionEvent,Node,NetworkInformation,NavigationHistoryEntry,NavigationCurrentEntryChangeEvent,Navigation,NavigateEvent,MouseEvent,MessagePort,MessageEvent,MediaStreamTrackGenerator,MediaStreamTrackEvent,MediaStreamTrack,MediaStreamEvent,MediaStreamAudioSourceNode,MediaStreamAudioDestinationNode,MediaStream,MediaSource,MediaRecorder,MediaQueryListEvent,MediaQueryList,MediaEncryptedEvent,MediaElementAudioSourceNode,MathMLElement,LayoutShift,LargestContentfulPaint,KeyframeEffect,KeyboardEvent,InputEvent,InputDeviceInfo,IIRFilterNode,IDBVersionChangeEvent,IDBTransaction,IDBRequest,IDBOpenDBRequest,IDBDatabase,IDBCursorWithValue,HashChangeEvent,HTMLVideoElement,HTMLUnknownElement,HTMLUListElement,HTMLTrackElement,HTMLTitleElement,HTMLTimeElement,HTMLTextAreaElement,HTMLTemplateElement,HTMLTableSectionElement,HTMLTableRowElement,HTMLTableElement,HTMLTableColElement,HTMLTableCellElement,HTMLTableCaptionElement,HTMLStyleElement,HTMLSpanElement,HTMLSourceElement,HTMLSlotElement,HTMLSelectedContentElement,HTMLSelectElement,HTMLScriptElement,HTMLQuoteElement,HTMLProgressElement,HTMLPreElement,HTMLPictureElement,HTMLParamElement,HTMLParagraphElement,HTMLOutputElement,HTMLOptionsCollection,HTMLOptionElement,HTMLOptGroupElement,HTMLObjectElement,HTMLOListElement,HTMLModElement,HTMLMeterElement,HTMLMetaElement,HTMLMenuElement,HTMLMediaElement,HTMLMarqueeElement,HTMLMapElement,HTMLLinkElement,HTMLLegendElement,HTMLLabelElement,HTMLLIElement,HTMLInputElement,HTMLImageElement,HTMLIFrameElement,HTMLHtmlElement,HTMLHeadingElement,HTMLHeadElement,HTMLHRElement,HTMLFrameSetElement,HTMLFrameElement,HTMLFormElement,HTMLFormControlsCollection,HTMLFontElement,HTMLFieldSetElement,HTMLEmbedElement,HTMLElement,HTMLDocument,HTMLDivElement,HTMLDirectoryElement,HTMLDialogElement,HTMLDetailsElement,HTMLDataListElement,HTMLDataElement,HTMLDListElement,HTMLCanvasElement,HTMLButtonElement,HTMLBodyElement,HTMLBaseElement,HTMLBRElement,HTMLAudioElement,HTMLAreaElement,HTMLAnchorElement,GamepadEvent,GainNode,FormDataEvent,FontFaceSetLoadEvent,FocusEvent,FileReader,File,EventSource,ErrorEvent,Element,EditContext,DynamicsCompressorNode,DragEvent,DocumentType,DocumentTimeline,DocumentFragment,Document,DelayNode,DOMRect,DOMPoint,DOMMatrix,CustomEvent,ConvolverNode,ContentVisibilityAutoStateChangeEvent,ConstantSourceNode,CompositionEvent,Comment,CommandEvent,CloseWatcher,CloseEvent,ClipboardEvent,CharacterData,CharacterBoundsUpdateEvent,ChannelSplitterNode,ChannelMergerNode,CanvasCaptureMediaStreamTrack,CSSViewTransitionRule,CSSUnparsedValue,CSSUnitValue,CSSTranslate,CSSTransition,CSSTransformValue,CSSSupportsRule,CSSStyleSheet,CSSStyleRule,CSSStartingStyleRule,CSSSkewY,CSSSkewX,CSSSkew,CSSScopeRule,CSSScale,CSSRotate,CSSPropertyRule,CSSPositionValue,CSSPositionTryRule,CSSPositionTryDescriptors,CSSPerspective,CSSPageRule,CSSNumericValue,CSSNestedDeclarations,CSSNamespaceRule,CSSMediaRule,CSSMatrixComponent,CSSMathValue,CSSMathSum,CSSMathProduct,CSSMathNegate,CSSMathMin,CSSMathMax,CSSMathInvert,CSSMathClamp,CSSMarginRule,CSSLayerStatementRule,CSSLayerBlockRule,CSSKeywordValue,CSSKeyframesRule,CSSKeyframeRule,CSSImportRule,CSSImageValue,CSSGroupingRule,CSSFontPaletteValuesRule,CSSFontFaceRule,CSSCounterStyleRule,CSSContainerRule,CSSConditionRule,CSSAnimation,CSPViolationReportBody,CDATASection,BrowserCaptureMediaStreamTrack,BroadcastChannel,BlobEvent,BiquadFilterNode,BeforeUnloadEvent,BeforeInstallPromptEvent,BaseAudioContext,AudioWorkletNode,AudioScheduledSourceNode,AudioProcessingEvent,AudioNode,AudioDestinationNode,AudioContext,AudioBufferSourceNode,Attr,AnimationPlaybackEvent,AnimationEvent,Animation,AnalyserNode,AbortSignal,SuppressedError,Float16Array,AbsoluteOrientationSensor,Accelerometer,AudioDecoder,AudioEncoder,AudioWorklet,BatteryManager,Clipboard,CookieChangeEvent,CookieStore,DeviceMotionEvent,DeviceOrientationEvent,FederatedCredential,GPUDevice,GPUInternalError,GPUOutOfMemoryError,GPUPipelineError,GPUUncapturedErrorEvent,GPUValidationError,GravitySensor,Gyroscope,IdleDetector,LinearAccelerationSensor,MIDIAccess,MIDIConnectionEvent,MIDIInput,MIDIMessageEvent,MIDIOutput,MIDIPort,MediaDevices,MediaKeyMessageEvent,MediaKeySession,NavigatorManagedData,OrientationSensor,PasswordCredential,RelativeOrientationSensor,ScreenDetailed,ScreenDetails,Sensor,SensorErrorEvent,ServiceWorkerRegistration,VideoDecoder,VideoEncoder,VirtualKeyboard,WebTransportError,XRLayer,AuthenticatorAssertionResponse,AuthenticatorAttestationResponse,PublicKeyCredential,CaptureController,CreateMonitor,DevicePosture,DigitalCredential,DocumentPictureInPicture,FileSystemDirectoryHandle,FileSystemFileHandle,FileSystemWritableFileStream,HID,HIDConnectionEvent,HIDDevice,HIDInputReportEvent,IdentityCredential,IdentityCredentialError,ServiceWorker,ServiceWorkerContainer,OTPCredential,PaymentRequest,PaymentRequestUpdateEvent,PaymentResponse,PaymentMethodChangeEvent,PresentationAvailability,PresentationConnection,PresentationConnectionAvailableEvent,PresentationConnectionCloseEvent,PresentationConnectionList,PresentationRequest,Serial,SerialPort,SharedWorker,USB,USBConnectionEvent,WakeLockSentinel,XRBoundedReferenceSpace,XRCPUDepthInformation,XRInputSourceEvent,XRInputSourcesChangeEvent,XRJointPose,XRJointSpace,XRLightProbe,XRReferenceSpace,XRReferenceSpaceEvent,XRSession,XRSessionEvent,XRSpace,XRSystem,XRViewerPose,XRWebGLDepthInformation,XRWebGLLayer,BackgroundFetchRegistration,CSSFontFeatureValuesRule,CSSFunctionDeclarations,CSSFunctionDescriptors,CSSFunctionRule,DocumentPictureInPictureEvent,HTMLFencedFrameElement,IntegrityViolationReportBody,Notification,PageRevealEvent,PageSwapEvent,PermissionStatus,QuotaExceededError,RTCDataChannel,RemotePlayback,SharedStorageAppendMethod,SharedStorageClearMethod,SharedStorageDeleteMethod,SharedStorageSetMethod,SnapEvent,SpeechRecognition,SpeechRecognitionErrorEvent,SpeechRecognitionEvent,SpeechSynthesis,SpeechSynthesisErrorEvent,SpeechSynthesisEvent,SpeechSynthesisUtterance,WebSocketError,webkitSpeechRecognition,webkitSpeechRecognitionError,webkitSpeechRecognitionEvent,constructor,constructor,constructor

89 'length,name,prototype,captureStackTrace,isError,stackTraceLimit,of,from,Symbol(Symbol.species),fromFloat32Array,fromFloat64Array,fromMatrix,parseHTMLUnsafe,NONE,CAPTURING_PHASE,AT_TARGET,BUBBLING_PHASE,abort,any,timeout,INDEX_SIZE_ERR,DOMSTRING_SIZE_ERR,HIERARCHY_REQUEST_ERR,WRONG_DOCUMENT_ERR,INVALID_CHARACTER_ERR,NO_DATA_ALLOWED_ERR,NO_MODIFICATION_ALLOWED_ERR,NOT_FOUND_ERR,NOT_SUPPORTED_ERR,INUSE_ATTRIBUTE_ERR,INVALID_STATE_ERR,SYNTAX_ERR,INVALID_MODIFICATION_ERR,NAMESPACE_ERR,INVALID_ACCESS_ERR,VALIDATION_ERR,TYPE_MISMATCH_ERR,SECURITY_ERR,NETWORK_ERR,ABORT_ERR,URL_MISMATCH_ERR,QUOTA_EXCEEDED_ERR,TIMEOUT_ERR,INVALID_NODE_TYPE_ERR,DATA_CLONE_ERR,NETWORK_EMPTY,NETWORK_IDLE,NETWORK_LOADING,NETWORK_NO_SOURCE,HAVE_NOTHING,HAVE_METADATA,HAVE_CURRENT_DATA,HAVE_FUTURE_DATA,HAVE_ENOUGH_DATA,ELEMENT_NODE,ATTRIBUTE_NODE,TEXT_NODE,CDATA_SECTION_NODE,ENTITY_REFERENCE_NODE,ENTITY_NODE,PROCESSING_INSTRUCTION_NODE,COMMENT_NODE,DOCUMENT_NODE,DOCUMENT_TYPE_NODE,DOCUMENT_FRAGMENT_NODE,NOTATION_NODE,DOCUMENT_POSITION_DISCONNECTED,DOCUMENT_POSITION_PRECEDING,DOCUMENT_POSITION_FOLLOWING,DOCUMENT_POSITION_CONTAINS,DOCUMENT_POSITION_CONTAINED_BY,DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,fromRect,fromPoint,STYLE_RULE,CHARSET_RULE,IMPORT_RULE,MEDIA_RULE,FONT_FACE_RULE,PAGE_RULE,MARGIN_RULE,NAMESPACE_RULE,KEYFRAMES_RULE,KEYFRAME_RULE,COUNTER_STYLE_RULE,FONT_FEATURE_VALUES_RULE,SUPPORTS_RULE,parse,parseAll'

</details>

<details>
<summary>Firefox results</summary>

All horrors: 320 InternalError,AggregateError,EvalError,RangeError,ReferenceError,SuppressedError,TypeError,URIError,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,Uint8ClampedArray,BigInt64Array,BigUint64Array,Float16Array,MIDIAccess,BroadcastChannel,ChannelMergerNode,SubmitEvent,ServiceWorkerContainer,WebKitCSSMatrix,MouseEvent,IDBOpenDBRequest,VTTCue,Notification,StaticRange,HTMLModElement,HTMLOptGroupElement,DragEvent,MathMLElement,HTMLDataElement,AudioDestinationNode,SpeechSynthesis,ToggleEvent,HTMLFrameSetElement,CSSTransition,WaveShaperNode,AudioWorkletNode,FileSystemDirectoryEntry,ServiceWorker,MediaKeyError,IDBVersionChangeEvent,RTCPeerConnectionIceEvent,HTMLTimeElement,GamepadEvent,HTMLBaseElement,DOMPoint,DelayNode,MouseScrollEvent,CanvasCaptureMediaStream,ProgressEvent,HTMLPreElement,MediaStreamAudioDestinationNode,HTMLOListElement,HTMLTableSectionElement,Worker,CDATASection,MediaKeySession,TaskPriorityChangeEvent,SourceBuffer,WebGLContextEvent,RTCDtlsTransport,HTMLFieldSetElement,HTMLLabelElement,HTMLAudioElement,RTCDataChannel,PopStateEvent,ChannelSplitterNode,VisualViewport,OffscreenCanvas,EventSource,RTCTrackEvent,ErrorEvent,FileSystemFileEntry,PermissionStatus,FileSystemDirectoryHandle,CSSStartingStyleRule,HTMLDetailsElement,HTMLTemplateElement,StereoPannerNode,CookieStore,LargestContentfulPaint,AnimationEvent,VideoDecoder,MIDIConnectionEvent,AudioEncoder,ProcessingInstruction,HTMLPictureElement,PerformancePaintTiming,FontFaceSet,PerformanceMark,CSSNestedDeclarations,VideoEncoder,WakeLockSentinel,DocumentTimeline,CSSPageDescriptors,AuthenticatorAssertionResponse,StorageEvent,HTMLProgressElement,MediaStreamAudioSourceNode,ScreenOrientation,File,MIDIInput,IDBDatabase,BaseAudioContext,WebTransportError,TextTrackList,GainNode,AudioDecoder,IDBTransaction,CSSFontFeatureValuesRule,RTCDTMFToneChangeEvent,HTMLLegendElement,ScriptProcessorNode,SpeechSynthesisUtterance,TimeEvent,KeyframeEffect,WebTransportReceiveStream,MediaStream,CSSContainerRule,HTMLMapElement,HTMLQuoteElement,Range,IDBRequest,PannerNode,HTMLEmbedElement,MediaRecorder,CSSPageRule,OfflineAudioCompletionEvent,XMLDocument,HTMLSlotElement,MediaStreamEvent,FileSystemFileHandle,HTMLFormControlsCollection,Animation,MediaStreamTrackAudioSourceNode,SpeechSynthesisEvent,HTMLOutputElement,BeforeUnloadEvent,FontFaceSetLoadEvent,DeviceOrientationEvent,AudioContext,ScrollAreaEvent,CSSFontPaletteValuesRule,CSSLayerStatementRule,MediaKeyMessageEvent,MediaStreamTrackEvent,TrackEvent,HTMLMeterElement,CSSStyleProperties,InputEvent,PointerEvent,OfflineAudioContext,HTMLMarqueeElement,TextEvent,DOMRect,AudioWorklet,AnalyserNode,HTMLDataListElement,FileReader,RTCDataChannelEvent,DeviceMotionEvent,MIDIOutput,HTMLCanvasElement,MediaEncryptedEvent,MIDIMessageEvent,CSSLayerBlockRule,MediaStreamTrack,RTCDTMFSender,TextTrackCue,HTMLSourceElement,CommandEvent,CloseEvent,BlobEvent,IDBCursorWithValue,PopupBlockedEvent,HTMLTableCaptionElement,OscillatorNode,CSSMozDocumentRule,ConstantSourceNode,TaskSignal,CSSKeyframeRule,CookieChangeEvent,HTMLTrackElement,Attr,MIDIPort,HTMLDirectoryElement,XMLHttpRequestUpload,PromiseRejectionEvent,MediaElementAudioSourceNode,HTMLParamElement,RTCPeerConnection,HTMLDialogElement,ClipboardEvent,ConvolverNode,Clipboard,CSSCounterStyleRule,CSSNamespaceRule,Screen,HTMLMenuElement,HTMLUnknownElement,HashChangeEvent,CompositionEvent,HTMLTableColElement,MediaQueryListEvent,PerformanceEventTiming,RTCIceTransport,ServiceWorkerRegistration,DOMMatrix,ContentVisibilityAutoStateChangeEvent,HTMLFontElement,SharedWorker,HTMLTableElement,AuthenticatorAttestationResponse,HTMLBRElement,TaskController,HTMLOptionsCollection,WheelEvent,MediaDevices,IIRFilterNode,RTCSctpTransport,BiquadFilterNode,TextTrack,WebTransportSendStream,PerformanceMeasure,SpeechSynthesisErrorEvent,SourceBufferList,AudioBufferSourceNode,FocusEvent,FileSystemWritableFileStream,HTMLTableCellElement,AnimationPlaybackEvent,HTMLTableRowElement,AudioProcessingEvent,HTMLFormElement,HTMLHRElement,HTMLDListElement,PerformanceNavigationTiming,TransitionEvent,DynamicsCompressorNode,RadioNodeList,PerformanceResourceTiming,CSSAnimation,FormDataEvent,AudioNode,AudioScheduledSourceNode,MediaRecorderErrorEvent,MessagePort,CSSPropertyRule,Window,Node,Document,HTMLDocument,Performance,XMLHttpRequestEventTarget,XMLHttpRequest,WebSocket,Element,HTMLElement,HTMLHtmlElement,CustomEvent,HTMLObjectElement,MediaSource,SecurityPolicyViolationEvent,HTMLMediaElement,HTMLVideoElement,DocumentType,PublicKeyCredential,HTMLFrameElement,HTMLIFrameElement,HTMLMetaElement,HTMLHeadElement,HTMLStyleElement,HTMLLinkElement,CharacterData,Text,HTMLTitleElement,HTMLScriptElement,CSSStyleSheet,CSSGroupingRule,CSSStyleRule,CSSConditionRule,CSSMediaRule,CSSImportRule,HTMLBodyElement,HTMLDivElement,HTMLAnchorElement,HTMLParagraphElement,HTMLUListElement,HTMLLIElement,Comment,HTMLHeadingElement,HTMLImageElement,HTMLSpanElement,CSSSupportsRule,CSSKeyframesRule,CSSFontFaceRule,HTMLButtonElement,HTMLOptionElement,HTMLTextAreaElement,DocumentFragment,ShadowRoot,MediaQueryList,HTMLInputElement,MessageEvent,AbortSignal,PageTransitionEvent,HTMLAreaElement,HTMLSelectElement,UIEvent,KeyboardEvent,SyntaxError,constructor,constructor,constructor 

98 isError,captureStackTrace,prototype,length,name,from,of,Symbol(Symbol.species),NONE,CAPTURING_PHASE,AT_TARGET,BUBBLING_PHASE,ALT_MASK,CONTROL_MASK,SHIFT_MASK,META_MASK,fromMatrix,fromFloat32Array,fromFloat64Array,SCROLL_PAGE_UP,SCROLL_PAGE_DOWN,MOZ_SOURCE_UNKNOWN,MOZ_SOURCE_MOUSE,MOZ_SOURCE_PEN,MOZ_SOURCE_ERASER,MOZ_SOURCE_CURSOR,MOZ_SOURCE_TOUCH,MOZ_SOURCE_KEYBOARD,fromPoint,NETWORK_EMPTY,NETWORK_IDLE,NETWORK_LOADING,NETWORK_NO_SOURCE,HAVE_NOTHING,HAVE_METADATA,HAVE_CURRENT_DATA,HAVE_FUTURE_DATA,HAVE_ENOUGH_DATA,STYLE_RULE,CHARSET_RULE,IMPORT_RULE,MEDIA_RULE,FONT_FACE_RULE,PAGE_RULE,NAMESPACE_RULE,KEYFRAMES_RULE,KEYFRAME_RULE,COUNTER_STYLE_RULE,SUPPORTS_RULE,FONT_FEATURE_VALUES_RULE,INDEX_SIZE_ERR,DOMSTRING_SIZE_ERR,HIERARCHY_REQUEST_ERR,WRONG_DOCUMENT_ERR,INVALID_CHARACTER_ERR,NO_DATA_ALLOWED_ERR,NO_MODIFICATION_ALLOWED_ERR,NOT_FOUND_ERR,NOT_SUPPORTED_ERR,INUSE_ATTRIBUTE_ERR,INVALID_STATE_ERR,SYNTAX_ERR,INVALID_MODIFICATION_ERR,NAMESPACE_ERR,INVALID_ACCESS_ERR,VALIDATION_ERR,TYPE_MISMATCH_ERR,SECURITY_ERR,NETWORK_ERR,ABORT_ERR,URL_MISMATCH_ERR,QUOTA_EXCEEDED_ERR,TIMEOUT_ERR,INVALID_NODE_TYPE_ERR,DATA_CLONE_ERR,parseHTMLUnsafe,fromRect,abort,timeout,any,ELEMENT_NODE,ATTRIBUTE_NODE,TEXT_NODE,CDATA_SECTION_NODE,ENTITY_REFERENCE_NODE,ENTITY_NODE,PROCESSING_INSTRUCTION_NODE,COMMENT_NODE,DOCUMENT_NODE,DOCUMENT_TYPE_NODE,DOCUMENT_FRAGMENT_NODE,NOTATION_NODE,DOCUMENT_POSITION_DISCONNECTED,DOCUMENT_POSITION_PRECEDING,DOCUMENT_POSITION_FOLLOWING,DOCUMENT_POSITION_CONTAINS,DOCUMENT_POSITION_CONTAINED_BY,DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC

</details>
