### PR TITLE
chore(ci): cancel in-progress test runs against new pushes to the same ref

### DIFF
--- a/.github/workflows/nodejs-macos.yml
+++ b/.github/workflows/nodejs-macos.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compatibility-test-macos:
     name: Test macOS compatibility

--- a/.github/workflows/nodejs-win.yml
+++ b/.github/workflows/nodejs-win.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compatibility-test-windows:
     name: Test Windows compatibility

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: '1'
 


### PR DESCRIPTION
This means if we push to the same PR branch before the previous run was complete, it will just cancel the previous run.