### PR TITLE
chore(deps): update qs to v6.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16772,9 +16772,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -20842,7 +20842,7 @@
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
       },
       "peerDependencies": {
-        "lavamoat-core": ">17.1.0"
+        "lavamoat-core": ">15.4.0"
       }
     },
     "packages/tofu/node_modules/@babel/parser": {


### PR DESCRIPTION
Fix for https://github.com/LavaMoat/LavaMoat/security/dependabot/701

This only affects development dependencies.