### PR TITLE
feat(node): Read pnpm bin wrapper scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19018,6 +19018,7 @@
         "lavamoat-core": "^18.0.1",
         "lavamoat-tofu": "^9.0.0",
         "loggerr": "4.2.0",
+        "read-cmd-shim": "4.0.0",
         "ses": "1.15.0",
         "terminal-link": "3.0.0",
         "type-fest": "4.41.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -64,6 +64,7 @@
     "lavamoat-core": "^18.0.1",
     "lavamoat-tofu": "^9.0.0",
     "loggerr": "4.2.0",
+    "read-cmd-shim": "4.0.0",
     "ses": "1.15.0",
     "terminal-link": "3.0.0",
     "type-fest": "4.41.0",

--- a/packages/node/src/resolve.js
+++ b/packages/node/src/resolve.js
@@ -10,9 +10,15 @@ import path from 'node:path'
 import { PACKAGE_JSON } from './constants.js'
 import { NoBinScriptError, NoWorkspaceError } from './error.js'
 import { hrLabel, hrPath } from './format.js'
-import { isExecutableSymlink, isReadableFileSync, realpathSync } from './fs.js'
+import {
+  isExecutablePathSync,
+  isExecutableSymlink,
+  isReadableFileSync,
+  realpathSync,
+} from './fs.js'
 import { log } from './log.js'
 import { toPath } from './util.js'
+import readCmdShim from 'read-cmd-shim'
 
 /**
  * @import {ResolveBinScriptOptions, ResolveEntrypointOptions, ResolveWorkspaceOptions} from './internal.js'
@@ -103,7 +109,7 @@ export const resolveBinScript = (
     )
   }
   let current = workspace
-   
+
   while (true) {
     const maybeBinDir = path.join(current, 'node_modules', '.bin')
     const niceBinDir = hrPath(maybeBinDir)
@@ -116,6 +122,19 @@ export const resolveBinScript = (
         `Found executable ${niceBin} in ${niceBinDir} linked from ${niceRealBinPath}`
       )
       return realBinPath
+    } else if (isExecutablePathSync(maybeBinPath, { fs })) {
+      try {
+        const binPath = readCmdShim.sync(maybeBinPath)
+        const realBinPath = realpathSync(path.join(maybeBinDir, binPath), {
+          fs,
+        })
+        log.debug(
+          `Found executable ${hrPath(realBinPath)} linked from ${hrPath(maybeBinPath)}`
+        )
+        return realBinPath
+      } catch {
+        // readCmdShim throws ENOTASHIM if a file exists but is not a recognizable shim
+      }
     }
 
     /** @type {string} */

--- a/packages/node/src/types/read-cmd-shim.d.ts
+++ b/packages/node/src/types/read-cmd-shim.d.ts
@@ -1,0 +1,35 @@
+declare module 'read-cmd-shim' {
+  /**
+   * Reads the `cmd-shim` located at path and resolves with the relative path
+   * that the shim points at. Consider this as roughly the equivalent of
+   * {@link fs.readlink}.
+   *
+   * This can read both `.cmd` style that are run by the Windows Command Prompt
+   * and PowerShell, and the kind without any extension that are used by
+   * Cygwin.
+   *
+   * This can return errors that {@link fs.readFile} returns, except that they'll
+   * include a stack trace from where `readCmdShim` was called. Plus it can
+   * return a special `ENOTASHIM` exception, when it can't find a cmd-shim in
+   * the file referenced by `path`. This should only happen if you pass in a
+   * non-command shim.
+   *
+   * @param path The path to the shim file
+   * @returns The relative target path extracted from the shim
+   * @throws ENOTASHIM If the file is not a recognized shim format
+   */
+  function readCmdShim(path: string): Promise<string>
+
+  namespace readCmdShim {
+    /**
+     * The same as {@link readCmdShim} but synchronous. Errors are thrown.
+     *
+     * @param path The path to the shim file
+     * @returns The relative target path extracted from the shim
+     * @throws ENOTASHIM If the file is not a recognized shim format
+     */
+    function sync(path: string): string
+  }
+
+  export default readCmdShim
+}

--- a/packages/node/test/e2e/resolve.spec.js
+++ b/packages/node/test/e2e/resolve.spec.js
@@ -2,10 +2,10 @@ import '../../src/preamble.js'
 
 // eslint-disable-next-line ava/use-test
 import anyTest from 'ava'
-import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { resolveEntrypoint } from '../../src/resolve.js'
+import { resolveBinScript, resolveEntrypoint } from '../../src/resolve.js'
 
 /**
  * @import {TestFn} from 'ava'
@@ -46,4 +46,54 @@ test('resolveEntrypoint - throws error if entrypoint not found', (t) => {
     },
     { message: /Cannot find module/ }
   )
+})
+
+test('resolveBinScript - resolves bin from pnpm wrapper script', async (t) => {
+  const root = t.context.tempdir
+  const binDir = path.join(root, 'node_modules', '.bin')
+  const targetScript = path.join(
+    root,
+    'node_modules',
+    '.pnpm',
+    'some-pkg@1.0.0',
+    'node_modules',
+    'some-pkg',
+    'cli.js'
+  )
+
+  await mkdir(binDir, { recursive: true })
+  await mkdir(path.join(root, 'node_modules', 'some-pkg'), { recursive: true })
+  await mkdir(path.dirname(targetScript), { recursive: true })
+  await writeFile(path.join(root, 'package.json'), '{}')
+  await writeFile(targetScript, '#!/usr/bin/env node\nconsole.log("some-pkg")')
+
+  const wrapper = `
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+
+case \`uname\` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
+esac
+
+if [ -z "$NODE_PATH" ]; then
+  export NODE_PATH="…"
+else
+  export NODE_PATH="…"
+fi
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../.pnpm/some-pkg@1.0.0/node_modules/some-pkg/cli.js" "$@"
+else
+  exec node  "$basedir/../.pnpm/some-pkg@1.0.0/node_modules/some-pkg/cli.js" "$@"
+fi
+`
+
+  await writeFile(path.join(binDir, 'some-pkg'), wrapper, { mode: 0o755 })
+
+  const resolved = resolveBinScript('some-pkg', { from: root })
+  const expected = await realpath(targetScript)
+  t.is(resolved, expected)
 })


### PR DESCRIPTION
Closes #1948

This change updates the resolution of the `--bin` argument, now reading from the executable file where it is a pnpm wrapper script. `read-cmd-shim` will return the path to the underlying script, and we now resolve that full path.