### PR TITLE
fix(node): fix corner case where policy override path was guessed incorrectly

### DIFF
--- a/.wallaby.cjs
+++ b/.wallaby.cjs
@@ -25,6 +25,7 @@ module.exports = {
     'packages/node/test/unit/**/snapshots/*.md',
     'packages/node/test/unit/json-fixture/**/*.json',
     'packages/node/test/unit/policy/**/*.json',
+    'packages/node/test/test-util.js',
     {
       pattern: 'packages/node/test/unit/fixture/**/*',
       instrument: false,

--- a/packages/node/src/cli.js
+++ b/packages/node/src/cli.js
@@ -461,7 +461,8 @@ const main = async (args = hideBin(process.argv)) => {
           prodOnly,
           projectRoot,
           scuttleGlobalThis,
-          ...(policy ? { policy } : { policyPath }),
+          policy,
+          policyPath,
         })
       }
     )

--- a/packages/node/src/exec/run.js
+++ b/packages/node/src/exec/run.js
@@ -57,13 +57,9 @@ export const run = async (
   const loadPoliciesOptions = {
     readFile,
     projectRoot,
-    ...('policyOverride' in options
-      ? {
-          policyOverride: options.policyOverride,
-        }
-      : {
-          policyOverridePath: options.policyOverridePath,
-        }),
+    policyPath: options.policyPath,
+    policyOverride: options.policyOverride,
+    policyOverridePath: options.policyOverridePath,
   }
 
   const policy = await loadPolicies(

--- a/packages/node/src/policy-gen/load-for-policy.js
+++ b/packages/node/src/policy-gen/load-for-policy.js
@@ -293,6 +293,8 @@ export const loadAndGeneratePolicy = async (
     )
     return { policy, packageJsonMap }
   } finally {
+    // we only check this if we have a policy override, because we're assuming
+    // the policy we just generated is valid, which may be a bad idea.
     if (policyOverride) {
       reportInvalidCanonicalNames(unknownCanonicalNames, knownCanonicalNames, {
         policy: policyOverride,

--- a/packages/node/src/policy-util.js
+++ b/packages/node/src/policy-util.js
@@ -14,12 +14,9 @@ import nodeFs from 'node:fs'
 import nodePath from 'node:path'
 import * as constants from './constants.js'
 import {
-  ATTENUATORS_COMPARTMENT,
-  DEFAULT_POLICY_DEBUG_FILENAME,
   DEFAULT_POLICY_DIR,
   DEFAULT_POLICY_FILENAME,
   DEFAULT_POLICY_OVERRIDE_FILENAME,
-  LAVAMOAT_PKG_POLICY_ROOT,
 } from './constants.js'
 import { InvalidPolicyError, NoPolicyError, WritePolicyError } from './error.js'
 import { hrCode, hrPath } from './format.js'
@@ -31,20 +28,14 @@ import {
   isPathLike,
   isString,
   toAbsolutePath,
-  toKeypath,
   toPath,
 } from './util.js'
 
-const { keys, values } = Object
-
 /**
- * @import {CompartmentDescriptor} from '@endo/compartment-mapper'
  * @import {RootPolicy, LavaMoatPolicy} from '@lavamoat/types'
  * @import {MergedLavaMoatPolicy,
- *  CanonicalName,
  *  LoadPoliciesOptions,
- *  WritableFsInterface,
- *  PolicyCanonicalNameInfo} from './types.js'
+ *  WritableFsInterface} from './types.js'
  * @import {ReadPolicyOptions, ReadPolicyOverrideOptions} from './internal.js'
  */
 
@@ -152,6 +143,10 @@ export const maybeReadPolicyOverride = async (
  * Reads a policy and policy override from object or disk and merges them into a
  * single policy.
  *
+ * If `policyOrPolicyPath` is a `LavaMoatPolicy`, providing `options.policyPath`
+ * is a hint for guessing the policy override path if neither
+ * `options.policyOverride` nor `options.policyOverridePath` are provided.
+ *
  * @privateRemarks
  * TODO: The way this fails is not user-friendly; it will just throw a
  * `InvalidPolicyError` saying that the policy is invalid. **We should use
@@ -173,7 +168,8 @@ export const loadPolicies = async (
     ...options
   } = {}
 ) => {
-  policyOrPolicyPath ??= makeDefaultPolicyPath(projectRoot)
+  policyOrPolicyPath ??=
+    options.policyPath ?? makeDefaultPolicyPath(projectRoot)
 
   /**
    * Path to policy
@@ -223,15 +219,20 @@ export const loadPolicies = async (
   }
 
   // either / or / or nothing at all
-  if (hasValue(options, 'policyOverridePath')) {
-    policyOverridePath = toPath(options.policyOverridePath)
-  } else if (hasValue(options, 'policyOverride')) {
+  if (hasValue(options, 'policyOverride')) {
     allegedPolicyOverride = options.policyOverride
+  } else if (hasValue(options, 'policyOverridePath')) {
+    policyOverridePath = toPath(options.policyOverridePath)
   } else {
+    let policyPathToUse = policyPath
+    // use the hint if it's provided
+    if (!policyPathToUse && hasValue(options, 'policyPath')) {
+      policyPathToUse = toPath(options.policyPath)
+    }
     // if the user specified a policy path, resolve as its sibling;
     // otherwise resolve from `projectRoot` since that's about all we can do.
     policyOverridePath = makeDefaultPolicyOverridePath({
-      policyPath,
+      policyPath: policyPathToUse,
       projectRoot,
     })
   }
@@ -240,11 +241,6 @@ export const loadPolicies = async (
    * An tuple of `Promise`s; each performs either a file read & a validation
    * _or_ just a validation.
    *
-   * @privateRemarks
-   * The fact that we either have a path _xor_ an alleged policy—combined with
-   * the every-so-slightly different signatures of {@link readPolicy} and
-   * {@link maybeReadPolicyOverride}—make these following conditionals painful to
-   * abstract into a type-safe function. So I didn't.
    * @type {[
    *   policy: Promise<LavaMoatPolicy> | LavaMoatPolicy,
    *   policyOverride:
@@ -395,111 +391,6 @@ export const isPolicy = (value) => {
 }
 
 /**
- * Gets an array of canonical name information including the name (`name`) and
- * its keypath (`source`) from `policy`.
- *
- * @param {LavaMoatPolicy} policy
- * @returns {PolicyCanonicalNameInfo[]}
- */
-const getPolicyCanonicalNames = (policy) => {
-  /**
-   * Canonical names from the keys of {@link LavaMoatPolicy.resources}
-   * (`ResourcePolicy`)
-   */
-  const resourceCanonicalNames = keys(policy.resources).map((name) => ({
-    name,
-    source: toKeypath(['resources', name]),
-  }))
-
-  // const untrustedRootResource = policy.root?.usePolicy
-
-  /**
-   * Canonical names from the keys of `ResourcePolicy.packages`
-   * (`PackagePolicy`)
-   */
-  const packagePolicyCanonicalNames = resourceCanonicalNames.flatMap(
-    ({ name: resourceName }) =>
-      keys(policy.resources[resourceName].packages ?? {}).map((name) => ({
-        name,
-        source: toKeypath(['resources', resourceName, 'packages', name]),
-      }))
-  )
-
-  /**
-   * Canonical names from the `LavaMoatPolicy.include` array
-   */
-  const includeCanonicalNames =
-    policy.include?.map((value) => {
-      if (isString(value)) {
-        return {
-          name: value,
-          source: toKeypath(['include', value]),
-        }
-      }
-      return {
-        name: value.name,
-        source: toKeypath(['include', value.entry]),
-      }
-    }) ?? []
-
-  /**
-   * Deduped array of all canonical names found in policy
-   */
-  const policyCanonicalNames = /** @type {PolicyCanonicalNameInfo[]} */ ([
-    ...new Set([
-      ...resourceCanonicalNames,
-      ...packagePolicyCanonicalNames,
-      ...includeCanonicalNames,
-      LAVAMOAT_PKG_POLICY_ROOT,
-      ATTENUATORS_COMPARTMENT,
-    ]),
-  ])
-  return policyCanonicalNames
-}
-
-/**
- * @template {CompartmentDescriptor} T
- * @template {string} K
- * @param {LavaMoatPolicy} policy
- * @param {Record<K, T>} compartmentDescriptors
- * @returns {{
- *   getInvalidCanonicalNames: () => PolicyCanonicalNameInfo[]
- *   policyCanonicalNameInfo: PolicyCanonicalNameInfo[]
- * }}
- */
-export const createGetInvalidCanonicalNamesFn = (
-  policy,
-  compartmentDescriptors
-) => {
-  const canonicalNames = new Set(
-    values(compartmentDescriptors).map(({ label }) => label)
-  )
-
-  /**
-   * @param {CanonicalName} name
-   * @returns {name is T[K]['label']}
-   */
-  const isCanonicalNameInCompartments = (name) => {
-    return canonicalNames.has(name)
-  }
-
-  const policyCanonicalNameInfo = getPolicyCanonicalNames(policy)
-
-  /**
-   * @returns {PolicyCanonicalNameInfo[]}
-   */
-  const getInvalidCanonicalNames = () =>
-    policyCanonicalNameInfo.filter(
-      ({ name }) => !isCanonicalNameInCompartments(name)
-    )
-
-  return {
-    getInvalidCanonicalNames,
-    policyCanonicalNameInfo,
-  }
-}
-
-/**
  * Returns `true` if there is no such
  * {@link RootPolicy.usePolicy `root.usePolicy`} field.
  *
@@ -580,7 +471,6 @@ const makeDefaultPath = (
  * @returns {string}
  * @internal
  */
-
 export const makeDefaultPolicyOverridePath = ({ policyPath, projectRoot }) => {
   const path = makeDefaultPath(
     DEFAULT_POLICY_DIR,
@@ -588,26 +478,6 @@ export const makeDefaultPolicyOverridePath = ({ policyPath, projectRoot }) => {
     { policyPath, projectRoot }
   )
   log.debug(`Guessed policy override path: ${hrPath(path)}`)
-  return path
-}
-/**
- * Given path to a policy file, returns the sibling path to the policy debug
- * file
- *
- * @param {Object} options
- * @param {string | URL} [options.policyPath] Path to the policy file
- * @param {string | URL} [options.projectRoot]
- * @returns {string}
- * @internal
- */
-
-export const makeDefaultPolicyDebugPath = ({ policyPath, projectRoot }) => {
-  const path = makeDefaultPath(
-    DEFAULT_POLICY_DIR,
-    DEFAULT_POLICY_DEBUG_FILENAME,
-    { policyPath, projectRoot }
-  )
-  log.debug(`Using debug policy path: ${hrPath(path)}`)
   return path
 }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -89,6 +89,14 @@ export interface WithLog {
   log?: Loggerr
 }
 
+export interface WithPolicyPath {
+  policyPath?: string | URL
+}
+
+export interface WithPolicy {
+  policy?: LavaMoatPolicy
+}
+
 export interface WithPolicyOnly {
   /**
    * A {@link LavaMoatPolicy} object.
@@ -99,19 +107,6 @@ export interface WithPolicyOnly {
    */
   policyPath?: never
 }
-
-export interface WithPolicyPathOnly {
-  /**
-   * Disallowed in lieu of {@link policy}
-   */
-  policy?: never
-  /**
-   * Path to a policy file.
-   */
-  policyPath?: string | URL
-}
-
-export type WithPolicyOrPath = WithPolicyOnly | WithPolicyPathOnly
 
 /**
  * Options having a `policyOverride` property and _not_ a `policyOverridePath`
@@ -218,11 +213,6 @@ export interface WritableFsInterface {
  * Options available when writing a policy
  */
 export interface WithWritePolicyOptions {
-  /**
-   * Path to a {@link LavaMoatPolicyDebug} file
-   */
-  policyDebugPath?: string | URL
-
   /**
    * Path to a {@link LavaMoatPolicy} file
    */
@@ -387,7 +377,8 @@ export type RunOptions = ComposeOptions<
     WithTrustRoot,
     WithScuttleGlobalThis,
     WithLog,
-    WithPolicyOrPath,
+    WithPolicy,
+    WithPolicyPath,
     LoadPoliciesOptions,
   ]
 >
@@ -452,7 +443,13 @@ export type WithReadPowersAndTrustAndEndoPolicy = ComposeOptions<
  * Options for `loadPolicies()`
  */
 export type LoadPoliciesOptions = ComposeOptions<
-  [WithProjectRoot, WithReadFile, WithPolicyOverrideOrPath]
+  [
+    WithProjectRoot,
+    WithReadFile,
+    WithPolicyOverride,
+    WithPolicyOverridePath,
+    WithPolicyPath,
+  ]
 >
 
 export type CanonicalName = LiteralUnion<
@@ -523,11 +520,25 @@ export interface WithFs {
 }
 
 /**
+ * `true` if all overlapping keys between `A` and `B` have identical types;
+ * vacuously `true` when there is no overlap.
+ */
+type OverlapCompatible<A extends object, B extends object> = [
+  keyof A & keyof B,
+] extends [never]
+  ? true
+  : {
+        [K in keyof A & keyof B]: [A[K], B[K]] extends [B[K], A[K]] ? 1 : 0
+      }[keyof A & keyof B] extends 1
+    ? true
+    : false
+
+/**
  * Safely composes properties from each object in `T` into a single, simplified
  * type.
  *
- * If `T` contains objects with non-exclusive keys, then the type will resolve
- * to `never`.
+ * Overlapping keys with identical types are permitted; overlapping keys with
+ * incompatible types cause the type to resolve to `never`.
  *
  * Drawback: this is a little slow.
  */
@@ -535,9 +546,13 @@ export type ComposeOptions<T extends object[]> = Simplify<
   T extends [infer First, ...infer Rest]
     ? First extends object
       ? Rest extends object[]
-        ? keyof First extends keyof ComposeOptions<Rest>
-          ? never
-          : First & ComposeOptions<Rest>
+        ? ComposeOptions<Rest> extends infer Composed
+          ? Composed extends object
+            ? OverlapCompatible<First, Composed> extends true
+              ? First & Composed
+              : never
+            : never
+          : never
         : never
       : never
     : object
@@ -549,9 +564,4 @@ export type MergedLavaMoatPolicy = LavaMoatPolicy & {
 
 export type UnmergedLavaMoatPolicy = LavaMoatPolicy & {
   [MERGED_POLICY_FIELD]?: never
-}
-
-export interface PolicyCanonicalNameInfo {
-  name: CanonicalName
-  source: string
 }

--- a/packages/node/test/test-util.js
+++ b/packages/node/test/test-util.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_POLICY_OVERRIDE_PATH,
   DEFAULT_POLICY_PATH,
 } from '../src/constants.js'
+import { toPath } from '../src/util.js'
 
 /**
  * @import {Fixture, FixtureOptions} from './types.js'
@@ -36,8 +37,10 @@ export const fixtureFinder = (referrer) => {
     const dir = fileURLToPath(new URL(`./fixture/${name}`, referrer))
     // do not compute entrypoint relative to dir if it already exists
     entrypoint ??= path.join(dir, entrypointFilename)
-    policyPath ??= path.join(dir, DEFAULT_POLICY_PATH)
-    policyOverridePath ??= path.join(dir, DEFAULT_POLICY_OVERRIDE_PATH)
+    policyPath = toPath(policyPath ?? path.join(dir, DEFAULT_POLICY_PATH))
+    policyOverridePath = toPath(
+      policyOverridePath ?? path.join(dir, DEFAULT_POLICY_OVERRIDE_PATH)
+    )
     return { entrypoint, dir, policyPath, policyOverridePath }
   }
   return fixture

--- a/packages/node/test/types.ts
+++ b/packages/node/test/types.ts
@@ -2,8 +2,13 @@ import type { LavaMoatPolicy } from '@lavamoat/types'
 import type { ExecutionContext } from 'ava'
 import type { LavaMoatScuttleOpts } from 'lavamoat-core'
 import type { NestedDirectoryJSON } from 'memfs'
-import { type ExecFileException } from 'node:child_process'
+import type { ExecFileException } from 'node:child_process'
 import type { Merge, RequireAtLeastOne, Simplify } from 'type-fest'
+import type {
+  ComposeOptions,
+  WithPolicyOverridePath,
+  WithPolicyPath,
+} from '../src/types.js'
 
 export interface RunnerWorkerData {
   entryPath: string
@@ -109,23 +114,24 @@ export interface TestExecForJSONMacroOptions extends TestExecMacroOptions {
 /**
  * Options for the function returned by the `fixtureFinder` factory
  */
-export interface FixtureOptions {
-  /**
-   * Entrypoint to use _verbatim_. This is useful when combined with `--bin`
-   */
-  entrypoint?: string
+export type FixtureOptions = ComposeOptions<
+  [
+    {
+      /**
+       * Entrypoint to use _verbatim_. This is useful when combined with `--bin`
+       */
+      entrypoint?: string
 
-  /**
-   * Filename of the entrypoint which will be computed relative to the fixture
-   * dir.
-   */
-  entrypointFilename?: string
-
-  policyPath?: string
-
-  policyOverridePath?: string
-}
-
+      /**
+       * Filename of the entrypoint which will be computed relative to the
+       * fixture dir.
+       */
+      entrypointFilename?: string
+    },
+    WithPolicyPath,
+    WithPolicyOverridePath,
+  ]
+>
 /**
  * Data structure representing information about a fixture
  */

--- a/packages/node/test/unit/policy-util.spec.js
+++ b/packages/node/test/unit/policy-util.spec.js
@@ -4,11 +4,14 @@ import test from 'ava'
 import { fs, vol } from 'memfs'
 import * as constants from '../../src/constants.js'
 import { ErrorCodes } from '../../src/error-code.js'
+import nodePath from 'node:path'
 import {
   assertPolicy,
   isPolicy,
   isTrusted,
   loadPolicies,
+  makeDefaultPolicyOverridePath,
+  makeDefaultPolicyPath,
   maybeReadPolicyOverride,
   readPolicy,
   writePolicy,
@@ -112,4 +115,89 @@ test('isTrusted - returns true for empty root policy', (t) => {
 
 test('isTrusted - returns false for root policy w/ usePolicy', (t) => {
   t.false(isTrusted({ root: { usePolicy: 'foo' }, resources: {} }))
+})
+
+test('loadPolicies - uses policyPath option as hint for override path when given a policy object', async (t) => {
+  const overrideResources = { foo: { packages: { bar: true } } }
+  vol.fromJSON({
+    '/hint/policy-override.json': JSON.stringify({
+      resources: overrideResources,
+    }),
+  })
+  const policy = await loadPolicies(
+    { resources: {} },
+    {
+      policyPath: '/hint/policy.json',
+      readFile: /** @type {any} */ (fs.promises.readFile),
+    }
+  )
+  t.deepEqual(policy, {
+    resources: overrideResources,
+    [constants.MERGED_POLICY_FIELD]: true,
+  })
+})
+
+test('makeDefaultPolicyPath - returns default policy path for project root', (t) => {
+  const result = makeDefaultPolicyPath('/my/project')
+  t.is(result, nodePath.join('/my/project', 'lavamoat/node', 'policy.json'))
+})
+
+test('makeDefaultPolicyOverridePath - derives override path from policyPath', (t) => {
+  const result = makeDefaultPolicyOverridePath({
+    policyPath: '/my/project/lavamoat/node/policy.json',
+  })
+  t.is(
+    result,
+    nodePath.join('/my/project/lavamoat/node', 'policy-override.json')
+  )
+})
+
+test('makeDefaultPolicyOverridePath - derives override path from projectRoot', (t) => {
+  const result = makeDefaultPolicyOverridePath({ projectRoot: '/my/project' })
+  t.is(
+    result,
+    nodePath.join('/my/project', 'lavamoat/node', 'policy-override.json')
+  )
+})
+
+test('writePolicy - throws WritePolicyError when directory creation fails', async (t) => {
+  const cause = new Error('EPERM: operation not permitted')
+  const mockFs = /** @type {any} */ ({
+    promises: {
+      mkdir: async () => {
+        throw cause
+      },
+      writeFile: async () => {},
+      rm: async () => {},
+    },
+  })
+  const err = await t.throwsAsync(
+    () => writePolicy('/nope/policy.json', { resources: {} }, { fs: mockFs }),
+    { code: ErrorCodes.WritePolicyFailure }
+  )
+  t.is(/** @type {Error} */ (err).cause, cause)
+})
+
+test('writePolicy - removes created directory when file write fails', async (t) => {
+  t.plan(3)
+  const cause = new Error('EACCES: permission denied')
+  /** @type {{ path: string; opts: { recursive: boolean } } | undefined} */
+  let rmCall
+  const mockFs = /** @type {any} */ ({
+    promises: {
+      mkdir: async () => '/nope',
+      writeFile: async () => {
+        throw cause
+      },
+      rm: async (/** @type {string} */ path, /** @type {any} */ opts) => {
+        rmCall = { path, opts }
+      },
+    },
+  })
+  const err = await t.throwsAsync(
+    () => writePolicy('/nope/policy.json', { resources: {} }, { fs: mockFs }),
+    { code: ErrorCodes.WritePolicyFailure }
+  )
+  t.is(/** @type {Error} */ (err).cause, cause)
+  t.deepEqual(rmCall, { path: '/nope', opts: { recursive: true } })
 })


### PR DESCRIPTION
I could only reproduce this when using `--generate-recklessly`, but a similar programmatic use of `run()` is not beyond possibility.

- Removes some cruft from `policy-util.js` and types (policy debug stuff, unknown canonical name crunching)
- Adds more tests for `policy-util.js`
- Fix `ComposeOptions` type to allow identical properties for ease of use
- Update Wallaby config