### PR TITLE
feat(laverna): support Yarn

### DIFF
--- a/packages/laverna/README.md
+++ b/packages/laverna/README.md
@@ -16,6 +16,7 @@ If you're unfamiliar with it: **Laverna** publishes all workspacess wherein the 
 - Requires confirmation (by default)
 - Prints all output from `npm publish`, including the output of `npm pack`, to enable review prior to confirmation
 - Provides a "dry-run" mode
+- **Supports Yarn Berry workspaces** -- automatically detects `yarn.lock` and uses `yarn npm publish`, which resolves `workspace:` protocol specifiers (e.g. `workspace:^`) in-memory during packing
 
 **Laverna**'s scope is intentionally limited to the above use-case.
 
@@ -36,6 +37,7 @@ Perhaps more importantly, **Laverna**:
 
 - Node.js v20.19.0+
 - `npm` v8.19.3+
+- `yarn` v2+ (for Yarn Berry workspaces; detected automatically via `yarn.lock`)
 
 ## Install
 
@@ -79,6 +81,16 @@ If you're publishing a package in a new workspace, you might:
 1. Set the initial version of the new package (call it `foo`) in its `package.json`.
 2. Run `npm exec laverna -- --newPkg=foo` (or `npm exec laverna -- --newPkg=foo --dryRun` first)
 3. Profit
+
+### Using with Yarn Berry (workspace: protocol)
+
+If your monorepo uses Yarn Berry (v2+) and `workspace:` protocol specifiers (e.g. `workspace:^`), **Laverna** handles this automatically. When a `yarn.lock` file is detected in the workspace root, **Laverna** delegates to `yarn workspaces foreach ... npm publish` instead of `npm publish`.
+
+```shell
+# From a Yarn Berry workspace root (yarn.lock present):
+npx laverna --dryRun
+# Laverna detects yarn.lock and uses: yarn workspaces foreach -A --no-private --include <pkg> npm publish --dry-run
+```
 
 ### Automating Publishes
 

--- a/packages/laverna/src/index.js
+++ b/packages/laverna/src/index.js
@@ -1,12 +1,14 @@
+/**
+ * @import {LavernaOptions, LavernaCapabilities, PublishFn, Publisher, GetVersions, GlobDirent} from './types'
+ * @import {ExecFileException} from 'node:child_process'
+ * @import {PackageJson} from 'type-fest'
+ */
+
 const path = require('node:path')
 const { INFO, ERR, WARN, OK } = require('./log-symbols')
 const { yellow, bold, gray } = require('kleur')
-const {
-  DEFAULT_SPAWN_OPTS,
-  DEFAULT_GLOB_OPTS,
-  DEFAULT_CAPS,
-  DEFAULT_OPTS,
-} = require('./defaults')
+const { DEFAULT_GLOB_OPTS, DEFAULT_CAPS, DEFAULT_OPTS } = require('./defaults')
+const { createPublisher } = require('./publisher')
 
 /**
  * @param {unknown} arr
@@ -23,8 +25,8 @@ exports.Laverna = class Laverna {
   /**
    * Initializes options & capabilities
    *
-   * @param {import('./types').LavernaOptions} [opts]
-   * @param {import('./types').LavernaCapabilities} [caps]
+   * @param {LavernaOptions} [opts]
+   * @param {LavernaCapabilities} [caps]
    */
   constructor(opts = {}, caps = {}) {
     this.opts = { ...DEFAULT_OPTS, ...opts }
@@ -32,9 +34,14 @@ exports.Laverna = class Laverna {
     this.getVersions = this.caps.getVersionsFactory
       ? this.caps.getVersionsFactory(this.opts, this.caps)
       : this.defaultGetVersions
-    this.invokePublish = this.caps.invokePublishFactory
-      ? this.caps.invokePublishFactory(this.opts, this.caps)
-      : this.defaultInvokePublish
+
+    /**
+     * Cached publisher instance, created lazily by {@link getPublisher}.
+     *
+     * @private
+     * @type {Publisher | undefined}
+     */
+    this._publisher = undefined
   }
 
   /**
@@ -52,35 +59,34 @@ exports.Laverna = class Laverna {
   }
 
   /**
-   * Invoke `npm publish`
+   * Returns the {@link Publisher} for this instance, creating it lazily if
+   * needed.
    *
-   * @type {import('./types').InvokePublish}
+   * If a custom `publisherFactory` capability was provided, it is called;
+   * otherwise the default {@link createPublisher} factory detects the package
+   * manager via lockfile.
+   *
+   * @returns {Promise<Publisher>}
    */
-  async defaultInvokePublish(pkgs) {
-    const { dryRun, root: cwd } = this.opts
-    const { spawn, console } = this.caps
+  async getPublisher() {
+    if (this._publisher !== undefined) {
+      return this._publisher
+    }
 
-    await new Promise((resolve, reject) => {
-      const args = ['publish', ...pkgs.map((name) => `--workspace=${name}`)]
-      if (dryRun) {
-        args.push('--dry-run')
-      }
+    const factory = this.caps.publisherFactory ?? createPublisher
+    this._publisher = await factory(this.opts, this.caps)
+    return this._publisher
+  }
 
-      const relativeCwd = this.relPath(cwd)
-      console.error(
-        `${INFO} Running command in ${relativeCwd}:\nnpm ${args.join(' ')}`
-      )
-
-      spawn('npm', args, { ...DEFAULT_SPAWN_OPTS, cwd })
-        .once('error', reject)
-        .once('exit', (code) => {
-          if (code === 0) {
-            resolve(void 0)
-          } else {
-            reject(new Error(`npm publish exited with code ${code}`))
-          }
-        })
-    })
+  /**
+   * Publishes the given packages using the detected (or injected)
+   * {@link Publisher}.
+   *
+   * @type {PublishFn}
+   */
+  async publish(pkgs) {
+    const publisher = await this.getPublisher()
+    await publisher.publish(pkgs)
   }
 
   /**
@@ -111,7 +117,7 @@ exports.Laverna = class Laverna {
   /**
    * Default implementation of a {@link GetVersions} function.
    *
-   * @type {import('./types').GetVersions}
+   * @type {GetVersions}
    */
   async defaultGetVersions(name, cwd) {
     const { execFile, parseJson, console } = this.caps
@@ -140,7 +146,7 @@ exports.Laverna = class Laverna {
         // promisify'd `exec` is surfaced in the node typings
         // anywhere.
         const err = /**
-         * @type {import('node:child_process').ExecFileException & {
+         * @type {ExecFileException & {
          *   stdout: string
          * }}
          */ (e)
@@ -249,7 +255,7 @@ exports.Laverna = class Laverna {
     }
 
     /**
-     * @type {import('./types').GlobDirent[]}
+     * @type {GlobDirent[]}
      * @see {@link https://github.com/isaacs/node-glob/issues/551}
      */
     const dirents = await glob(workspaces, {
@@ -283,7 +289,7 @@ exports.Laverna = class Laverna {
                  * Parsed contents of `package.json` for the package in the dir
                  * represented by `dirent`
                  *
-                 * @type {import('type-fest').PackageJson}
+                 * @type {PackageJson}
                  */
                 let pkg
 
@@ -401,7 +407,16 @@ exports.Laverna = class Laverna {
     )
 
     if (this.opts.yes || (await this.confirm())) {
-      await this.invokePublish(pkgNames)
+      const publisher = await this.getPublisher()
+      if (publisher.name === 'yarn') {
+        console.error(
+          `${INFO} Detected ${bold('yarn.lock')}; using ${bold('yarn npm publish')}`
+        )
+      } else {
+        console.error(`${INFO} using ${bold('npm publish')}`)
+      }
+
+      await publisher.publish(pkgNames)
       console.error(`${OK} Done!`)
     } else {
       console.error(`${ERR} Aborted; no packages haved been published.`)

--- a/packages/laverna/src/publisher.js
+++ b/packages/laverna/src/publisher.js
@@ -1,0 +1,165 @@
+/**
+ * Publisher implementations for npm and Yarn Berry workspaces.
+ *
+ * Each publisher knows how to invoke its package manager's publish command. Use
+ * {@link createPublisher} to detect the correct one automatically.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * @import {Publisher, AllLavernaOptions, AllLavernaCapabilities, PublishFn, PublisherFactory} from './types'
+ */
+
+const path = require('node:path')
+const { INFO } = require('./log-symbols')
+const { DEFAULT_SPAWN_OPTS } = require('./defaults')
+
+/**
+ * Computes a display-friendly relative path from `root`.
+ *
+ * @param {string} root
+ * @param {string} somePath
+ * @returns {string}
+ */
+function relPath(root, somePath) {
+  const fromRoot = path.relative(root, somePath)
+  return fromRoot ? `.${path.sep}${fromRoot}` : '.'
+}
+
+/**
+ * Publishes workspace packages via `npm publish --workspace=...`.
+ *
+ * This is the default publisher used when no `yarn.lock` is detected.
+ *
+ * @implements {Publisher}
+ */
+class NpmPublisher {
+  /** @type {'npm'} */
+  name = 'npm'
+
+  /**
+   * @param {AllLavernaOptions} opts
+   * @param {Pick<AllLavernaCapabilities, 'spawn' | 'console'>} caps
+   */
+  constructor(opts, caps) {
+    this.opts = opts
+    this.caps = caps
+  }
+
+  /** @type {PublishFn} */
+  async publish(pkgs) {
+    const { dryRun, root: cwd } = this.opts
+    const { spawn, console } = this.caps
+
+    await new Promise((resolve, reject) => {
+      const args = ['publish', ...pkgs.map((name) => `--workspace=${name}`)]
+      if (dryRun) {
+        args.push('--dry-run')
+      }
+
+      const relativeCwd = relPath(cwd, cwd)
+      console.error(
+        `${INFO} Running command in ${relativeCwd}:\nnpm ${args.join(' ')}`
+      )
+
+      spawn('npm', args, { ...DEFAULT_SPAWN_OPTS, cwd })
+        .once('error', reject)
+        .once('exit', (code) => {
+          if (code === 0) {
+            resolve(void 0)
+          } else {
+            reject(new Error(`npm publish exited with code ${code}`))
+          }
+        })
+    })
+  }
+}
+
+/**
+ * Publishes workspace packages via `yarn workspaces foreach ... npm publish`.
+ *
+ * Yarn Berry resolves `workspace:` protocol specifiers (e.g. `workspace:^`)
+ * in-memory during packing, so no on-disk `package.json` rewriting is needed.
+ *
+ * The `--include` flag selects specific workspaces by package name.
+ * `--no-private` is belt-and-suspenders (laverna already filters private
+ * packages). `--tolerate-republish` prevents errors if a version was already
+ * published (laverna already filters these too, but just in case).
+ *
+ * @implements {Publisher}
+ */
+class YarnPublisher {
+  /** @type {'yarn'} */
+  name = 'yarn'
+
+  /**
+   * @param {AllLavernaOptions} opts
+   * @param {Pick<AllLavernaCapabilities, 'spawn' | 'console'>} caps
+   */
+  constructor(opts, caps) {
+    this.opts = opts
+    this.caps = caps
+  }
+
+  /** @type {PublishFn} */
+  async publish(pkgs) {
+    const { dryRun, root: cwd } = this.opts
+    const { spawn, console } = this.caps
+
+    await new Promise((resolve, reject) => {
+      const args = [
+        'workspaces',
+        'foreach',
+        '-A',
+        '--no-private',
+        ...pkgs.flatMap((name) => ['--include', name]),
+        'npm',
+        'publish',
+        '--tolerate-republish',
+      ]
+      if (dryRun) {
+        args.push('--dry-run')
+      }
+
+      const relativeCwd = relPath(cwd, cwd)
+      console.error(
+        `${INFO} Running command in ${relativeCwd}:\nyarn ${args.join(' ')}`
+      )
+
+      spawn('yarn', args, { ...DEFAULT_SPAWN_OPTS, cwd })
+        .once('error', reject)
+        .once('exit', (code) => {
+          if (code === 0) {
+            resolve(void 0)
+          } else {
+            reject(
+              new Error(
+                `yarn workspaces foreach npm publish exited with code ${code}`
+              )
+            )
+          }
+        })
+    })
+  }
+}
+
+/**
+ * Detects the package manager and creates the appropriate {@link Publisher}.
+ *
+ * Checks for `yarn.lock` in the workspace root. If present, returns a
+ * {@link YarnPublisher}; otherwise returns an {@link NpmPublisher}.
+ *
+ * @type {PublisherFactory}
+ */
+async function createPublisher(opts, caps) {
+  const yarnLockPath = path.resolve(opts.root, 'yarn.lock')
+  try {
+    await caps.fs.promises.lstat(yarnLockPath)
+    return new YarnPublisher(opts, caps)
+  } catch {
+    return new NpmPublisher(opts, caps)
+  }
+}
+
+module.exports = { createPublisher }

--- a/packages/laverna/src/types.js
+++ b/packages/laverna/src/types.js
@@ -1,9 +1,16 @@
 /**
+ * @import {Dirent} from 'fs'
+ * @import {SpawnOptions} from 'node:child_process'
+ * @import {EventEmitter} from 'node:events'
+ * @import {GlobOptionsWithFileTypesTrue} from 'glob'
+ */
+
+/**
  * `Dirent`-like object returned by `glob`; adds a `fullpath()` method and
  * `parent` prop
  *
  * @defaultValue `Path` from `path-scurry`, which is resolved by `glob()` if the
- * @typedef {import('fs').Dirent & {
+ * @typedef {Dirent & {
  *   fullpath: () => string
  *   parent?: GlobDirent
  * }} GlobDirent
@@ -15,11 +22,7 @@
  * Returned `EventEmitter` _must_ emit `exit` and _may_ emit `error`.
  *
  * @defaultValue `childProcess.spawn`
- * @typedef {(
- *   cmd: string,
- *   args: string[],
- *   opts: import('node:child_process').SpawnOptions
- * ) => import('node:events').EventEmitter} SpawnFn
+ * @typedef {(cmd: string, args: string[], opts: SpawnOptions) => EventEmitter} SpawnFn
  */
 
 /**
@@ -41,7 +44,7 @@
  * @defaultValue `Glob.glob`
  * @typedef {(
  *   pattern: string | string[],
- *   opts: import('glob').GlobOptionsWithFileTypesTrue
+ *   opts: GlobOptionsWithFileTypesTrue
  * ) => Promise<GlobDirent[]>} GlobFn
  */
 
@@ -102,8 +105,9 @@
  * @property {MinimalConsole} console - Console to use for logging
  * @property {GetVersionsFactory} [getVersionsFactory] - Factory for
  *   {@link GetVersions}
- * @property {InvokePublishFactory} [invokePublishFactory] - Factory for
- *   {@link InvokePublish}
+ * @property {PublisherFactory} [publisherFactory] - Async factory that creates
+ *   a {@link Publisher}. Defaults to {@link createPublisher}, which detects the
+ *   package manager via lockfile.
  */
 /**
  * Capabilities for {@link Laverna}, allowing the user to override functionality.
@@ -131,23 +135,35 @@
  */
 
 /**
- * Factory for a {@link InvokePublish} function.
- *
- * @callback InvokePublishFactory
- * @param {LavernaOptions} opts
- * @param {LavernaCapabilities} caps
- * @returns {InvokePublish}
- */
-
-/**
  * Function which publishes a list of packages.
  *
  * Packages are expected to be workspaces in the current project.
  *
- * @callback InvokePublish
+ * @callback PublishFn
  * @param {string[]} pkgs
  * @returns {Promise<void>}
- * @this {Laverna}
+ */
+
+/**
+ * A publisher that knows how to invoke a specific package manager's publish
+ * command.
+ *
+ * @typedef Publisher
+ * @property {string} name - Identifier for this publisher (e.g. `'npm'` or
+ *   `'yarn'`)
+ * @property {PublishFn} publish - Publishes the given packages
+ */
+
+/**
+ * Async factory function that creates a {@link Publisher}.
+ *
+ * The default factory ({@link createPublisher}) checks for `yarn.lock` to decide
+ * between Yarn and npm.
+ *
+ * @callback PublisherFactory
+ * @param {AllLavernaOptions} opts
+ * @param {AllLavernaCapabilities} caps
+ * @returns {Promise<Publisher>}
  */
 
 module.exports = {}

--- a/packages/laverna/test/cli.spec.js
+++ b/packages/laverna/test/cli.spec.js
@@ -301,3 +301,22 @@ test(
     t.true(result.stderr.includes('@lavamoat/lavamutt@0.1.0'))
   }
 )
+
+test(
+  'cli - yarn workspace detection',
+  testProject,
+  { name: 'yarn-workspace', args: ['--newPkg=@test/workspace1'] },
+  async (t, result) => {
+    // The actual yarn command may fail (yarn might not be installed, or the
+    // workspace isn't a real yarn project), but we can still verify that
+    // laverna detected yarn mode and logged the detection message.
+    t.true(
+      result.stderr.includes('yarn.lock'),
+      'should log yarn.lock detection'
+    )
+    t.true(
+      result.stderr.includes('yarn npm publish'),
+      'should mention yarn npm publish'
+    )
+  }
+)

--- a/packages/laverna/test/fixture/yarn-workspace/package.json
+++ b/packages/laverna/test/fixture/yarn-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "yarn-workspace-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/laverna/test/fixture/yarn-workspace/packages/workspace1/package.json
+++ b/packages/laverna/test/fixture/yarn-workspace/packages/workspace1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/workspace1",
+  "version": "31337.420.69",
+  "dependencies": {
+    "some-dep": "workspace:^"
+  }
+}

--- a/packages/laverna/test/fixture/yarn-workspace/yarn.lock
+++ b/packages/laverna/test/fixture/yarn-workspace/yarn.lock
@@ -1,0 +1,2 @@
+# This file triggers yarn mode detection in laverna.
+# It does not need to be a valid yarn.lock file for detection purposes.

--- a/packages/laverna/test/laverna.spec.js
+++ b/packages/laverna/test/laverna.spec.js
@@ -7,6 +7,12 @@
  * @see {@link https://npm.im/memfs}
  */
 
+/**
+ * @import {SpawnFn, LavernaOptions, LavernaCapabilities} from '../src/types'
+ * @import {TestFn} from 'ava'
+ * @import {SpawnOptions} from 'node:child_process'
+ */
+
 const kleur = require('kleur')
 const crypto = require('node:crypto')
 const { glob: realGlob } = require('glob')
@@ -14,29 +20,30 @@ const { EventEmitter } = require('node:events')
 const { default: anyTest } = require('ava')
 const { memfs, fs } = require('memfs')
 const { Laverna } = require('../src')
-const { mock } = require('node:test')
+const nodeTest = require('node:test')
 
+const { mock } = nodeTest
 /**
  * Test context object for our tests
  *
  * @typedef PublishTestContext
- * @property {{ error: import('node:test').Mock<Console['error']> }} console
- * @property {import('node:test').Mock<import('../src/types').SpawnFn>} spawn
+ * @property {{ error: nodeTest.Mock<Console['error']> }} console
+ * @property {nodeTest.Mock<SpawnFn>} spawn
  * @property {(
- *   opts?: import('../src/types').LavernaOptions,
- *   caps?: import('../src/types').LavernaCapabilities
+ *   opts?: LavernaOptions,
+ *   caps?: LavernaCapabilities
  * ) => Promise<void>} runLaverna
  * @property {(
  *   pkgNames: string[],
- *   opts?: import('../src/types').LavernaOptions,
- *   caps?: import('../src/types').LavernaCapabilities
- * ) => Promise<void>} runInvokePublish
+ *   opts?: LavernaOptions,
+ *   caps?: LavernaCapabilities
+ * ) => Promise<void>} runPublish
  */
 
 /**
  * This just tells `ava` we're using {@link PublishTestContext} for the context.
  */
-const test = /** @type {import('ava').TestFn<PublishTestContext>} */ (anyTest)
+const test = /** @type {TestFn<PublishTestContext>} */ (anyTest)
 
 /**
  * A valid `package.json` for the root workspace used in many tests
@@ -60,7 +67,7 @@ function getRandomPkgName() {
  * Base options for {@link Laverna}, providing some stubs.
  */
 const BASE_OPTS = Object.freeze(
-  /** @type {import('../src/types').LavernaOptions} */ ({
+  /** @type {LavernaOptions} */ ({
     /**
      * Because the root of the phony `memfs` filesystem is `/`, we use it here.
      */
@@ -82,7 +89,7 @@ const BASE_OPTS = Object.freeze(
  * Base capabilities for {@link Laverna}, providing some stubs.
  */
 const BASE_CAPS = Object.freeze(
-  /** @type {import('../src/types').LavernaCapabilities} */ ({
+  /** @type {LavernaCapabilities} */ ({
     /**
      * The phony `fs` is given to `glob`--it supports a custom `fs` module--so
      * it can find files in there.
@@ -131,8 +138,8 @@ test.beforeEach((t) => {
     /**
      * @param {string} _cmd
      * @param {string[]} _args
-     * @param {import('node:child_process').SpawnOptions} _opts
-     * @returns {import('node:events').EventEmitter}
+     * @param {SpawnOptions} _opts
+     * @returns {EventEmitter}
      */
     (_cmd, _args, _opts) => {
       const ee = new EventEmitter()
@@ -144,8 +151,7 @@ test.beforeEach((t) => {
   )
 
   /**
-   * Helps run {@link Laverna.invokePublish} with a custom set of options and
-   * caps.
+   * Helps run {@link Laverna.publish} with a custom set of options and caps.
    *
    * Provides the default {@link ConsoleSpy} and {@link SpawnSpy} implementations
    * if not overridden by the test.
@@ -153,11 +159,11 @@ test.beforeEach((t) => {
    * Does not create a child process
    *
    * @param {string[]} pkgNames
-   * @param {import('../src/types').LavernaOptions} opts
-   * @param {import('../src/types').LavernaCapabilities} caps
+   * @param {LavernaOptions} opts
+   * @param {LavernaCapabilities} caps
    * @returns {Promise<void>}
    */
-  const runInvokePublish = async (pkgNames, opts = {}, caps = {}) => {
+  const runPublish = async (pkgNames, opts = {}, caps = {}) => {
     opts = { ...BASE_OPTS, ...opts }
     t.true(opts.dryRun, 'dryRun must be true for tests')
     const laverna = new Laverna(opts, {
@@ -166,7 +172,7 @@ test.beforeEach((t) => {
       spawn: spawn,
       ...caps,
     })
-    await laverna.invokePublish(pkgNames)
+    await laverna.publish(pkgNames)
   }
 
   /**
@@ -178,8 +184,8 @@ test.beforeEach((t) => {
    *
    * Does not create a child process
    *
-   * @param {import('../src/types').LavernaOptions} opts
-   * @param {import('../src/types').LavernaCapabilities} caps
+   * @param {LavernaOptions} opts
+   * @param {LavernaCapabilities} caps
    * @returns {Promise<void>}
    */
   const runLaverna = async (opts = {}, caps = {}) => {
@@ -198,7 +204,7 @@ test.beforeEach((t) => {
     console,
     spawn,
     runLaverna,
-    runInvokePublish,
+    runPublish,
   }
 })
 
@@ -865,9 +871,9 @@ test('publishWorkspaces - known packages - duplicate package names', async (t) =
   )
 })
 
-test('invokePublish - basic usage', async (t) => {
+test('publish - basic usage', async (t) => {
   const pkgName = getRandomPkgName()
-  await t.context.runInvokePublish([pkgName])
+  await t.context.runPublish([pkgName])
 
   t.deepEqual(t.context.spawn.mock.calls[0].arguments, [
     'npm',
@@ -876,8 +882,8 @@ test('invokePublish - basic usage', async (t) => {
   ])
 })
 
-test('invokePublish - dry run', async (t) => {
-  await t.context.runInvokePublish(['foo'])
+test('publish - dry run', async (t) => {
+  await t.context.runPublish(['foo'])
 
   t.deepEqual(t.context.spawn.mock.calls[0].arguments, [
     'npm',
@@ -886,9 +892,9 @@ test('invokePublish - dry run', async (t) => {
   ])
 })
 
-test('invokePublish - nonzero exit code', async (t) => {
+test('publish - nonzero exit code', async (t) => {
   await t.throwsAsync(
-    t.context.runInvokePublish(
+    t.context.runPublish(
       ['foo'],
       {},
       {
@@ -907,10 +913,10 @@ test('invokePublish - nonzero exit code', async (t) => {
   )
 })
 
-test('invokePublish - other error', async (t) => {
+test('publish - other error', async (t) => {
   const err = new Error('help meeeee')
   await t.throwsAsync(
-    t.context.runInvokePublish(
+    t.context.runPublish(
       ['foo'],
       {},
       {
@@ -926,5 +932,115 @@ test('invokePublish - other error', async (t) => {
     {
       is: err,
     }
+  )
+})
+
+test('publish - yarn.lock present - uses yarn command', async (t) => {
+  const { fs: yarnFs } = memfs({
+    '/': {
+      'yarn.lock': '',
+    },
+  })
+
+  await t.context.runPublish(['foo'], {}, { fs: yarnFs })
+
+  const [cmd, args] = t.context.spawn.mock.calls[0].arguments
+  t.is(
+    [cmd, ...args].join(' '),
+    'yarn workspaces foreach -A --no-private --include foo npm publish --tolerate-republish --dry-run'
+  )
+})
+
+test('publish - yarn.lock present - multiple packages', async (t) => {
+  const { fs: yarnFs } = memfs({
+    '/': {
+      'yarn.lock': '',
+    },
+  })
+
+  await t.context.runPublish(['@endo/ses', '@endo/init'], {}, { fs: yarnFs })
+
+  const [cmd, args] = t.context.spawn.mock.calls[0].arguments
+  t.is(
+    [cmd, ...args].join(' '),
+    'yarn workspaces foreach -A --no-private --include @endo/ses --include @endo/init npm publish --tolerate-republish --dry-run'
+  )
+})
+
+test('publish - yarn.lock present - nonzero exit code', async (t) => {
+  const { fs: yarnFs } = memfs({
+    '/': {
+      'yarn.lock': '',
+    },
+  })
+
+  await t.throwsAsync(
+    t.context.runPublish(
+      ['foo'],
+      {},
+      {
+        fs: yarnFs,
+        spawn: mock.fn(() => {
+          const ee = new EventEmitter()
+          setImmediate(() => {
+            ee.emit('exit', 1)
+          })
+          return ee
+        }),
+      }
+    ),
+    {
+      message: /yarn workspaces foreach npm publish exited with code 1/,
+    }
+  )
+})
+
+test('publish - no yarn.lock - uses npm command', async (t) => {
+  const { fs: npmFs } = memfs({
+    '/': {
+      'package.json': JSON.stringify({ name: 'root', version: '1.0.0' }),
+    },
+  })
+
+  await t.context.runPublish(['foo'], {}, { fs: npmFs })
+
+  const [cmd] = t.context.spawn.mock.calls[0].arguments
+  t.is(cmd, 'npm')
+})
+
+test('publishWorkspaces - yarn.lock present - logs detection', async (t) => {
+  const { fs: yarnFs } = memfs({
+    '/': {
+      'yarn.lock': '',
+      'package.json': DEFAULT_ROOT_PKG_JSON,
+      packages: {
+        workspace1: {
+          'package.json': JSON.stringify({
+            name: 'workspace1',
+            version: '31337.420.69',
+          }),
+        },
+      },
+    },
+  })
+
+  await t.context.runLaverna(
+    {},
+    {
+      fs: yarnFs,
+      getVersionsFactory: () => async () => ['1.0.0'],
+    }
+  )
+
+  const logArgs = t.context.console.error.mock.calls.flatMap(
+    (call) => call.arguments
+  )
+  t.true(
+    logArgs.some((arg) => `${arg}`.includes('yarn.lock')),
+    'should log yarn.lock detection'
+  )
+  t.true(
+    logArgs.some((arg) => `${arg}`.includes('yarn npm publish')),
+    'should log yarn npm publish'
   )
 })


### PR DESCRIPTION
This adds support for Yarn v2 workspaces to `@lavamoat/laverna`.

In a nutshell, it detects `yarn.lock`; if present, publishing will be done via `yarn npm publish` which will automatically resolve the `workspace:X` version ranges present in the `package.json` files prior to packing.

Refactored the publish command logic out into a new interface, `Publisher`.

Closes #1883