### PR TITLE
chore(vscode): fix double-formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.formatDocument": "explicit",
-    "source.organizeImports": "explicit"
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.prettier": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "files.insertFinalNewline": false,


### PR DESCRIPTION
This fixes the VSCode settings so that double-formatting does not occur. This can cause Prettier to erroneously start reordering JSON files.

It also disables `organizeImports` since this is better handled by ESLint.