### PR TITLE
chore(ci): use staged publishing w/ release-please

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -25,11 +25,6 @@ runs:
       with:
         node-version-file: .nvmrc
         cache: npm
-    - name: Set npm version
-      run: |
-        corepack enable
-        npm --version
-      shell: ${{ inputs.shell }}
     - name: Install dependencies
       run: npm ci --foreground-scripts
       shell: ${{ inputs.shell }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,14 +6,93 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
-name: release-please
+name: Release & Publish
 
 jobs:
+  # Creates release PRs, and creates GitHub Releases once those PRs are merged.
   release-please:
+    name: Release Please
+    concurrency:
+      group: release-please-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
+    outputs:
+      # boolean indicating whether any releases were created
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      # JSON array of workspace paths that were released
+      paths_released: ${{ steps.release.outputs.paths_released }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        id: release
+
+  # If any releases were created in release-please, this job packs the released
+  # workspaces into tarballs and uploads them as artifacts.
+  pack:
+    name: Pack Released Workspaces
+    runs-on: ubuntu-latest
+    needs: release-please
+    concurrency:
+      group: pack-${{ github.ref }}
+      cancel-in-progress: false
+    outputs:
+      # JSON array of tarball filenames that were packed (relative to outdir)
+      files: ${{ steps.pack.outputs.files }}
+    if: needs.release-please.result == 'success' && needs.release-please.outputs.releases_created == 'true'
+    permissions: {}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/prepare
+        with:
+          node-version: 24.x
+      - run: npm run build
+      - id: pack
+        run: |
+          paths='${NEEDS_RELEASE_PLEASE_OUTPUTS_PATHS_RELEASED}'
+          outdir='${{ runner.temp }}/lavamoat-pack'
+          readarray -t workspace_args < <(jq -r '.[] | "--workspace=" + .' <<< "$paths")
+          echo "Packing workspaces: ${workspace_args[*]}"
+          pack_output=$(npm pack "${workspace_args[@]}" --pack-destination="$outdir" --json)
+          files=$(jq -c '[.[].filename]' <<< "$pack_output")
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          NEEDS_RELEASE_PLEASE_OUTPUTS_PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lavamoat-pack
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ runner.temp }}/lavamoat-pack
+
+  publish:
+    name: Publish Released Workspaces
+    runs-on: ubuntu-latest
+    needs: [release-please, pack]
+    permissions:
+      id-token: write
+    environment: npm
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    if: needs.pack.result == 'success' && needs.pack.outputs.files != '[]'
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lavamoat-pack
+          path: ${{ runner.temp }}/lavamoat-tarballs
+      - run: npm install -g 'npm@^11.15.0'
+      - run: |
+          files='${NEEDS_PACK_OUTPUTS_FILES}'
+          pkgdir='${{ runner.temp }}/lavamoat-tarballs'
+          while IFS= read -r filename; do
+            echo "Publishing $filename to staging registry..."
+            npm stage publish "$pkgdir/$filename" --provenance --ignore-scripts --access=public --registry=https://registry.npmjs.org
+          done < <(jq -r '.[]' <<< "$files")
+        shell: bash
+        env:
+          NEEDS_PACK_OUTPUTS_FILES: ${{ needs.pack.outputs.files }}


### PR DESCRIPTION
This modifies the `release-please` workflow to automatically publish a release to the staged registry.  Inspiration was taken from https://github.com/danielroe/uppt.

In a nutshell:

1. If the `release-please` job creates releases, they are stuffed into the job output. If it doesn't, the workflow ends.
2. If those releases are present and `release-please` succeeded, the `pack` job prepares the repo, builds, and packs all workspaces which were released.
3. The `pack` job then uploads the tarballs as an artifact. It outputs a list of the tarball filenames to be read by the `publish` job.
4. If `pack` succeeds, then the `publish` job runs, receiving the list of tarballs. It does _not_ install dependencies (though it must upgrade `npm`), but rather fetches the artifact uploaded by `pack`.
5. `publish` iterates through the list of tarballs and invokes a staged publish for each (with provenance).

Permissions are granted on a per-job basis. `release-please` needs to be able to write GitHub Releases and create PRs. `pack` doesn't need to do much of anything. `publish` needs `id-token` to enable a publish w/ provenance, as well as `environment: npm`.

Modified `prepare/action.yml` to omit `corepack`, since it no longer ships by default in latest Node.js. Replaced `--foreground-scripts` with `--ignore-scripts` just to be really damn sure.