### PR TITLE
fix(core): make the wrapper for global functions strict

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -776,6 +776,7 @@ function defaultCreateFunctionWrapper(sourceValue, unwrapTest, unwrapTo) {
    */
   // eslint-disable-next-line func-style
   const newValue = function () {
+    'use strict'
     if (new.target) {
       // handle constructor calls
       return Reflect.construct(sourceValue, arguments, new.target)


### PR DESCRIPTION
For the main functionality of `defaultCreateFunctionWrapper`, which is to wrap endowed global functions, it doesn't matter whether the wrapping function `newValue` is strict or not, because the whole point is that it's being called with compartment's `globalThis` as this and the whole point of unwrapping is to call the original function on the actual `globalThis` so that it doesn't complain with `Illegal invocation`. Checking whether `this===globalThis` happens in `unwrapTest`.
As a result, it doesn't matter whether the wrapping function is strict or not, because its functionality is unnecessary whenever real `globalThis` or `undefined` is bound to `this`

It should be fine to make it strict just to be on the safe side though - to avoid a potential mishap where the real global is brought one step closer to being revealed.

The way it's being used in the wrapper for the `Function` constructor we provide to compartments is not aligned with its main purpose - it's used for unwrapping to compartment global, and in testing we've stumbled upon a case in which it not being strict affected when unwrapping worked. See:
https://github.com/LavaMoat/LavaMoat/blob/233aeb011f8b8da22d6d79ec194c2def50590ddd/packages/node/src/exec/exec-compartment-class.js#L53-L62
and
https://github.com/LavaMoat/LavaMoat/blob/233aeb011f8b8da22d6d79ec194c2def50590ddd/packages/core/src/makePrepareRealmGlobalFromConfig.js#L116-L120

making the wrapping function strict is therefore:
- marginally better for security
- a fix for emulating `new Function('return this')()` 

*Observations about further work:*
- I intend to replace the use of `defaultCreateFunctionWrapper` in function constructor with a simplified copy of it later.
- There is no Function constructor wrapping in webpack plugin runtime. We might want to investigete if/why it works as expected.