### PR TITLE
feat(lavamoat-node): expose top level export as return value of runLava

### DIFF
--- a/packages/lavamoat-node/src/index.js
+++ b/packages/lavamoat-node/src/index.js
@@ -94,7 +94,7 @@ async function runLava(options) {
     })
 
     // run entrypoint
-    kernel.internalRequire(entryId)
+    return kernel.internalRequire(entryId)
   }
 }
 


### PR DESCRIPTION
When not generating policy, calling `runLava()` programmatically now resolves with an object containing the exported namespace