### PR TITLE
Revert "chore: release main" 

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,16 +1,16 @@
 {
   "packages/aa": "5.0.1",
   "packages/allow-scripts": "5.0.2",
-  "packages/browserify": "20.0.5",
-  "packages/core": "18.0.4",
+  "packages/browserify": "20.0.4",
+  "packages/core": "18.0.3",
   "packages/git-safe-dependencies": "1.0.0",
-  "packages/lavapack": "8.0.4",
+  "packages/lavapack": "8.0.3",
   "packages/laverna": "2.1.0",
-  "packages/lavamoat-node": "11.1.3",
-  "packages/node": "1.0.5",
+  "packages/lavamoat-node": "11.1.2",
+  "packages/node": "1.0.4",
   "packages/preinstall-always-fail": "3.0.0",
   "packages/react-native-lockdown": "1.0.0",
-  "packages/tofu": "9.0.2",
-  "packages/webpack": "2.2.2",
+  "packages/tofu": "9.0.1",
+  "packages/webpack": "2.2.1",
   "packages/types": "1.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18845,17 +18845,17 @@
     },
     "packages/browserify": {
       "name": "lavamoat-browserify",
-      "version": "20.0.5",
+      "version": "20.0.4",
       "license": "MIT",
       "dependencies": {
         "@lavamoat/aa": "^5.0.1",
-        "@lavamoat/lavapack": "^8.0.4",
+        "@lavamoat/lavapack": "^8.0.3",
         "@lavamoat/sourcemap-validator": "2.1.1",
         "browser-resolve": "2.0.0",
         "concat-stream": "2.0.0",
         "convert-source-map": "2.0.0",
         "duplexify": "4.1.3",
-        "lavamoat-core": "^18.0.4",
+        "lavamoat-core": "^18.0.3",
         "pify": "5.0.0",
         "readable-stream": "4.7.0",
         "source-map": "0.7.4",
@@ -18865,7 +18865,7 @@
         "@babel/code-frame": "7.29.0",
         "browserify": "17.0.1",
         "keccak": "3.0.4",
-        "lavamoat": "11.1.3",
+        "lavamoat": "11.1.2",
         "source-map-explorer": "2.5.3",
         "tmp-promise": "3.0.3",
         "watchify": "4.0.0"
@@ -18876,13 +18876,13 @@
     },
     "packages/core": {
       "name": "lavamoat-core",
-      "version": "18.0.4",
+      "version": "18.0.3",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "7.29.0",
         "@lavamoat/types": "^1.0.1",
         "json-stable-stringify": "1.3.0",
-        "lavamoat-tofu": "^9.0.2",
+        "lavamoat-tofu": "^9.0.1",
         "ses": "1.15.0"
       },
       "bin": {
@@ -18915,7 +18915,7 @@
     },
     "packages/lavamoat-node": {
       "name": "lavamoat",
-      "version": "11.1.3",
+      "version": "11.1.2",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.29.0",
@@ -18924,8 +18924,8 @@
         "bindings": "1.5.0",
         "corepack": "0.34.6",
         "htmlescape": "1.1.1",
-        "lavamoat-core": "^18.0.4",
-        "lavamoat-tofu": "^9.0.2",
+        "lavamoat-core": "^18.0.3",
+        "lavamoat-tofu": "^9.0.1",
         "node-gyp-build": "4.8.4",
         "resolve": "1.22.12",
         "yargs": "17.7.2"
@@ -18940,14 +18940,14 @@
     },
     "packages/lavapack": {
       "name": "@lavamoat/lavapack",
-      "version": "8.0.4",
+      "version": "8.0.3",
       "license": "MIT",
       "dependencies": {
         "combine-source-map": "0.8.0",
         "espree": "9.6.1",
         "json-stable-stringify": "1.3.0",
         "JSONStream": "1.3.5",
-        "lavamoat-core": "^18.0.4",
+        "lavamoat-core": "^18.0.3",
         "readable-stream": "4.7.0",
         "through2": "4.0.2",
         "umd": "3.0.3"
@@ -19012,7 +19012,7 @@
     },
     "packages/node": {
       "name": "@lavamoat/node",
-      "version": "1.0.5",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.29.3",
@@ -19021,8 +19021,8 @@
         "@lavamoat/types": "^1.0.1",
         "@types/node": "20.19.39",
         "chalk": "4.1.2",
-        "lavamoat-core": "^18.0.4",
-        "lavamoat-tofu": "^9.0.2",
+        "lavamoat-core": "^18.0.3",
+        "lavamoat-tofu": "^9.0.1",
         "loggerr": "4.2.0",
         "ses": "1.15.0",
         "terminal-link": "3.0.0",
@@ -19101,7 +19101,7 @@
     },
     "packages/tofu": {
       "name": "lavamoat-tofu",
-      "version": "9.0.2",
+      "version": "9.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.29.3",
@@ -19118,7 +19118,7 @@
         "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
       },
       "peerDependencies": {
-        "lavamoat-core": ">18.0.4"
+        "lavamoat-core": ">15.4.0"
       }
     },
     "packages/types": {
@@ -19149,7 +19149,7 @@
     },
     "packages/webpack": {
       "name": "@lavamoat/webpack",
-      "version": "2.2.2",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "7.29.3",
@@ -19157,7 +19157,7 @@
         "@lavamoat/types": "^1.0.1",
         "browser-resolve": "2.0.0",
         "json-stable-stringify": "1.3.0",
-        "lavamoat-core": "^18.0.4",
+        "lavamoat-core": "^18.0.3",
         "ses": "1.15.0"
       },
       "devDependencies": {

--- a/packages/browserify/CHANGELOG.md
+++ b/packages/browserify/CHANGELOG.md
@@ -33,18 +33,6 @@
     * @lavamoat/lavapack bumped from ^6.1.1 to ^6.1.2
     * lavamoat-core bumped from ^15.2.0 to ^15.2.1
 
-## [20.0.5](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-browserify-v20.0.4...lavamoat-browserify-v20.0.5) (2026-05-28)
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @lavamoat/lavapack bumped from ^8.0.3 to ^8.0.4
-    * lavamoat-core bumped from ^18.0.3 to ^18.0.4
-  * devDependencies
-    * lavamoat bumped from 11.1.2 to 11.1.3
-
 ## [20.0.4](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-browserify-v20.0.3...lavamoat-browserify-v20.0.4) (2026-05-13)
 
 

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-browserify",
-  "version": "20.0.5",
+  "version": "20.0.4",
   "description": "browserify plugin for sandboxing dependencies with LavaMoat",
   "repository": {
     "type": "git",
@@ -34,13 +34,13 @@
   },
   "dependencies": {
     "@lavamoat/aa": "^5.0.1",
-    "@lavamoat/lavapack": "^8.0.4",
+    "@lavamoat/lavapack": "^8.0.3",
     "@lavamoat/sourcemap-validator": "2.1.1",
     "browser-resolve": "2.0.0",
     "concat-stream": "2.0.0",
     "convert-source-map": "2.0.0",
     "duplexify": "4.1.3",
-    "lavamoat-core": "^18.0.4",
+    "lavamoat-core": "^18.0.3",
     "pify": "5.0.0",
     "readable-stream": "4.7.0",
     "source-map": "0.7.4",
@@ -50,7 +50,7 @@
     "@babel/code-frame": "7.29.0",
     "browserify": "17.0.1",
     "keccak": "3.0.4",
-    "lavamoat": "11.1.3",
+    "lavamoat": "11.1.2",
     "source-map-explorer": "2.5.3",
     "tmp-promise": "3.0.3",
     "watchify": "4.0.0"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,20 +6,6 @@
   * dependencies
     * lavamoat-tofu bumped from ^7.2.1 to ^7.2.2
 
-## [18.0.4](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-core-v18.0.3...lavamoat-core-v18.0.4) (2026-05-28)
-
-
-### Bug Fixes
-
-* ensure internal sequence of specifier handling does not leak con… ([#1992](https://github.com/LavaMoat/LavaMoat/issues/1992)) ([6acf157](https://github.com/LavaMoat/LavaMoat/commit/6acf157cd43d2855d6d9250c507bda40225e5dab))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * lavamoat-tofu bumped from ^9.0.1 to ^9.0.2
-
 ## [18.0.3](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-core-v18.0.2...lavamoat-core-v18.0.3) (2026-05-13)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-core",
-  "version": "18.0.4",
+  "version": "18.0.3",
   "description": "LavaMoat kernel and utils",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "@babel/types": "7.29.0",
     "@lavamoat/types": "^1.0.1",
     "json-stable-stringify": "1.3.0",
-    "lavamoat-tofu": "^9.0.2",
+    "lavamoat-tofu": "^9.0.1",
     "ses": "1.15.0"
   },
   "devDependencies": {

--- a/packages/lavamoat-node/CHANGELOG.md
+++ b/packages/lavamoat-node/CHANGELOG.md
@@ -19,21 +19,6 @@
     * lavamoat-core bumped from ^15.2.0 to ^15.2.1
     * lavamoat-tofu bumped from ^7.2.1 to ^7.2.2
 
-## [11.1.3](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-v11.1.2...lavamoat-v11.1.3) (2026-05-28)
-
-
-### Bug Fixes
-
-* **lavamoat-node:** fix old resolution bug where paths containing # were misinterpreted ([#1971](https://github.com/LavaMoat/LavaMoat/issues/1971)) ([494f852](https://github.com/LavaMoat/LavaMoat/commit/494f85238577bb3ced97ee1c08a412f0f9a13873))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * lavamoat-core bumped from ^18.0.3 to ^18.0.4
-    * lavamoat-tofu bumped from ^9.0.1 to ^9.0.2
-
 ## [11.1.2](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-v11.1.1...lavamoat-v11.1.2) (2026-05-13)
 
 

--- a/packages/lavamoat-node/package.json
+++ b/packages/lavamoat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat",
-  "version": "11.1.3",
+  "version": "11.1.2",
   "description": "",
   "repository": {
     "type": "git",
@@ -45,8 +45,8 @@
     "bindings": "1.5.0",
     "corepack": "0.34.6",
     "htmlescape": "1.1.1",
-    "lavamoat-core": "^18.0.4",
-    "lavamoat-tofu": "^9.0.2",
+    "lavamoat-core": "^18.0.3",
+    "lavamoat-tofu": "^9.0.1",
     "node-gyp-build": "4.8.4",
     "resolve": "1.22.12",
     "yargs": "17.7.2"

--- a/packages/lavapack/CHANGELOG.md
+++ b/packages/lavapack/CHANGELOG.md
@@ -24,15 +24,6 @@
   * dependencies
     * lavamoat-core bumped from ^15.2.0 to ^15.2.1
 
-## [8.0.4](https://github.com/LavaMoat/LavaMoat/compare/lavapack-v8.0.3...lavapack-v8.0.4) (2026-05-28)
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * lavamoat-core bumped from ^18.0.3 to ^18.0.4
-
 ## [8.0.3](https://github.com/LavaMoat/LavaMoat/compare/lavapack-v8.0.2...lavapack-v8.0.3) (2026-05-13)
 
 

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/lavapack",
-  "version": "8.0.4",
+  "version": "8.0.3",
   "description": "LavaMoat packer",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "combine-source-map": "0.8.0",
     "espree": "9.6.1",
     "json-stable-stringify": "1.3.0",
-    "lavamoat-core": "^18.0.4",
+    "lavamoat-core": "^18.0.3",
     "readable-stream": "4.7.0",
     "through2": "4.0.2",
     "umd": "3.0.3"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## [1.0.5](https://github.com/LavaMoat/LavaMoat/compare/node-v1.0.4...node-v1.0.5) (2026-05-28)
-
-
-### Bug Fixes
-
-* **deps:** update babel monorepo ([#1982](https://github.com/LavaMoat/LavaMoat/issues/1982)) ([5b375cb](https://github.com/LavaMoat/LavaMoat/commit/5b375cb85d85bc3e37962eae5836b67de9ed474c))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * lavamoat-core bumped from ^18.0.3 to ^18.0.4
-    * lavamoat-tofu bumped from ^9.0.1 to ^9.0.2
-
 ## [1.0.4](https://github.com/LavaMoat/LavaMoat/compare/node-v1.0.3...node-v1.0.4) (2026-05-13)
 
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/node",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "type": "module",
   "description": "Next-gen LavaMoat for Node.js",
   "repository": {
@@ -61,8 +61,8 @@
     "@lavamoat/types": "^1.0.1",
     "@types/node": "20.19.39",
     "chalk": "4.1.2",
-    "lavamoat-core": "^18.0.4",
-    "lavamoat-tofu": "^9.0.2",
+    "lavamoat-core": "^18.0.3",
+    "lavamoat-tofu": "^9.0.1",
     "loggerr": "4.2.0",
     "ses": "1.15.0",
     "terminal-link": "3.0.0",

--- a/packages/tofu/CHANGELOG.md
+++ b/packages/tofu/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [9.0.2](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-tofu-v9.0.1...lavamoat-tofu-v9.0.2) (2026-05-28)
-
-
-### Bug Fixes
-
-* **deps:** update babel monorepo ([#1982](https://github.com/LavaMoat/LavaMoat/issues/1982)) ([5b375cb](https://github.com/LavaMoat/LavaMoat/commit/5b375cb85d85bc3e37962eae5836b67de9ed474c))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * peerDependencies
-    * lavamoat-core bumped from >15.4.0 to >18.0.4
-
 ## [9.0.1](https://github.com/LavaMoat/LavaMoat/compare/lavamoat-tofu-v9.0.0...lavamoat-tofu-v9.0.1) (2026-04-15)
 
 

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavamoat-tofu",
-  "version": "9.0.2",
+  "version": "9.0.1",
   "description": "This is the TOFU (trust-on-first-use) static analysis tool used by LavaMoat to automatically generate useable config",
   "repository": {
     "type": "git",

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -18,20 +18,6 @@
   * dependencies
     * lavamoat-core bumped from ^15.2.0 to ^15.2.1
 
-## [2.2.2](https://github.com/LavaMoat/LavaMoat/compare/webpack-v2.2.1...webpack-v2.2.2) (2026-05-28)
-
-
-### Bug Fixes
-
-* **deps:** update babel monorepo ([#1982](https://github.com/LavaMoat/LavaMoat/issues/1982)) ([5b375cb](https://github.com/LavaMoat/LavaMoat/commit/5b375cb85d85bc3e37962eae5836b67de9ed474c))
-
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * lavamoat-core bumped from ^18.0.3 to ^18.0.4
-
 ## [2.2.1](https://github.com/LavaMoat/LavaMoat/compare/webpack-v2.2.0...webpack-v2.2.1) (2026-05-13)
 
 

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lavamoat/webpack",
-  "version": "2.2.2",
+  "version": "2.2.1",
   "description": "LavaMoat Webpack plugin for running dependencies in Compartments without eval",
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
     "@lavamoat/types": "^1.0.1",
     "browser-resolve": "2.0.0",
     "json-stable-stringify": "1.3.0",
-    "lavamoat-core": "^18.0.4",
+    "lavamoat-core": "^18.0.3",
     "ses": "1.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts LavaMoat/LavaMoat#1979
so we can re-trigger the publishing workflow from scratch after a fix