### PR TITLE
chore(node): run execution unit tests in worker thread

### DIFF
--- a/packages/node/test/integration/scenario-runner.js
+++ b/packages/node/test/integration/scenario-runner.js
@@ -14,7 +14,7 @@ import { log as defaultLog } from '../../src/log.js'
 
 /**
  * @import {FsInterface} from '@endo/compartment-mapper';
- * @import {RunnerWorkerData} from '../types.js';
+ * @import {ScenarioRunnerWorkerData} from '../types.js';
  */
 
 if (isMainThread) {
@@ -28,7 +28,7 @@ if (isMainThread) {
 globalThis.getTrueGlobalThisForTestsOnly = () => globalThis
 
 const { entryPath, policy, vol, scuttleGlobalThis } =
-  /** @type {RunnerWorkerData} */ (workerData)
+  /** @type {ScenarioRunnerWorkerData} */ (workerData)
 
 const { fs } = memfs(vol)
 

--- a/packages/node/test/integration/scenario-runner.js
+++ b/packages/node/test/integration/scenario-runner.js
@@ -14,7 +14,7 @@ import { log as defaultLog } from '../../src/log.js'
 
 /**
  * @import {FsInterface} from '@endo/compartment-mapper'
- * @import {RunnerWorkerData} from '../types.js'
+ * @import {ScenarioRunnerWorkerData} from '../types.js'
  */
 
 if (isMainThread) {
@@ -28,7 +28,7 @@ if (isMainThread) {
 globalThis.getTrueGlobalThisForTestsOnly = () => globalThis
 
 const { entryPath, policy, vol, scuttleGlobalThis } =
-  /** @type {RunnerWorkerData} */ (workerData)
+  /** @type {ScenarioRunnerWorkerData} */ (workerData)
 
 const { fs } = memfs(vol)
 

--- a/packages/node/test/types.ts
+++ b/packages/node/test/types.ts
@@ -10,12 +10,70 @@ import type {
   WithPolicyPath,
 } from '../src/types.js'
 
-export interface RunnerWorkerData {
+export interface ScenarioRunnerWorkerData {
   entryPath: string
   policy: LavaMoatPolicy
   vol: NestedDirectoryJSON
   scuttleGlobalThis: LavaMoatScuttleOpts
 }
+
+/**
+ * Common fields for worker data sent to the exec runner
+ */
+export interface ExecRunnerWorkerDataBase {
+  policy: LavaMoatPolicy
+}
+
+/**
+ * Worker data for exec runner when running a JSON fixture
+ */
+export interface ExecRunnerWorkerDataJson extends ExecRunnerWorkerDataBase {
+  isJsonFixture: true
+  fixtureFilename: string
+  jsonEntrypoint?: string
+}
+
+/**
+ * Worker data for exec runner when running a real filesystem entrypoint
+ */
+export interface ExecRunnerWorkerDataDirect extends ExecRunnerWorkerDataBase {
+  isJsonFixture: false
+  entryPath: string
+}
+
+/**
+ * Discriminated union of worker data sent to the exec runner.
+ *
+ * When `isJsonFixture` is `true`, the runner loads a JSON fixture from disk
+ * (via `loadJSONFixture`) and uses the resulting `readPowers`. Otherwise, it
+ * runs against the real filesystem.
+ */
+export type ExecRunnerWorkerData =
+  | ExecRunnerWorkerDataJson
+  | ExecRunnerWorkerDataDirect
+
+/**
+ * Message posted by the exec runner on successful execution
+ */
+export interface ExecRunnerSuccessMessage {
+  type: 'success'
+  result: unknown
+}
+
+/**
+ * Message posted by the exec runner when execution fails
+ */
+export interface ExecRunnerErrorMessage {
+  type: 'error'
+  error: Error
+}
+
+/**
+ * Discriminated union of messages the exec runner can post to the parent thread
+ */
+export type ExecRunnerMessage =
+  | ExecRunnerSuccessMessage
+  | ExecRunnerErrorMessage
 
 export type TestCLIExpectationFn<Ctx = unknown> = (
   t: ExecutionContext<Ctx>,

--- a/packages/node/test/unit/exec/exec-macros.js
+++ b/packages/node/test/unit/exec/exec-macros.js
@@ -1,18 +1,32 @@
-import '../../../src/preamble.js'
-
-import chalk from 'chalk'
-import { run } from '../../../src/exec/run.js'
-import {
-  DEFAULT_JSON_FIXTURE_ENTRY_POINT,
-  JSON_FIXTURE_DIR_URL,
-  loadJSONFixture,
-} from '../json-fixture-util.js'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { Worker } from 'node:worker_threads'
+import { toPath } from '../../../src/util.js'
 
 /**
- * @import {TestFn, MacroDeclarationOptions} from 'ava'
+ * @import {TestFn, MacroDeclarationOptions, ExecutionContext} from 'ava'
  * @import {LavaMoatPolicy} from '@lavamoat/types'
- * @import {TestExecForJSONMacroOptions, TestExecMacroOptions} from '../../types.js'
+ * @import {ExecRunnerMessage, TestExecForJSONMacroOptions, TestExecMacroOptions} from '../../types.js'
  */
+
+/**
+ * Path to `./exec-runner.js`
+ */
+const RUNNER_MODULE_PATH = (
+  process.env.WALLABY_PROJECT_DIR
+    ? pathToFileURL(
+        path.join(
+          process.env.WALLABY_PROJECT_DIR,
+          'packages',
+          'node',
+          'test',
+          'unit',
+          'exec',
+          'exec-runner.js'
+        )
+      )
+    : new URL('./exec-runner.js', import.meta.url)
+).pathname
 
 /**
  * @satisfies {LavaMoatPolicy}
@@ -20,6 +34,55 @@ import {
 const DEFAULT_POLICY = Object.freeze({
   resources: {},
 })
+
+/**
+ * Waits for the exec runner worker to post its result message.
+ *
+ * The worker posts `{type: 'success', result}` or `{type: 'error', message}`.
+ * This function resolves with the result on success, and rejects with an
+ * `Error` reconstituted from the worker's error message on failure.
+ *
+ * @param {Worker} worker
+ * @returns {Promise<unknown>}
+ */
+const receiveResult = async (worker) => {
+  const result = await new Promise((resolve, reject) => {
+    worker
+      .once(
+        'message',
+        /** @param {ExecRunnerMessage} msg */ (msg) => {
+          if (msg.type === 'success') {
+            resolve(msg.result)
+          } else {
+            reject(msg.error)
+          }
+        }
+      )
+      .once('error', reject)
+  })
+  try {
+    await worker.terminate()
+  } finally {
+    worker.removeAllListeners()
+  }
+  return result
+}
+
+/**
+ * Executes the given code in the worker and asserts the result matches the
+ * expected value.
+ *
+ * @param {Worker} worker
+ * @param {ExecutionContext<unknown>} t
+ * @param {unknown} expected
+ */
+const execInWorker = async (worker, t, expected) => {
+  worker.unref()
+  worker.stdout.resume()
+  worker.stderr.resume()
+  const result = await receiveResult(worker)
+  t.deepEqual({ .../** @type {any} */ (result) }, expected)
+}
 
 /**
  * Given an AVA test function, returns a set of macros for testing policy
@@ -53,25 +116,19 @@ export const createExecMacros = (test) => {
         t,
         fixtureFilename,
         expected,
-        {
-          policy = DEFAULT_POLICY,
-          jsonEntrypoint = DEFAULT_JSON_FIXTURE_ENTRY_POINT,
-        } = {}
+        { policy = DEFAULT_POLICY, jsonEntrypoint } = {}
       ) => {
-        const { readPowers, vol } = await loadJSONFixture(
-          new URL(fixtureFilename, JSON_FIXTURE_DIR_URL)
-        )
-        try {
-          const result = await run(jsonEntrypoint, { policy, readPowers })
-          t.deepEqual(
-            { .../** @type {any} */ (result) },
-            expected,
-            'program output did not match expected value'
-          )
-        } catch (err) {
-          t.log(`Volume tree:\n${chalk.yellow(vol.toTree())}`)
-          throw err
-        }
+        const worker = new Worker(RUNNER_MODULE_PATH, {
+          stdout: true,
+          stderr: true,
+          workerData: {
+            isJsonFixture: true,
+            fixtureFilename,
+            jsonEntrypoint: jsonEntrypoint ? toPath(jsonEntrypoint) : undefined,
+            policy,
+          },
+        })
+        await execInWorker(worker, t, expected)
       },
       title: (title) =>
         title ?? `program output matches expected (${genericTitleIndex++}`,
@@ -94,8 +151,16 @@ export const createExecMacros = (test) => {
         expected,
         { policy = DEFAULT_POLICY } = {}
       ) => {
-        const result = await run(entrypoint, { policy })
-        t.deepEqual({ .../** @type {any} */ (result) }, expected)
+        const worker = new Worker(RUNNER_MODULE_PATH, {
+          stdout: true,
+          stderr: true,
+          workerData: {
+            isJsonFixture: false,
+            entryPath: toPath(entrypoint),
+            policy,
+          },
+        })
+        await execInWorker(worker, t, expected)
       },
       title: (title) =>
         title ?? `program output matches expected (${genericTitleIndex++}`,

--- a/packages/node/test/unit/exec/exec-macros.js
+++ b/packages/node/test/unit/exec/exec-macros.js
@@ -1,24 +1,40 @@
-import '../../../src/preamble.js'
-
-import chalk from 'chalk'
-import { run } from '../../../src/exec/run.js'
-import {
-  DEFAULT_JSON_FIXTURE_ENTRY_POINT,
-  JSON_FIXTURE_DIR_URL,
-  loadJSONFixture,
-} from '../json-fixture-util.js'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { Worker } from 'node:worker_threads'
+import { toPath } from '../../../src/util.js'
 
 /**
  * @import {LavaMoatPolicy} from '@lavamoat/types'
  * @import {
+ *   ExecutionContext,
  *   MacroDeclarationOptions,
  *   TestFn
  * } from 'ava'
  * @import {
+ *   ExecRunnerMessage,
  *   TestExecForJSONMacroOptions,
  *   TestExecMacroOptions
  * } from '../../types.js'
  */
+
+/**
+ * Path to `./exec-runner.js`
+ */
+const RUNNER_MODULE_PATH = (
+  process.env.WALLABY_PROJECT_DIR
+    ? pathToFileURL(
+        path.join(
+          process.env.WALLABY_PROJECT_DIR,
+          'packages',
+          'node',
+          'test',
+          'unit',
+          'exec',
+          'exec-runner.js'
+        )
+      )
+    : new URL('./exec-runner.js', import.meta.url)
+).pathname
 
 /**
  * @satisfies {LavaMoatPolicy}
@@ -26,6 +42,55 @@ import {
 const DEFAULT_POLICY = Object.freeze({
   resources: {},
 })
+
+/**
+ * Waits for the exec runner worker to post its result message.
+ *
+ * The worker posts `{type: 'success', result}` or `{type: 'error', message}`.
+ * This function resolves with the result on success, and rejects with an
+ * `Error` reconstituted from the worker's error message on failure.
+ *
+ * @param {Worker} worker
+ * @returns {Promise<unknown>}
+ */
+const receiveResult = async (worker) => {
+  const result = await new Promise((resolve, reject) => {
+    worker
+      .once(
+        'message',
+        /** @param {ExecRunnerMessage} msg */ (msg) => {
+          if (msg.type === 'success') {
+            resolve(msg.result)
+          } else {
+            reject(msg.error)
+          }
+        }
+      )
+      .once('error', reject)
+  })
+  try {
+    await worker.terminate()
+  } finally {
+    worker.removeAllListeners()
+  }
+  return result
+}
+
+/**
+ * Executes the given code in the worker and asserts the result matches the
+ * expected value.
+ *
+ * @param {Worker} worker
+ * @param {ExecutionContext<unknown>} t
+ * @param {unknown} expected
+ */
+const execInWorker = async (worker, t, expected) => {
+  worker.unref()
+  worker.stdout.resume()
+  worker.stderr.resume()
+  const result = await receiveResult(worker)
+  t.deepEqual({ .../** @type {any} */ (result) }, expected)
+}
 
 /**
  * Given an AVA test function, returns a set of macros for testing policy
@@ -58,25 +123,19 @@ export const createExecMacros = (test) => {
         t,
         fixtureFilename,
         expected,
-        {
-          policy = DEFAULT_POLICY,
-          jsonEntrypoint = DEFAULT_JSON_FIXTURE_ENTRY_POINT,
-        } = {}
+        { policy = DEFAULT_POLICY, jsonEntrypoint } = {}
       ) => {
-        const { readPowers, vol } = await loadJSONFixture(
-          new URL(fixtureFilename, JSON_FIXTURE_DIR_URL)
-        )
-        try {
-          const result = await run(jsonEntrypoint, { policy, readPowers })
-          t.deepEqual(
-            { .../** @type {any} */ (result) },
-            expected,
-            'program output did not match expected value'
-          )
-        } catch (err) {
-          t.log(`Volume tree:\n${chalk.yellow(vol.toTree())}`)
-          throw err
-        }
+        const worker = new Worker(RUNNER_MODULE_PATH, {
+          stdout: true,
+          stderr: true,
+          workerData: {
+            isJsonFixture: true,
+            fixtureFilename,
+            jsonEntrypoint: jsonEntrypoint ? toPath(jsonEntrypoint) : undefined,
+            policy,
+          },
+        })
+        await execInWorker(worker, t, expected)
       },
       title: (title) =>
         title ?? `program output matches expected (${genericTitleIndex++}`,
@@ -99,8 +158,16 @@ export const createExecMacros = (test) => {
         expected,
         { policy = DEFAULT_POLICY } = {}
       ) => {
-        const result = await run(entrypoint, { policy })
-        t.deepEqual({ .../** @type {any} */ (result) }, expected)
+        const worker = new Worker(RUNNER_MODULE_PATH, {
+          stdout: true,
+          stderr: true,
+          workerData: {
+            isJsonFixture: false,
+            entryPath: toPath(entrypoint),
+            policy,
+          },
+        })
+        await execInWorker(worker, t, expected)
       },
       title: (title) =>
         title ?? `program output matches expected (${genericTitleIndex++}`,

--- a/packages/node/test/unit/exec/exec-runner.js
+++ b/packages/node/test/unit/exec/exec-runner.js
@@ -1,0 +1,73 @@
+/**
+ * Worker thread module for exec macro tests.
+ *
+ * Runs a LavaMoat-protected entry point and posts an {@link ExecRunnerMessage}
+ * back to the parent.
+ *
+ * @packageDocumentation
+ */
+import '../../../src/preamble.js'
+
+import { isMainThread, parentPort, workerData } from 'node:worker_threads'
+import { run } from '../../../src/exec/run.js'
+import {
+  DEFAULT_JSON_FIXTURE_ENTRY_POINT,
+  JSON_FIXTURE_DIR_URL,
+  loadJSONFixture,
+} from '../json-fixture-util.js'
+
+/**
+ * @import {ExecRunnerWorkerData, ExecRunnerMessage, ExecRunnerWorkerDataJson} from '../../types.js'
+ */
+
+if (isMainThread) {
+  throw new Error('This module is not meant to be run in the main thread')
+}
+
+if (!parentPort) {
+  throw new Error('Parent port is not available')
+}
+
+/**
+ * Runs a JSON fixture.
+ *
+ * @param {ExecRunnerWorkerDataJson} data
+ * @returns {Promise<unknown>}
+ */
+const runJsonFixture = async (data) => {
+  const { readPowers } = await loadJSONFixture(
+    new URL(data.fixtureFilename, JSON_FIXTURE_DIR_URL)
+  )
+  return run(data.jsonEntrypoint ?? DEFAULT_JSON_FIXTURE_ENTRY_POINT, {
+    policy: data.policy,
+    readPowers,
+  })
+}
+
+const data = /** @type {ExecRunnerWorkerData} */ (workerData)
+
+/** @type {ExecRunnerMessage} */
+let msg
+try {
+  /** @type {unknown} */
+  let result
+
+  if (data.isJsonFixture) {
+    result = await runJsonFixture(data)
+  } else {
+    result = await run(data.entryPath, { policy: data.policy })
+  }
+
+  msg = {
+    type: 'success',
+    result: { .../** @type {any} */ (result) },
+  }
+} catch (e) {
+  const error = e instanceof Error ? e : new Error(String(e), { cause: e })
+  msg = {
+    type: 'error',
+    error,
+  }
+}
+
+parentPort.postMessage(msg)


### PR DESCRIPTION
This changes unit tests of `run()` to execute in worker threads. This gives us two things:

1. Better control over stdout/stderr
2. Better isolation

The new `exec-runner.js` supports both on-disk fixtures and JSON fixtures.

While the strategy is similar for how we run scenarios, it's not quite the same—scenarios make assertions about the _output_ of the program; exec unit tests make assertions about the _exports_ of the program.