### PR TITLE
fix(allow-scripts): fix issues with --skip-versions backward-compatibility

### DIFF
--- a/packages/allow-scripts/src/cli.js
+++ b/packages/allow-scripts/src/cli.js
@@ -24,7 +24,7 @@ async function start() {
   switch (command) {
     // (default) run scripts
     case 'run': {
-      await runAllowedPackages({ rootDir })
+      await runAllowedPackages({ rootDir, skipVersions })
       return
     }
     // automatically set configuration
@@ -35,7 +35,7 @@ async function start() {
     // list packages
     case 'list':
     case 'debug': {
-      await printPackagesList({ rootDir })
+      await printPackagesList({ rootDir, skipVersions })
       return
     }
     case 'setup': {

--- a/packages/allow-scripts/src/config.js
+++ b/packages/allow-scripts/src/config.js
@@ -15,8 +15,9 @@ const ROOT_CANONICAL_NAME = '$root$'
 
 /**
  * @param {Record<string, boolean>} allowConfig
+ * @param {boolean} [skipVersions] - Whether to skip versioning in patterns
  */
-const versionAwareMatcher = (allowConfig) => {
+const versionAwareMatcher = (allowConfig, skipVersions = false) => {
   const allowed = new Set(
     Object.entries(allowConfig)
       .filter(([, value]) => !!value)
@@ -30,7 +31,7 @@ const versionAwareMatcher = (allowConfig) => {
     const [name, version] = pattern.split('#')
     if (version) {
       knownPatternsWithVersion.add(pattern)
-    } else if (!value) {
+    } else if (!value || skipVersions) {
       knownNames.add(name)
     }
   }
@@ -53,14 +54,15 @@ const versionAwareMatcher = (allowConfig) => {
       )
     },
     /**
-     * Compares two allowlist patterns by version, returns true if the
-     * patternToCheck is the same version or lower than the patternAllowed
+     * Checks if a pattern is allowed. Takes versions into account unless
+     * specifically turned off.
      *
      * @param {string} patternToCheck
      * @returns {boolean}
      */
-    allowedWithVersion: (patternToCheck) => {
+    isAllowed: (patternToCheck) => {
       if (
+        !skipVersions &&
         patternToCheck !== ROOT_CANONICAL_NAME &&
         !patternToCheck.includes('#')
       ) {
@@ -193,10 +195,13 @@ async function loadAllPackageConfigurations({
   const lavamoatConfig = packageJson.lavamoat || {}
 
   const configs = {
-    lifecycle: indexLifecycleConfiguration({
-      packagesWithScripts: packagesWithScriptsLifecycle,
-      allowConfig: lavamoatConfig.allowScripts,
-    }),
+    lifecycle: indexLifecycleConfiguration(
+      {
+        packagesWithScripts: packagesWithScriptsLifecycle,
+        allowConfig: lavamoatConfig.allowScripts,
+      },
+      skipVersions
+    ),
     bin: indexBinsConfiguration({
       binCandidates,
       allowConfig: lavamoatConfig.allowBins,
@@ -339,7 +344,9 @@ async function setDefaultConfiguration({
   if (somePoliciesAreMissing && !changed) {
     // should not be possible
     console.log(
-      '\nSome packages with scripts are missing from the configuration, but no automatic migrations were applicable. You can run "allow-scripts auto" again to apply migrations after manually adding missing packages to the configuration.'
+      '\nSome packages with scripts are missing from the configuration, but no automatic migrations were applicable. You can run "allow-scripts auto" again to apply migrations after manually adding missing packages to the configuration.',
+      lifecycle.missingPolicies,
+      skipVersions
     )
   }
 
@@ -412,14 +419,18 @@ async function savePackageConfigurations({
  *   Partial<ScriptsConfig>,
  *   'packagesWithScripts'
  * >} config
+ * @param {boolean} [skipVersions] - Whether to skip versioning in patterns
  * @returns {ScriptsConfig}
  */
-function indexLifecycleConfiguration(config) {
+function indexLifecycleConfiguration(config, skipVersions = false) {
   config.allowConfig = config.allowConfig || {}
   // packages with config
   const configuredPatterns = Object.keys(config.allowConfig)
 
-  const { isCorrectlyConfigured } = versionAwareMatcher(config.allowConfig)
+  const { isCorrectlyConfigured } = versionAwareMatcher(
+    config.allowConfig,
+    skipVersions
+  )
   // select allowed + disallowed
   config.allowedPatterns = Object.entries(config.allowConfig)
     .filter(([, packageData]) => !!packageData)

--- a/packages/allow-scripts/src/report.js
+++ b/packages/allow-scripts/src/report.js
@@ -9,10 +9,10 @@ const { loadAllPackageConfigurations, applyMigrations } = require('./config.js')
  * @param {PrintPackagesListParams} params
  * @returns {Promise<void>}
  */
-async function printPackagesList({ rootDir }) {
+async function printPackagesList({ rootDir, skipVersions = false }) {
   const {
     configs: { bin, lifecycle },
-  } = await loadAllPackageConfigurations({ rootDir })
+  } = await loadAllPackageConfigurations({ rootDir, skipVersions })
 
   printPackagesByBins(bin)
   printPackagesByScriptConfiguration(lifecycle)

--- a/packages/allow-scripts/src/runAllowedPackages.js
+++ b/packages/allow-scripts/src/runAllowedPackages.js
@@ -17,11 +17,11 @@ const { FEATURE } = require('./toggles.js')
  * @param {RunAllowedPackagesParams} params
  * @returns {Promise<void>}
  */
-async function runAllowedPackages({ rootDir }) {
+async function runAllowedPackages({ rootDir, skipVersions }) {
   const {
     configs: { lifecycle, bin },
     somePoliciesAreMissing,
-  } = await loadAllPackageConfigurations({ rootDir })
+  } = await loadAllPackageConfigurations({ rootDir, skipVersions })
 
   if (somePoliciesAreMissing) {
     console.log(
@@ -37,7 +37,7 @@ async function runAllowedPackages({ rootDir }) {
     process.exit(1)
   }
 
-  const { allowedWithVersion } = versionAwareMatcher(lifecycle.allowConfig)
+  const { isAllowed } = versionAwareMatcher(lifecycle.allowConfig, skipVersions)
 
   if (FEATURE.bins && bin.allowConfig) {
     // Consider: Might as well delete entire .bin and recreate in case it was left there
@@ -59,7 +59,7 @@ async function runAllowedPackages({ rootDir }) {
     const allowedPackagesWithScriptsLifecycleScripts = Array.from(
       lifecycle.packagesWithScripts.entries()
     )
-      .filter(([pattern]) => allowedWithVersion(pattern))
+      .filter(([pattern]) => isAllowed(pattern))
       .flatMap(([, packages]) => packages)
 
     console.log('running lifecycle scripts for event "preinstall"')

--- a/packages/allow-scripts/src/types/common.ts
+++ b/packages/allow-scripts/src/types/common.ts
@@ -98,6 +98,7 @@ declare global {
   // runAllowedPackages.js
   export interface RunAllowedPackagesParams {
     rootDir: string
+    skipVersions?: boolean
   }
 
   export interface RunScriptParams {
@@ -108,6 +109,7 @@ declare global {
   // report.js
   export interface PrintPackagesListParams {
     rootDir: string
+    skipVersions?: boolean
   }
 
   export interface PrintMissingPoliciesIfAnyParams {

--- a/packages/allow-scripts/test/index.spec.js
+++ b/packages/allow-scripts/test/index.spec.js
@@ -441,7 +441,7 @@ test('cli - run command - version mismatch', (t) => {
 })
 
 test('cli - run command - versions skipped', (t) => {
-  const projectRoot = path.join(__dirname, 'projects', '5')
+  const projectRoot = path.join(__dirname, 'projects', 'skip_versions')
 
   // run the "run" command
   const result = run(t, ['run', '--skip-versions'], projectRoot)
@@ -451,7 +451,8 @@ test('cli - run command - versions skipped', (t) => {
     multilineTrim(result.stdout.toString()),
     multilineTrim(`
       running lifecycle scripts for event "preinstall"
-      - bbbb#1.0.99
+      - aaaa
+      - bbbb
       running lifecycle scripts for event "install"
       running lifecycle scripts for event "postinstall"
       running lifecycle scripts for top level package

--- a/packages/allow-scripts/test/prepare.js
+++ b/packages/allow-scripts/test/prepare.js
@@ -10,12 +10,14 @@ readdirSync(baseDir, { withFileTypes: true })
     (p) => p.isDirectory() && existsSync(join(baseDir, p.name, 'package.json'))
   )
   .forEach((dir) => {
+    console.log(`running "auto" command for project "${dir.name}"...`)
     execSync(
       [
         portableExecPath(process.execPath),
         normalize('../../../src/cli.js'),
         'auto',
         '--experimental-bins',
+        dir.name === 'skip_versions' ? '--skip-versions' : '',
       ].join(' '),
       {
         cwd: join(baseDir, dir.name),

--- a/packages/allow-scripts/test/projects/skip_versions/node_modules/aaaa/index.js
+++ b/packages/allow-scripts/test/projects/skip_versions/node_modules/aaaa/index.js
@@ -1,0 +1,1 @@
+console.log('ok')

--- a/packages/allow-scripts/test/projects/skip_versions/node_modules/aaaa/package.json
+++ b/packages/allow-scripts/test/projects/skip_versions/node_modules/aaaa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aaaa",
+  "version": "1.0.99",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "preinstall": "echo good NOT evil"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/allow-scripts/test/projects/skip_versions/node_modules/bbbb/index.js
+++ b/packages/allow-scripts/test/projects/skip_versions/node_modules/bbbb/index.js
@@ -1,0 +1,1 @@
+console.log('ok')

--- a/packages/allow-scripts/test/projects/skip_versions/node_modules/bbbb/package.json
+++ b/packages/allow-scripts/test/projects/skip_versions/node_modules/bbbb/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bbbb",
+  "version": "1.0.99",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "preinstall": "echo good NOT evil"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/allow-scripts/test/projects/skip_versions/package.json
+++ b/packages/allow-scripts/test/projects/skip_versions/package.json
@@ -13,9 +13,8 @@
   "devDependencies": {},
   "lavamoat": {
     "allowScripts": {
-      "bbbb#1.0.99": true,
-      "aaaa#1.0.0": true,
-      "aaaa#1.0.99": false
+      "aaaa": true,
+      "bbbb": true
     }
   }
 }


### PR DESCRIPTION
`--skip-versions` worked fine for `auto` but not for `run` command. 
The logic now makes sense - versions are consistently skipped.

closes: #1968