### PR TITLE
fix(browserify,core,lavamoat-node,node): do not publish extraneous files

### DIFF
--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -21,6 +21,10 @@
     "lib": "lib",
     "test": "test"
   },
+  "files": [
+    "CHANGELOG.md",
+    "src"
+  ],
   "scripts": {
     "build:ses": "(cd ./node_modules/ses && npm install && npm run build && cp ./dist/ses.umd.js ../../lib/)",
     "lint:deps": "depcheck",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "bin": {
-    "lavamoat-sort-policy": "./src/policy-sort-cli.js"
+    "lavamoat-sort-policy": "src/policy-sort-cli.js"
   },
   "main": "src/index.js",
   "types": "./types/src/types.d.ts",

--- a/packages/lavamoat-node/package.json
+++ b/packages/lavamoat-node/package.json
@@ -25,6 +25,11 @@
     "example": "examples",
     "test": "test"
   },
+  "files": [
+    "CHANGELOG.md",
+    "examples",
+    "src"
+  ],
   "scripts": {
     "lint:deps": "depcheck",
     "test": "npm run test:npm && npm run test:yarn1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -41,6 +41,12 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "CHANGELOG.md",
+    "src",
+    "types",
+    "!*.tsbuildinfo"
+  ],
   "scripts": {
     "lint:deps": "depcheck",
     "test": "npm run test:run",


### PR DESCRIPTION
Also fixes `bin` prop in `lavamoat-core`.

Closes #1865