### PR TITLE
fix(aa): normalize root path to not contain a trailing slash regardless of what is provided in input

### DIFF
--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -79,6 +79,10 @@ async function loadCanonicalNameMap({
   includeDevDeps,
   resolve = performantResolve,
 }) {
+  rootDir = path.normalize(rootDir)
+  if (rootDir.endsWith(path.sep) && rootDir !== path.sep) {
+    rootDir = rootDir.slice(0, -1)
+  }
   const canonicalNameMap = /** @type {CanonicalNameMap} */ (new Map())
   // walk tree
   const logicalPathMap = walkDependencyTreeForBestLogicalPaths({

--- a/packages/aa/test/index.spec.js
+++ b/packages/aa/test/index.spec.js
@@ -50,11 +50,9 @@ test('project 1', async (t) => {
 
 test('Keys in canonicalNameMap must not end with slashes', async (t) => {
   const canonicalNameMap = await loadCanonicalNameMap({
-    rootDir: path.join(__dirname, 'projects', '1'),
+    rootDir: path.join(__dirname, 'projects', '1') + path.sep, // deliberately add a slash to mess with it
   })
-  t.true(
-    [...canonicalNameMap.keys()].every((key) => !key.endsWith(path.sep))
-  )
+  t.true([...canonicalNameMap.keys()].every((key) => !key.endsWith(path.sep)))
 })
 
 test('project 2', async (t) => {


### PR DESCRIPTION
Earlier the test missed one possibility. It occurred in the wild.