### PR TITLE
fix: performant implementation of getPackageDirForModulePath in aa and minor memoization in lavamoat-node

### DIFF
--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -275,33 +275,22 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
   return packageName
 }
 
+const pathSeparator = path.sep;
+
 /**
  * @param {CanonicalNameMap} canonicalNameMap
  * @param {string} modulePath
  * @returns {string | undefined}
  */
 function getPackageDirForModulePath(canonicalNameMap, modulePath) {
-  // find which of these directories the module is in
-  const matchingPackageDirs = Array.from(canonicalNameMap.keys()).filter(
-    (packageDir) => modulePath.startsWith(packageDir)
-  )
-  if (matchingPackageDirs.length === 0) {
-    return undefined
-    // throw new Error(`Could not find package for module path: "${modulePath}" out of these package dirs:\n${Array.from(canonicalNameMap.keys()).join('\n')}`)
+  let subPath = modulePath
+  while (subPath.length > 0) {
+    if (canonicalNameMap.has(subPath)) {
+      return subPath
+    }
+    subPath = subPath.substring(0, subPath.lastIndexOf(pathSeparator))
   }
-  const longestMatch = matchingPackageDirs.reduce(takeLongest)
-  return longestMatch
-}
-
-/**
- * For comparing string lengths
- *
- * @param {string} a
- * @param {string} b
- * @returns {string}
- */
-function takeLongest(a, b) {
-  return a.length > b.length ? a : b
+  return undefined
 }
 
 /**

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -275,7 +275,7 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
   return packageName
 }
 
-const pathSeparator = path.sep;
+const pathSeparator = path.sep
 
 /**
  * @param {CanonicalNameMap} canonicalNameMap
@@ -289,6 +289,12 @@ function getPackageDirForModulePath(canonicalNameMap, modulePath) {
       return subPath
     }
     subPath = subPath.substring(0, subPath.lastIndexOf(pathSeparator))
+  }
+  if (
+    canonicalNameMap.has(pathSeparator) &&
+    modulePath.startsWith(pathSeparator)
+  ) {
+    return pathSeparator
   }
   return undefined
 }

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -48,6 +48,15 @@ test('project 1', async (t) => {
   )
 })
 
+test('Keys in canonicalNameMap must not end with slashes', async (t) => {
+  const canonicalNameMap = await loadCanonicalNameMap({
+    rootDir: path.join(__dirname, 'projects', '1'),
+  })
+  t.true(
+    [...canonicalNameMap.keys()].every((key) => !key.endsWith(path.sep))
+  )
+})
+
 test('project 2', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
     rootDir: path.join(__dirname, 'projects', '2'),

--- a/packages/lavamoat-node/src/kernel.js
+++ b/packages/lavamoat-node/src/kernel.js
@@ -117,7 +117,11 @@ function createModuleResolver({ projectRoot, resolutions, canonicalNameMap }) {
 }
 
 function createModuleLoader({ canonicalNameMap }) {
+  const memo = new Map()
   return function loadModuleData(absolutePath) {
+    if( memo.has(absolutePath)) {
+      return memo.get(absolutePath)
+    }
     // load builtin modules (eg "fs")
     if (resolve.isCore(absolutePath)) {
       return {
@@ -200,14 +204,16 @@ function createModuleLoader({ canonicalNameMap }) {
         canonicalNameMap,
         absolutePath
       )
+      const moduleData = {
 
-      return {
         type: 'js',
         file: absolutePath,
         package: packageName,
         source: wrappedContent,
         id: absolutePath,
       }
+      memo.set(absolutePath, moduleData)
+      return moduleData
     }
   }
 }

--- a/packages/webpack/test/aa.spec.js
+++ b/packages/webpack/test/aa.spec.js
@@ -64,11 +64,11 @@ const lookupFixture = {
   canonicalNameMap: new Map(
     Object.entries({
       '/': '$root$',
-      '/node_modules/leftpad/': 'leftpad',
+      '/node_modules/leftpad': 'leftpad',
       '/node_modules/fast-json-patch': 'fast-json-patch',
       '/node_modules/fast-json-patch/module': 'fast-json-patch',
-      '/node_modules/@ethereumjs/util/dist/': '@ethereumjs/util',
-      '/node_modules/@ethereumjs/util/node_modules/ethereum-cryptography/dist/':
+      '/node_modules/@ethereumjs/util/dist': '@ethereumjs/util',
+      '/node_modules/@ethereumjs/util/node_modules/ethereum-cryptography/dist':
         '@ethereumjs/util>ethereum-cryptography',
     })
   ),


### PR DESCRIPTION
the assumption that splitting by path separator works is valid.

there's a possibility that `path.sep` is not the right separator if a memfs is used. 
should I add a fallback to detect a separator?
should this be an expensive to construct prefix tree for an algorithm that is agnostic to the concept of a path? (very meh imho)

The build I tested this on goes from 90sec to 64sec with this fix.