### PR TITLE
feat(webpack): sourcemap-preserving evasive transforms

### DIFF
--- a/packages/webpack/src/buildtime/generator.js
+++ b/packages/webpack/src/buildtime/generator.js
@@ -2,9 +2,6 @@
 /** @import {ProgressAPI} from './utils.js' */
 /** @typedef {import('webpack').sources.Source} Source */
 
-const {
-  sources: { ConcatSource },
-} = require('webpack')
 const { wrapper } = require('./wrapper.js')
 const diag = require('./diagnostics.js')
 
@@ -173,12 +170,8 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
           module
         )
 
-        const { before, after, source, sourceChanged } = wrapper({
-          // There's probably a good reason why webpack stores source in those objects instead
-          // of strings. Turning it into a string here might mean we're loosing some caching.
-          // Wrapper checks if transforms changed the source and indicates it, so that we can
-          // decide if we want to keep the original object representing it.
-          source: originalGeneratedSource.source().toString(),
+        const { wrappedSource, sourceChanged } = wrapper({
+          source: originalGeneratedSource,
           id: packageId,
           runtimeKit,
           runChecks,
@@ -194,12 +187,7 @@ exports.wrapGenerator = ({ excludes, runChecks, PROGRESS }) => {
 
         PROGRESS.report('generatorCalled')
 
-        // using this in webpack.config.ts complained about made up issues
-        if (sourceChanged) {
-          return new ConcatSource(before, source, after)
-        } else {
-          return new ConcatSource(before, originalGeneratedSource, after)
-        }
+        return wrappedSource
       }
       wrappedGeneratorInstances.add(generator)
       return generator

--- a/packages/webpack/src/buildtime/sourceTransforms.js
+++ b/packages/webpack/src/buildtime/sourceTransforms.js
@@ -1,0 +1,91 @@
+/** @typedef {import('webpack').sources.Source} Source */
+
+const {
+  sources: { ReplaceSource },
+} = require('webpack')
+
+/**
+ * @typedef {object} TransformEntry
+ * @property {RegExp} pattern - Global regex pattern to match against source
+ * @property {(match: RegExpMatchArray) => string} replaceFn - Receives the
+ *   matchAll result, returns replacement string
+ */
+
+// Patterns copied from SES transforms (transforms.umd.js)
+const importPatternString = '\\bimport(\\s*(?:\\(|/[/*]))'
+const htmlCommentPatternString = `(?:${'<'}!--|--${'>'})`
+const evalPatternString = '\\beval(\\s*\\()'
+
+const htmlCommentPattern = new RegExp(htmlCommentPatternString, 'g')
+const importPattern = new RegExp(importPatternString, 'g')
+const evalPattern = new RegExp(evalPatternString, 'g')
+
+/**
+ * Combined detection regex — non-global, used only for `.test()`. Single engine
+ * pass for the common case (no match).
+ */
+const NEEDS_TRANSFORM = new RegExp(
+  // the `?:` is to avoid unnecessary capture groups since we only care about the presence of a match, not the details
+  `(?:${importPatternString}|${htmlCommentPatternString}|${evalPatternString})`
+  // note no `g` here - we only need to find one match and avoid worrying about lastIndex
+)
+
+/** @type {TransformEntry[]} */
+const SES_TRANSFORMS = [
+  {
+    pattern: htmlCommentPattern,
+    replaceFn: (match) => (match[0][0] === '<' ? '< ! --' : '-- >'),
+  },
+  {
+    pattern: importPattern,
+    replaceFn: (match) => `__import__${match[1]}`,
+  },
+  {
+    pattern: evalPattern,
+    replaceFn: (match) => `(0,eval)${match[1]}`,
+  },
+]
+
+/**
+ * Cheap detection — returns true if source may need any SES transforms.
+ *
+ * @param {string} sourceString
+ * @returns {boolean}
+ */
+function needsTransform(sourceString) {
+  return NEEDS_TRANSFORM.test(sourceString)
+}
+
+/**
+ * Generic sourcemap-preserving transform using webpack's ReplaceSource. Applies
+ * all matching replacements from the given transforms list.
+ *
+ * @param {Source} webpackSource - The original webpack Source object
+ * @param {string} sourceString - The already-extracted source string (avoids
+ *   re-calling .source())
+ * @param {TransformEntry[]} transforms - Array of { pattern, replaceFn }
+ *   entries
+ * @returns {Source}
+ */
+function applyReplaceTransforms(webpackSource, sourceString, transforms) {
+  const replaceSource = new ReplaceSource(webpackSource)
+
+  for (const { pattern, replaceFn } of transforms) {
+    // Reset lastIndex in case the regex was used before
+    pattern.lastIndex = 0
+    for (const match of sourceString.matchAll(pattern)) {
+      const start = /** @type {number} */ (match.index)
+      const end = start + match[0].length - 1
+      replaceSource.replace(start, end, replaceFn(match))
+    }
+  }
+
+  return replaceSource
+}
+
+module.exports = {
+  NEEDS_TRANSFORM,
+  SES_TRANSFORMS,
+  needsTransform,
+  applyReplaceTransforms,
+}

--- a/packages/webpack/src/buildtime/wrapper.js
+++ b/packages/webpack/src/buildtime/wrapper.js
@@ -1,4 +1,13 @@
-const { applySourceTransforms } = require('lavamoat-core')
+/** @typedef {import('webpack').sources.Source} Source */
+
+const {
+  sources: { ConcatSource },
+} = require('webpack')
+const {
+  needsTransform,
+  applyReplaceTransforms,
+  SES_TRANSFORMS,
+} = require('./sourceTransforms')
 const diag = require('./diagnostics')
 const fs = require('node:fs')
 const q = JSON.stringify
@@ -12,7 +21,7 @@ const q = JSON.stringify
  */
 /**
  * @typedef {object} WrappingInput
- * @property {string} source
+ * @property {Source} source
  * @property {string} id
  * @property {string[] | Set<string>} runtimeKit
  * @property {string} evalKitFunctionName
@@ -29,9 +38,7 @@ const {
 /**
  * @param {WrappingInput} params
  * @returns {{
- *   before: string
- *   after: string
- *   source: string
+ *   wrappedSource: Source
  *   sourceChanged: boolean
  * }}
  */
@@ -44,11 +51,19 @@ exports.wrapper = function wrapper({
   runtimeFlags = {},
 }) {
   const runtimeKitArray = Array.from(runtimeKit)
-  // validateSource(source);
 
-  // No AST used in these transforms, so string comparison should indicate if anything was changed.
-  const sesCompatibleSource = applySourceTransforms(source)
-  const sourceChanged = source !== sesCompatibleSource
+  const sourceString = source.source().toString()
+
+  let transformedSource = source
+  let sourceChanged = false
+  if (needsTransform(sourceString)) {
+    transformedSource = applyReplaceTransforms(
+      source,
+      sourceString,
+      SES_TRANSFORMS
+    )
+    sourceChanged = true
+  }
 
   // This adds support for mapping `this` to `exports` or `module.exports` if webpack detected it's necessary
   let optionalBinding = ''
@@ -85,12 +100,12 @@ exports.wrapper = function wrapper({
     ','
   )}}))${optionalBinding}()`
   if (runChecks) {
-    validateSource(sesCompatibleSource)
+    validateSource(
+      sourceChanged ? transformedSource.source().toString() : sourceString
+    )
   }
   return {
-    before,
-    after,
-    source: sesCompatibleSource,
+    wrappedSource: new ConcatSource(before, transformedSource, after),
     sourceChanged,
   }
 }

--- a/packages/webpack/test/e2e-sourcemap.spec.js
+++ b/packages/webpack/test/e2e-sourcemap.spec.js
@@ -1,0 +1,131 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const path = require('node:path')
+const fs = require('node:fs')
+const { SourceMapConsumer } = require('source-map-js')
+const { scaffold } = require('./scaffold.js')
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
+
+test.before(async (t) => {
+  const webpackConfig = makeConfig({
+    generatePolicy: false,
+  })
+  // Toggle to include and exclude minification
+  webpackConfig.mode = 'production'
+  webpackConfig.entry = { app: './sourcemap.js' }
+  webpackConfig.devtool = 'source-map'
+
+  await t.notThrowsAsync(async () => {
+    t.context.build = await scaffold(webpackConfig)
+  }, 'Expected the build to succeed')
+  t.context.mode = webpackConfig.mode
+  t.context.bundle = t.context.build.snapshot['/dist/app.js']
+  t.context.mapJson = JSON.parse(t.context.build.snapshot['/dist/app.js.map'])
+})
+
+test('webpack/sourcemap - .map file exists and is valid', (t) => {
+  t.truthy(t.context.build.snapshot['/dist/app.js.map'])
+  t.truthy(t.context.mapJson.version)
+  t.truthy(t.context.mapJson.mappings)
+  t.truthy(t.context.mapJson.sources.length > 0)
+})
+
+test('webpack/sourcemap - bundle references the sourcemap', (t) => {
+  t.regex(t.context.bundle, /\/\/# sourceMappingURL=app\.js\.map/)
+})
+
+test('webpack/sourcemap - SES transforms were applied in the bundle', (t) => {
+  // eval( → (0,eval)(
+  t.regex(t.context.bundle, /\(0,eval\)/)
+})
+
+test('webpack/sourcemap - production mangled identifiers away from bundle but map has them', (t) => {
+  if (t.context.mode === 'production') {
+    // These identifiers should not survive production minification
+    t.notRegex(t.context.bundle, /secretEvalResult/)
+    t.notRegex(t.context.bundle, /computeSomethingUnique/)
+  }
+  const allContent = t.context.mapJson.sourcesContent.join('\n')
+
+  t.regex(allContent, /secretEvalResult/)
+  t.regex(allContent, /computeSomethingUnique/)
+})
+
+test('webpack/sourcemap - sourcesContent has pre-transform code', (t) => {
+  const allContent = t.context.mapJson.sourcesContent.join('\n')
+
+  // The original eval( should appear in sourcesContent, not the transformed (0,eval)(
+  t.regex(allContent, /const secretEvalResult = eval\(/)
+})
+
+test('webpack/sourcemap - eval transform maps back to original position', (t) => {
+  const consumer = new SourceMapConsumer(t.context.mapJson)
+
+  // Read the fixture source to find eval position dynamically
+  const fixturePath = path.join(__dirname, 'fixtures', 'main', 'sourcemap.js')
+  const fixtureSource = fs.readFileSync(fixturePath, 'utf8')
+  const fixtureLines = fixtureSource.split('\n')
+  const { line: expectedLine, column: expectedColumn } = findInSource(
+    fixtureLines,
+    'eval('
+  )
+  t.not(expectedLine, -1, 'eval( should exist in the fixture source')
+
+  // Verify our detected position is correct by checking the file contents
+  t.is(
+    fixtureLines[expectedLine - 1].slice(expectedColumn, expectedColumn + 5),
+    'eval(',
+    'sanity check: detected position should point at eval('
+  )
+
+  // Find (0,eval) in the generated bundle
+  const bundleLines = t.context.bundle.split('\n')
+  const { line: genLine, column: genColumn } = findInSource(
+    bundleLines,
+    '(0,eval)'
+  )
+  t.not(genLine, -1, '(0,eval) should exist in the bundle')
+
+  // use sourcemap to convert to original position
+  const original = consumer.originalPositionFor({
+    line: genLine,
+    column: genColumn,
+  })
+
+  t.log('source positions', {
+    original: { line: expectedLine, column: expectedColumn },
+    generated: { line: genLine, column: genColumn },
+    retrieved: { line: original.line, column: original.column },
+  })
+
+  t.truthy(original.source, 'should map to a source file')
+  t.regex(original.source, /sourcemap\.js/, 'should map back to sourcemap.js')
+  t.is(
+    original.line,
+    expectedLine,
+    'should map to the original line containing eval'
+  )
+
+  // Column may not be exact after terser sourcemap composition, but should be
+  // on the same statement — verify the rest of the line from the mapped column
+  // still contains eval(
+  const restOfLine = fixtureLines[original.line - 1].slice(original.column)
+  t.regex(
+    restOfLine,
+    /eval\(/,
+    'from the mapped column onwards, the source should contain eval('
+  )
+})
+
+/**
+ * Find the first occurrence of a substring in an array of lines. Returns
+ * 1-based line and 0-based column, or {line: -1, column: -1} if not found.
+ */
+function findInSource(lines, needle) {
+  for (let i = 0; i < lines.length; i++) {
+    const col = lines[i].indexOf(needle)
+    if (col !== -1) {
+      return { line: i + 1, column: col }
+    }
+  }
+  return { line: -1, column: -1 }
+}

--- a/packages/webpack/test/e2e.manual.js
+++ b/packages/webpack/test/e2e.manual.js
@@ -34,6 +34,6 @@ function writeFromSnapshot(snapshot) {
 scaffold(webpackConfig).then(({ stdout, snapshot }) => {
   console.log(stdout)
   writeFromSnapshot(snapshot)
-  console.log('\nBuild written to:', path.resolve('.', 'tmp', now))
+  console.log('\nBuild written to:', path.resolve('tmp', now))
   runScriptWithSES(snapshot['/dist/app.js'])
 })

--- a/packages/webpack/test/e2e.manual.js
+++ b/packages/webpack/test/e2e.manual.js
@@ -2,12 +2,15 @@
 const fs = require('node:fs')
 const path = require('node:path')
 const { scaffold, runScriptWithSES } = require('./scaffold.js')
-const webpackConfigDefault = require('./fixtures/main/webpack.config.js')
-const webpackConfig = {
-  ...webpackConfigDefault,
-  // mode: 'development',
-  // devtool: false,
-}
+
+const { makeConfig } = require('./fixtures/main/webpack.config.js')
+
+const webpackConfig = makeConfig({
+  generatePolicy: false,
+})
+// webpackConfig.entry = { app: './sourcemap.js' }
+// webpackConfig.devtool = 'source-map'
+// webpackConfig.mode = 'production'
 
 const now = new Date().toISOString()
 
@@ -31,5 +34,6 @@ function writeFromSnapshot(snapshot) {
 scaffold(webpackConfig).then(({ stdout, snapshot }) => {
   console.log(stdout)
   writeFromSnapshot(snapshot)
+  console.log('\nBuild written to:', path.resolve('.', 'tmp', now))
   runScriptWithSES(snapshot['/dist/app.js'])
 })

--- a/packages/webpack/test/fixtures/main/sourcemap.js
+++ b/packages/webpack/test/fixtures/main/sourcemap.js
@@ -1,0 +1,9 @@
+// triggers eval transform — the identifier `secretEvalResult` only exists as code, not in any string
+const secretEvalResult = eval('1+1')
+
+// distinctive identifier only used as code, never in a string literal
+function computeSomethingUnique() {
+  return secretEvalResult
+}
+
+console.log(computeSomethingUnique())


### PR DESCRIPTION
currently rebuilt with webpack primitives.

Tried out the new babel-based evasive transforms instead for better meaning preservation. It's not that much slower thanks to how rare the need for a transform is. The main problem for now is we can't use them in webpack, because lavamoat-node doesn't support ESM so it won't work under lavamoat. Has to be postponed till we create a cjs export from `@endo/evasive-transform` or switch to lavamoat/node for good.

Babel experiments in branch: `naugtur/webpack-evasive-transform-babel`

this replaces #1956 