### PR TITLE
fix: typescript got confused into creating a cyclic reference in types for scuttling in core

### DIFF
--- a/packages/core/src/scuttle.d.ts
+++ b/packages/core/src/scuttle.d.ts
@@ -1,25 +1,11 @@
-/**
- * Options for scuttling global properties
- */
-export type LavaMoatScuttleOpts = {
-  /** Whether scuttling is enabled or not. */
-  enabled: boolean;
-  /** List of properties to exclude from scuttling. */
-  exceptions?: Array<string | RegExp>;
-  /** Name of the scuttler function to use which is expected to be found as a property on the global object (e.g. if scuttlerName is 'x', scuttler function is obtained from globalThis['x']). */
-  scuttlerName?: string;
-}
+// Declaring types here and importing them in scuttle.js 
+// leads to typescript getting confused into generating 
+// a self-referential cycle in the generated .d.ts files:
+// types/src/scuttle.d.ts
+// import type { LavaMoatScuttleOpts } from './scuttle.d.ts';
 
-/**
- * Reference to the global object
- */
-export interface GlobalRef {
-  globalThis?: Record<PropertyKey, unknown>;
-}
+export type {
+    LavaMoatScuttleOpts
+} from './scuttle.js'
 
-/**
- * Scuttles (disables or restricts) certain global properties
- * @param globalRef The global object to scuttle
- * @param [opts] Options for scuttling
- */
-export function scuttle(globalRef: GlobalRef, opts?: LavaMoatScuttleOpts | boolean): void;
+export { scuttle } from './scuttle.js'

--- a/packages/core/src/scuttle.js
+++ b/packages/core/src/scuttle.js
@@ -1,4 +1,14 @@
-/** @import { LavaMoatScuttleOpts, GlobalRef } from './scuttle.d.ts' */
+/**
+ * @typedef {object} LavaMoatScuttleOpts Options for scuttling `globalThis`.
+ * @property {boolean} enabled Whether scuttling is enabled or not.
+ * @property {Array<string | RegExp>} [exceptions] List of properties to exclude from scuttling.
+ * @property {string} [scuttlerName] Name of the scuttler function to use which is expected to be found as a property on the global object (e.g. if scuttlerName is 'x', scuttler function is obtained from globalThis['x']).
+ */
+
+/**
+ * @typedef {object} GlobalRef Reference to the global object
+ * @property {Record<PropertyKey, unknown>} [globalThis] Reference to the global object.
+ */
 
 const { Object, Array, Error, RegExp, Set, console, Proxy, Reflect } =
   globalThis

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,6 @@ export * from './index'
 export type * from './moduleRecord'
 export type * from './options'
 export type * from './parseForPolicy'
-export type { LavaMoatScuttleOpts } from './scuttle.d.ts'
+export type { LavaMoatScuttleOpts } from './scuttle'
 export { E as EndowmentsToolkitFactory }
 

--- a/packages/webpack/examples/webpack.config.js
+++ b/packages/webpack/examples/webpack.config.js
@@ -1,3 +1,4 @@
+// @ts-check
 const LavaMoat = require('../src/plugin.js')
 const { ProgressPlugin } = require('webpack')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
@@ -40,6 +41,10 @@ module.exports = {
       runChecks: true,
       diagnosticsVerbosity: 1,
       HtmlWebpackPluginInterop: true,
+      // scuttleGlobalThis: { 
+      //   enabled: true, 
+      //   exceptions: ['Proxy', /Uint[0-9]+Array/]
+      // },
     }),
     // virtualModules,
     new ProgressPlugin(),


### PR DESCRIPTION
hopefully this is the last time we're fixing scuttling types.

Resulting types/src/scuttling.d.ts

**before**

```ts
/**
 * Applies scuttling, with the default set of options, including using Snow if
 * passed in as scuttlerFunc. Scuttle globalThis right after we used it to
 * create the root package compartment.
 *
 * @param {GlobalRef} globalRef - Reference to the global object.
 * @param {LavaMoatScuttleOpts} opts - Scuttling options.
 */
export function scuttle(globalRef: GlobalRef, opts: LavaMoatScuttleOpts): void;
import type { GlobalRef } from './scuttle.d.ts';
import type { LavaMoatScuttleOpts } from './scuttle.d.ts';
//# sourceMappingURL=scuttle.d.ts.map
```


**after**

```ts
/**
 * Options for scuttling `globalThis`.
 */
export type LavaMoatScuttleOpts = {
    /**
     * Whether scuttling is enabled or not.
     */
    enabled: boolean;
    /**
     * List of properties to exclude from scuttling.
     */
    exceptions?: (string | RegExp)[] | undefined;
    /**
     * Name of the scuttler function to use which is expected to be found as a property on the global object (e.g. if scuttlerName is 'x', scuttler function is obtained from globalThis['x']).
     */
    scuttlerName?: string | undefined;
};
/**
 * Reference to the global object
 */
export type GlobalRef = {
    /**
     * Reference to the global object.
     */
    globalThis?: Record<PropertyKey, unknown> | undefined;
};
/**
 * Applies scuttling, with the default set of options, including using Snow if
 * passed in as scuttlerFunc. Scuttle globalThis right after we used it to
 * create the root package compartment.
 *
 * @param {GlobalRef} globalRef - Reference to the global object.
 * @param {LavaMoatScuttleOpts} opts - Scuttling options.
 */
export function scuttle(globalRef: GlobalRef, opts: LavaMoatScuttleOpts): void;
//# sourceMappingURL=scuttle.d.ts.map
```
