### PR TITLE
fix(webpack): preserve sourcemaps when SES source transforms modify module code

### DIFF
--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -3,7 +3,7 @@
 /** @typedef {import('webpack').sources.Source} Source */
 
 const {
-  sources: { ConcatSource },
+  sources: { ConcatSource, SourceMapSource },
 } = require('webpack')
 const { wrapper } = require('./wrapper.js')
 const diag = require('./diagnostics.js')
@@ -196,6 +196,20 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
 
         // using this in webpack.config.ts complained about made up issues
         if (sourceChanged) {
+          // Preserve the original sourcemap even when SES source transforms
+          // modify the code. Without this, chunks containing only transformed
+          // modules lose all sourcemap data, causing webpack to skip .map file
+          // generation entirely for those chunks.
+          const originalMap =
+            originalGeneratedSource.map && originalGeneratedSource.map()
+          if (originalMap) {
+            const sourceWithMap = new SourceMapSource(
+              source,
+              originalMap.file || 'lavamoat-transformed',
+              originalMap
+            )
+            return new ConcatSource(before, sourceWithMap, after)
+          }
           return new ConcatSource(before, source, after)
         } else {
           return new ConcatSource(before, originalGeneratedSource, after)

--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -173,7 +173,7 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
           module
         )
 
-        const { before, after, source } = wrapper({
+        const { before, source, after } = wrapper({
           source: originalGeneratedSource,
           id: packageId,
           runtimeKit,

--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -3,7 +3,7 @@
 /** @typedef {import('webpack').sources.Source} Source */
 
 const {
-  sources: { ConcatSource, SourceMapSource },
+  sources: { ConcatSource },
 } = require('webpack')
 const { wrapper } = require('./wrapper.js')
 const diag = require('./diagnostics.js')
@@ -173,12 +173,8 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
           module
         )
 
-        const { before, after, source, sourceChanged } = wrapper({
-          // There's probably a good reason why webpack stores source in those objects instead
-          // of strings. Turning it into a string here might mean we're loosing some caching.
-          // Wrapper checks if transforms changed the source and indicates it, so that we can
-          // decide if we want to keep the original object representing it.
-          source: originalGeneratedSource.source().toString(),
+        const { before, after, source } = wrapper({
+          source: originalGeneratedSource,
           id: packageId,
           runtimeKit,
           runChecks,
@@ -189,31 +185,11 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
         diag.rawDebug(4, {
           packageId,
           requirements: options.runtimeRequirements,
-          sourceChanged,
         })
 
         PROGRESS.report('generatorCalled')
 
-        // using this in webpack.config.ts complained about made up issues
-        if (sourceChanged) {
-          // Preserve the original sourcemap even when SES source transforms
-          // modify the code. Without this, chunks containing only transformed
-          // modules lose all sourcemap data, causing webpack to skip .map file
-          // generation entirely for those chunks.
-          const originalMap =
-            originalGeneratedSource.map && originalGeneratedSource.map()
-          if (originalMap) {
-            const sourceWithMap = new SourceMapSource(
-              source,
-              originalMap.file || 'lavamoat-transformed',
-              originalMap
-            )
-            return new ConcatSource(before, sourceWithMap, after)
-          }
-          return new ConcatSource(before, source, after)
-        } else {
-          return new ConcatSource(before, originalGeneratedSource, after)
-        }
+        return new ConcatSource(before, source, after)
       }
       wrappedGeneratorInstances.add(generator)
       return generator

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -43,6 +43,7 @@ const evalPattern = /\beval(\s*\()/g
  * This re-implements the same replacements as lavamoat-core's
  * applySourceTransforms and evadeDirectEvalExpressions, but operates on
  * positional replacements so that webpack's sourcemap pipeline can track the
+ * exact character offsets.
  *
  * @param {Source} originalSource - The original webpack source object with
  *   sourcemap

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -2,7 +2,7 @@ const diag = require('./diagnostics')
 const fs = require('node:fs')
 const q = JSON.stringify
 const {
-  sources: { ReplaceSource },
+  sources: { ReplaceSource, SourceMapSource, RawSource },
 } = require('webpack')
 
 /**
@@ -47,14 +47,21 @@ const evalPattern = /\beval(\s*\()/g
  *
  * @param {Source} originalSource - The original webpack source object with
  *   sourcemap
- * @returns {{ source: Source; sourceStr: string; sourceChanged: boolean }}
+ * @returns {{ source: Source; sourceStr: string }}
  */
 function applySesTransforms(originalSource) {
-  const sourceStr = originalSource.source().toString()
-  let sourceChanged = false
+  // Flatten the source so that character positions from .source() output match
+  // what ReplaceSource expects. Without this, compound sources (e.g. a
+  // ReplaceSource from webpack's generator) have internal positions that don't
+  // correspond to their flattened string output.
+  const { source, map } = originalSource.sourceAndMap()
+  const sourceStr = typeof source === 'string' ? source : source.toString()
+  const flatSource = map
+    ? new SourceMapSource(sourceStr, 'lavamoat-ses-transforms', map)
+    : new RawSource(sourceStr)
   let match
 
-  const replaceSource = new ReplaceSource(originalSource)
+  const replaceSource = new ReplaceSource(flatSource)
 
   // evadeHtmlCommentTest: <!-- → < ! -- and --> → -- >
   htmlCommentPattern.lastIndex = 0
@@ -65,7 +72,6 @@ function applySesTransforms(originalSource) {
       match.index + match[0].length - 1,
       replacement
     )
-    sourceChanged = true
   }
 
   // evadeImportExpressionTest: import → __import__ (preserve trailing whitespace/paren)
@@ -73,7 +79,6 @@ function applySesTransforms(originalSource) {
   while ((match = importPattern.exec(sourceStr)) !== null) {
     // Only replace the 'import' keyword (6 chars), keep the capture group
     replaceSource.replace(match.index, match.index + 5, '__import__')
-    sourceChanged = true
   }
 
   // evadeDirectEvalExpressions: eval → (0,eval) (preserve trailing whitespace/paren)
@@ -81,13 +86,11 @@ function applySesTransforms(originalSource) {
   while ((match = evalPattern.exec(sourceStr)) !== null) {
     // Only replace the 'eval' keyword (4 chars), keep the capture group
     replaceSource.replace(match.index, match.index + 3, '(0,eval)')
-    sourceChanged = true
   }
 
   return {
-    source: sourceChanged ? replaceSource : originalSource,
-    sourceStr: sourceChanged ? replaceSource.source().toString() : sourceStr,
-    sourceChanged,
+    source: replaceSource,
+    sourceStr: replaceSource.source().toString(),
   }
 }
 
@@ -97,7 +100,6 @@ function applySesTransforms(originalSource) {
  *   before: string
  *   after: string
  *   source: Source
- *   sourceChanged: boolean
  * }}
  */
 exports.wrapper = function wrapper({
@@ -110,11 +112,8 @@ exports.wrapper = function wrapper({
 }) {
   const runtimeKitArray = Array.from(runtimeKit)
 
-  const {
-    source: transformedSource,
-    sourceStr,
-    sourceChanged,
-  } = applySesTransforms(source)
+  const { source: transformedSource, sourceStr: sesCompatibleStr } =
+    applySesTransforms(source)
 
   // This adds support for mapping `this` to `exports` or `module.exports` if webpack detected it's necessary
   let optionalBinding = ''
@@ -151,13 +150,12 @@ exports.wrapper = function wrapper({
     ','
   )}}))${optionalBinding}()`
   if (runChecks) {
-    validateSource(sourceStr)
+    validateSource(sesCompatibleStr)
   }
   return {
     before,
     after,
     source: transformedSource,
-    sourceChanged,
   }
 }
 

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -154,8 +154,8 @@ exports.wrapper = function wrapper({
   }
   return {
     before,
-    after,
     source: transformedSource,
+    after,
   }
 }
 

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -1,7 +1,9 @@
-const { applySourceTransforms } = require('lavamoat-core')
 const diag = require('./diagnostics')
 const fs = require('node:fs')
 const q = JSON.stringify
+const {
+  sources: { ReplaceSource },
+} = require('webpack')
 
 /**
  * Flags enabling runtime features based on webpack's runtime requirements.
@@ -11,8 +13,11 @@ const q = JSON.stringify
  * @property {boolean} [thisAsExports]
  */
 /**
+ * @typedef {import('webpack').sources.Source} Source
+ */
+/**
  * @typedef {object} WrappingInput
- * @property {string} source
+ * @property {Source} source
  * @property {string} id
  * @property {string[] | Set<string>} runtimeKit
  * @property {string} evalKitFunctionName
@@ -26,12 +31,71 @@ const {
   NAME_runtimeHandler,
 } = require('../ENUM.json')
 
+// Regex patterns matching those used by lavamoat-core's applySourceTransforms
+// and evadeDirectEvalExpressions. These must be kept in sync.
+// Ideally we should import these from lavamoat-core.
+const htmlCommentPattern = /(?:<!--|-->)/g
+const importPattern = /\bimport(\s*(?:\(|\/[/*]))/g
+const evalPattern = /\beval(\s*\()/g
+
+/**
+ * Applies SES source transforms using ReplaceSource to preserve sourcemap data.
+ * This re-implements the same replacements as lavamoat-core's
+ * applySourceTransforms and evadeDirectEvalExpressions, but operates on
+ * positional replacements so that webpack's sourcemap pipeline can track the
+ *
+ * @param {Source} originalSource - The original webpack source object with
+ *   sourcemap
+ * @returns {{ source: Source; sourceStr: string; sourceChanged: boolean }}
+ */
+function applySesTransforms(originalSource) {
+  const sourceStr = originalSource.source().toString()
+  let sourceChanged = false
+  let match
+
+  const replaceSource = new ReplaceSource(originalSource)
+
+  // evadeHtmlCommentTest: <!-- → < ! -- and --> → -- >
+  htmlCommentPattern.lastIndex = 0
+  while ((match = htmlCommentPattern.exec(sourceStr)) !== null) {
+    const replacement = match[0][0] === '<' ? '< ! --' : '-- >'
+    replaceSource.replace(
+      match.index,
+      match.index + match[0].length - 1,
+      replacement
+    )
+    sourceChanged = true
+  }
+
+  // evadeImportExpressionTest: import → __import__ (preserve trailing whitespace/paren)
+  importPattern.lastIndex = 0
+  while ((match = importPattern.exec(sourceStr)) !== null) {
+    // Only replace the 'import' keyword (6 chars), keep the capture group
+    replaceSource.replace(match.index, match.index + 5, '__import__')
+    sourceChanged = true
+  }
+
+  // evadeDirectEvalExpressions: eval → (0,eval) (preserve trailing whitespace/paren)
+  evalPattern.lastIndex = 0
+  while ((match = evalPattern.exec(sourceStr)) !== null) {
+    // Only replace the 'eval' keyword (4 chars), keep the capture group
+    replaceSource.replace(match.index, match.index + 3, '(0,eval)')
+    sourceChanged = true
+  }
+
+  return {
+    source: sourceChanged ? replaceSource : originalSource,
+    sourceStr: sourceChanged ? replaceSource.source().toString() : sourceStr,
+    sourceChanged,
+  }
+}
+
 /**
  * @param {WrappingInput} params
  * @returns {{
  *   before: string
  *   after: string
- *   source: string
+ *   source: Source
  *   sourceChanged: boolean
  * }}
  */
@@ -44,11 +108,12 @@ exports.wrapper = function wrapper({
   runtimeFlags = {},
 }) {
   const runtimeKitArray = Array.from(runtimeKit)
-  // validateSource(source);
 
-  // No AST used in these transforms, so string comparison should indicate if anything was changed.
-  const sesCompatibleSource = applySourceTransforms(source)
-  const sourceChanged = source !== sesCompatibleSource
+  const {
+    source: transformedSource,
+    sourceStr,
+    sourceChanged,
+  } = applySesTransforms(source)
 
   // This adds support for mapping `this` to `exports` or `module.exports` if webpack detected it's necessary
   let optionalBinding = ''
@@ -85,12 +150,12 @@ exports.wrapper = function wrapper({
     ','
   )}}))${optionalBinding}()`
   if (runChecks) {
-    validateSource(sesCompatibleSource)
+    validateSource(sourceStr)
   }
   return {
     before,
     after,
-    source: sesCompatibleSource,
+    source: transformedSource,
     sourceChanged,
   }
 }

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -55,7 +55,7 @@ function applySesTransforms(originalSource) {
   // ReplaceSource from webpack's generator) have internal positions that don't
   // correspond to their flattened string output.
   const { source, map } = originalSource.sourceAndMap()
-  const sourceStr = typeof source === 'string' ? source : source.toString()
+  const sourceStr = source.toString()
   const flatSource = map
     ? new SourceMapSource(sourceStr, 'lavamoat-ses-transforms', map)
     : new RawSource(sourceStr)

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -1,3 +1,4 @@
+const { applySourceTransforms } = require('lavamoat-core')
 const diag = require('./diagnostics')
 const fs = require('node:fs')
 const q = JSON.stringify
@@ -31,67 +32,121 @@ const {
   NAME_runtimeHandler,
 } = require('../ENUM.json')
 
-// Regex patterns matching those used by lavamoat-core's applySourceTransforms
-// and evadeDirectEvalExpressions. These must be kept in sync.
-// Ideally we should import these from lavamoat-core.
-const htmlCommentPattern = /(?:<!--|-->)/g
-const importPattern = /\bimport(\s*(?:\(|\/[/*]))/g
-const evalPattern = /\beval(\s*\()/g
+/**
+ * Computes the character-level diff between two strings and returns an array of
+ * replacement operations (start, end, content) suitable for ReplaceSource.
+ *
+ * @param {string} original - The original string
+ * @param {string} transformed - The transformed string
+ * @returns {{ start: number; end: number; content: string }[]}
+ */
+function diffReplacements(original, transformed) {
+  const replacements = []
+  let i = 0
+  let j = 0
+
+  while (i < original.length && j < transformed.length) {
+    if (original[i] === transformed[j]) {
+      i++
+      j++
+    } else {
+      // Found a difference — find where it ends
+      const diffStart = i
+
+      // Look ahead to find the next sync point
+      // Try increasing window sizes to find where the strings re-align
+      let foundSync = false
+      for (let window = 1; window <= 20 && !foundSync; window++) {
+        for (let oi = 0; oi <= window; oi++) {
+          const ti = window - oi
+          if (
+            i + oi < original.length &&
+            j + ti < transformed.length &&
+            original[i + oi] === transformed[j + ti]
+          ) {
+            // Verify this is a real sync point (check a few more chars)
+            let isSync = true
+            for (let k = 1; k < Math.min(3, original.length - i - oi); k++) {
+              if (original[i + oi + k] !== transformed[j + ti + k]) {
+                isSync = false
+                break
+              }
+            }
+            if (isSync) {
+              const endExclusive = i + oi
+              const content = transformed.slice(j, j + ti)
+              replacements.push({
+                start: diffStart,
+                end: endExclusive - 1,
+                content,
+              })
+              i = endExclusive
+              j = j + ti
+              foundSync = true
+              break
+            }
+          }
+        }
+      }
+      if (!foundSync) {
+        // Can't find sync — treat the rest as one big replacement
+        replacements.push({
+          start: diffStart,
+          end: original.length - 1,
+          content: transformed.slice(j),
+        })
+        return replacements
+      }
+    }
+  }
+
+  // Handle trailing content
+  if (i < original.length || j < transformed.length) {
+    replacements.push({
+      start: i,
+      end: original.length - 1,
+      content: transformed.slice(j),
+    })
+  }
+
+  return replacements
+}
 
 /**
- * Applies SES source transforms using ReplaceSource to preserve sourcemap data.
- * This re-implements the same replacements as lavamoat-core's
- * applySourceTransforms and evadeDirectEvalExpressions, but operates on
- * positional replacements so that webpack's sourcemap pipeline can track the
- * exact character offsets.
+ * Applies SES source transforms while preserving sourcemap data. Uses
+ * lavamoat-core's applySourceTransforms as the source of truth for what to
+ * transform, then diffs the original and transformed strings to compute
+ * positional replacements for webpack's ReplaceSource.
  *
- * @param {Source} originalSource - The original webpack source object with
- *   sourcemap
+ * @param {Source} originalSource - The original webpack source object
  * @returns {{ source: Source; sourceStr: string }}
  */
 function applySesTransforms(originalSource) {
-  // Flatten the source so that character positions from .source() output match
-  // what ReplaceSource expects. Without this, compound sources (e.g. a
-  // ReplaceSource from webpack's generator) have internal positions that don't
-  // correspond to their flattened string output.
   const { source, map } = originalSource.sourceAndMap()
   const sourceStr = source.toString()
+  const transformedStr = applySourceTransforms(sourceStr)
+
+  if (sourceStr === transformedStr) {
+    return { source: originalSource, sourceStr }
+  }
+
+  // Flatten the source so that character positions match what ReplaceSource
+  // expects. Without this, compound sources (e.g. a ReplaceSource from
+  // webpack's generator) have internal positions that don't correspond to
+  // their flattened string output.
   const flatSource = map
     ? new SourceMapSource(sourceStr, 'lavamoat-ses-transforms', map)
     : new RawSource(sourceStr)
-  let match
 
   const replaceSource = new ReplaceSource(flatSource)
 
-  // evadeHtmlCommentTest: <!-- → < ! -- and --> → -- >
-  htmlCommentPattern.lastIndex = 0
-  while ((match = htmlCommentPattern.exec(sourceStr)) !== null) {
-    const replacement = match[0][0] === '<' ? '< ! --' : '-- >'
-    replaceSource.replace(
-      match.index,
-      match.index + match[0].length - 1,
-      replacement
-    )
+  const replacements = diffReplacements(sourceStr, transformedStr)
+
+  for (const { start, end, content } of replacements) {
+    replaceSource.replace(start, end, content)
   }
 
-  // evadeImportExpressionTest: import → __import__ (preserve trailing whitespace/paren)
-  importPattern.lastIndex = 0
-  while ((match = importPattern.exec(sourceStr)) !== null) {
-    // Only replace the 'import' keyword (6 chars), keep the capture group
-    replaceSource.replace(match.index, match.index + 5, '__import__')
-  }
-
-  // evadeDirectEvalExpressions: eval → (0,eval) (preserve trailing whitespace/paren)
-  evalPattern.lastIndex = 0
-  while ((match = evalPattern.exec(sourceStr)) !== null) {
-    // Only replace the 'eval' keyword (4 chars), keep the capture group
-    replaceSource.replace(match.index, match.index + 3, '(0,eval)')
-  }
-
-  return {
-    source: replaceSource,
-    sourceStr: replaceSource.source().toString(),
-  }
+  return { source: replaceSource, sourceStr: transformedStr }
 }
 
 /**


### PR DESCRIPTION
## Problem

When `applySourceTransforms` modifies a module's source (to evade `<!--`, `-->`, `import()`, `eval()`), the generator discards the original sourcemap — it returns a plain string inside `ConcatSource` instead of a webpack `Source` object.

For most chunks this goes unnoticed because other unmodified modules still carry sourcemap data. But chunks containing **only transformed modules** end up with zero mapping data, and webpack skips `.map` file generation entirely. In MetaMask's build, this caused 2 out of 45 UI chunks to have no sourcemaps at all.

## Fix

`wrapper.js` now accepts a webpack `Source` object instead of a string. It:

1. Flattens the source via `sourceAndMap()` into a `SourceMapSource` (needed because the incoming source may be a compound `ReplaceSource` whose internal positions don't match the flattened output)
2. Runs `applySourceTransforms` on the string to get the SES-compatible result (used for validation)
3. Diffs the original and transformed strings to compute exact positional replacements
4. Applies those replacements via webpack's `ReplaceSource`, which automatically adjusts the sourcemap

`generator.js` is simplified — it passes the `Source` object directly to `wrapper` and uses the result in `ConcatSource(before, source, after)` with no branching.

## Test plan

- [x] MetaMask webpack build passes cleanly (no SES validation errors)
- [x] All 45 UI chunks produce `.map` files (previously 43/45)
- [x] Sentry stack traces resolve to original source with correct file paths, line numbers, and variable names