### PR TITLE
chore: open up features and fixes reviews to a potentially wider group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @naugtur @boneskull
+packages @LavaMoat/devs


### PR DESCRIPTION
We can add people that can review changes without letting them merge repo configuration and releases.

- [ ] turn on CODEOWNERS enforcement in repo settings 