### PR TITLE
chore(node): force worker count to 3 in worker pool test

### DIFF
--- a/packages/node/test/unit/worker-pool.spec.js
+++ b/packages/node/test/unit/worker-pool.spec.js
@@ -195,7 +195,8 @@ test.serial('WorkerPool sendTask - concurrent tasks', async (t) => {
   t.plan(6)
 
   pool = new WorkerPool(
-    /** @type {WorkerPool<TestMessage, TestResponse>} */ TEST_WORKER_PATH
+    /** @type {WorkerPool<TestMessage, TestResponse>} */ TEST_WORKER_PATH,
+    { maxWorkers: 3 }
   )
 
   // Send multiple tasks concurrently


### PR DESCRIPTION
This should fix an issue on macOS wherein it only has 2 cores.
