### PR TITLE
fix(lavamoat-node): cli entry args (#1857)

### DIFF
--- a/packages/lavamoat-node/README.md
+++ b/packages/lavamoat-node/README.md
@@ -99,6 +99,12 @@ Options:
 
 ```
 
+To pass arguments to the script without revealing lavamoat-specific arguments, use `--` like so:
+
+```
+ lavamoat index.js --override './policies/policy-override.json' -- --arg-for-index=1
+```
+
 ## More Examples
 
 ### Run with Policy in default location

--- a/packages/lavamoat-node/src/cli.js
+++ b/packages/lavamoat-node/src/cli.js
@@ -40,6 +40,7 @@ function parseArgs() {
   // so we just remove the node path
   process.argv.shift()
   } else {
+    // Rebuild process.argv to pass only entry args
     process.argv = [process.argv[0], parsedArgs.entryPath, ...entryArgs]
   }
 

--- a/packages/lavamoat-node/src/cli.js
+++ b/packages/lavamoat-node/src/cli.js
@@ -24,15 +24,16 @@ function parseArgs() {
       })
       yargsFlags(yargs, defaults)
     })
+    .parserConfiguration({
+      'populate--': true,
+    })
     .help()
 
   const parsedArgs = argsParser.parse()
 
-  // patch process.argv so it matches the normal pattern
-  // e.g. [runtime path, entrypoint, ...args]
-  // we'll use the LavaMoat path as the runtime
-  // so we just remove the node path
-  process.argv.shift()
+  // Rebuild process.argv to pass only entry args
+  const entryArgs = parsedArgs['--'] || []
+  process.argv = [process.argv[0], parsedArgs.entryPath, ...entryArgs]
 
   return parsedArgs
 }

--- a/packages/lavamoat-node/src/cli.js
+++ b/packages/lavamoat-node/src/cli.js
@@ -32,8 +32,16 @@ function parseArgs() {
   const parsedArgs = argsParser.parse()
 
   // Rebuild process.argv to pass only entry args
-  const entryArgs = parsedArgs['--'] || []
-  process.argv = [process.argv[0], parsedArgs.entryPath, ...entryArgs]
+  const entryArgs = parsedArgs['--']
+  if (!entryArgs) {
+    // patch process.argv so it matches the normal pattern
+  // e.g. [runtime path, entrypoint, ...args]
+  // we'll use the LavaMoat path as the runtime
+  // so we just remove the node path
+  process.argv.shift()
+  } else {
+    process.argv = [process.argv[0], parsedArgs.entryPath, ...entryArgs]
+  }
 
   return parsedArgs
 }

--- a/packages/lavamoat-node/src/cli.js
+++ b/packages/lavamoat-node/src/cli.js
@@ -31,14 +31,14 @@ function parseArgs() {
 
   const parsedArgs = argsParser.parse()
 
-  // Rebuild process.argv to pass only entry args
   const entryArgs = parsedArgs['--']
   if (!entryArgs) {
+    // backward compatibility mode
     // patch process.argv so it matches the normal pattern
-  // e.g. [runtime path, entrypoint, ...args]
-  // we'll use the LavaMoat path as the runtime
-  // so we just remove the node path
-  process.argv.shift()
+    // e.g. [runtime path, entrypoint, ...args]
+    // we'll use the LavaMoat path as the runtime
+    // so we just remove the node path
+    process.argv.shift()
   } else {
     // Rebuild process.argv to pass only entry args
     process.argv = [process.argv[0], parsedArgs.entryPath, ...entryArgs]

--- a/packages/lavamoat-node/src/run-command.js
+++ b/packages/lavamoat-node/src/run-command.js
@@ -20,18 +20,30 @@ function parseArgs() {
     .usage(
       '$0',
       'lavamoat-run-command [flags for lavamoat] -- command [args for the command]',
-      (yarn) => yargsFlags(yarn, defaults)
+      (yargs) => yargsFlags(yargs, defaults)
     )
+    .parserConfiguration({
+      'populate--': true,
+    })
     .help()
 
   const parsedArgs = argsParser.parse()
-  const commandName = parsedArgs._[0]
+  const passDownArgs = parsedArgs['--'] || []
+  const commandName = passDownArgs[0]
+
+  if (!commandName) {
+    console.error(
+      'Error: No command specified. Usage: lavamoat-run-command [lavamoat-flags] -- command [command-args]'
+    )
+    process.exit(2)
+  }
 
   const binEntry = path.resolve(
     process.cwd(),
     './node_modules/.bin/',
     commandName
   )
+
   if (!fs.existsSync(binEntry)) {
     console.error(`Error: '${commandName}' is not one of the locally installed commands. Missing: '${binEntry}'
     Possible reasons for this error:
@@ -51,7 +63,7 @@ function parseArgs() {
   // e.g. [runtime path, entrypoint, ...args]
   // we'll use the LavaMoat path as the runtime
   // so we just remove the node path
-  process.argv = [process.argv[0], ...parsedArgs._]
+  process.argv = [process.argv[0], ...passDownArgs]
 
   return parsedArgs
 }

--- a/packages/lavamoat-node/src/yargsFlags.js
+++ b/packages/lavamoat-node/src/yargsFlags.js
@@ -1,4 +1,9 @@
 module.exports = (yargs, defaults) => {
+  yargs.positional('entryPath', {
+    describe:
+      'the path to the entry file for your application. same as node.js',
+    type: 'string',
+  })
   // the path for the policy file
   yargs.option('policy', {
     alias: ['p', 'policyPath'],

--- a/packages/lavamoat-node/test/projects/5/index.js
+++ b/packages/lavamoat-node/test/projects/5/index.js
@@ -1,1 +1,2 @@
 require('a')
+process.stdout.write(process.argv.join(','))


### PR DESCRIPTION
fix #344

continuation of a contribution from @itsyoboieltr 

todo:
- [x] validate it's needed and correct
- [x] figure out if it's a breaking change and whether we can keep backward-compatibility
- [x] tests
- [x] docs
- [ ] compare with `@lavamoat/node`