### PR TITLE
fix(webpack): source maps

### DIFF
--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -564,7 +564,7 @@ class LavaMoatPlugin {
           compilation.hooks.processAssets.tap(
             {
               name: PLUGIN_NAME,
-              stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+              stage: Compilation.PROCESS_ASSETS_STAGE_DEV_TOOLING - 1,
             },
             sesPrefixFiles({
               compilation,


### PR DESCRIPTION
sesPrefixFiles prepends SES lockdown to the runtime chunk using ConcatSource. It currently runs at stage 700 (OPTIMIZE_INLINE), which is after webpack generates source maps at stage 500 (DEV_TOOLING). The .map file gets frozen at stage 500, then the JS is modified at stage 700, so they get out of sync.

Moving to stage 499 (DEV_TOOLING - 1) means lockdown is prepended before source maps are generated. ConcatSource already correctly offsets the original source map by the number of prepended lines, so the .map file is correct with no other changes needed. Stage 499 is still after Terser (stage 400), so the lockdown code won't be minified.