### PR TITLE
fix(webpack): stabilize runtime lookup data

### DIFF
--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -41,6 +41,57 @@ class VirtualRuntimeModule extends RuntimeModule {
   }
 }
 
+/**
+ * Compare runtime IDs in a stable way without changing their types.
+ *
+ * @param {string | number} a
+ * @param {string | number} b
+ * @returns {number}
+ */
+const compareIds = (a, b) => {
+  const typeA = typeof a
+  const typeB = typeof b
+  if (typeA !== typeB) {
+    return typeA < typeB ? -1 : 1
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b
+  }
+  const stringA = String(a)
+  const stringB = String(b)
+  if (stringA < stringB) {
+    return -1
+  }
+  if (stringA > stringB) {
+    return 1
+  }
+  return 0
+}
+
+/**
+ * @template {string | number} T
+ * @param {T[]} ids
+ * @returns {T[]}
+ */
+const sortedIds = (ids) => [...ids].sort(compareIds)
+
+/**
+ * @param {[string, (string | number)[]][]} identifiersForModuleIds
+ * @returns {[string, (string | number)[]][]}
+ */
+const sortedIdentifierMap = (identifiersForModuleIds) =>
+  identifiersForModuleIds
+    .map(
+      ([resourceId, moduleIds]) =>
+        /** @type {[string, (string | number)[]]} */ ([
+          resourceId,
+          sortedIds(moduleIds),
+        ])
+    )
+    .sort(([resourceIdA], [resourceIdB]) =>
+      compareIds(resourceIdA, resourceIdB)
+    )
+
 /** @import {LavaMoatPluginOptions, LavaMoatChunkRuntimeConfiguration} from '../buildtime/types' */
 /** @import {LavaMoatPolicy} from '@lavamoat/types' */
 /** @import {RuntimeFragment} from './assemble.js' */
@@ -190,7 +241,7 @@ const LOCKDOWN_SHIMS = [];`
         // a mapping used to look up resource ids by module id
         {
           name: 'idmap',
-          data: identifiersForModuleIds,
+          data: sortedIdentifierMap(identifiersForModuleIds),
           json: true,
         },
         // list of ids of modules to skip in policy enforcement
@@ -208,7 +259,7 @@ const LOCKDOWN_SHIMS = [];`
         // known chunk ids
         {
           name: 'kch',
-          data: chunkIds,
+          data: sortedIds(chunkIds),
           json: true,
         },
         // a record of module ids that are externals and need to be enforced as builtins

--- a/packages/webpack/test/runtimeBuilder.spec.js
+++ b/packages/webpack/test/runtimeBuilder.spec.js
@@ -1,0 +1,64 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { runtimeBuilder } = require('../src/runtime/runtimeBuilder.js')
+
+/**
+ * @param {Object} params
+ * @param {(string | number)[]} params.chunkIds
+ * @param {{
+ *   root: string
+ *   identifiersForModuleIds: [string, (string | number)[]][]
+ *   unenforceableModuleIds: (string | number)[]
+ *   contextModuleIds: (string | number)[]
+ *   externals: Record<string | number, string>
+ * }} params.identifiers
+ * @returns {string}
+ */
+const getRuntimeSource = ({ chunkIds, identifiers }) => {
+  const { getLavaMoatRuntimeModules } = runtimeBuilder({
+    options: { skipRepairs: true },
+  })
+  const runtimeModules = getLavaMoatRuntimeModules({
+    PROGRESS: { report() {} },
+    currentChunk: { name: 'runtime' },
+    chunkIds,
+    policyData: { resources: {} },
+    identifiers,
+    chunkLoaderName: 'webpackChunk',
+  })
+
+  return runtimeModules.find(({ name }) => name === 'LavaMoat/runtime')
+    .virtualSource
+}
+
+test('runtimeBuilder emits module and chunk lookup data deterministically', (t) => {
+  const commonIdentifiers = {
+    root: '$root$',
+    unenforceableModuleIds: ['u2', 1, 'u1'],
+    contextModuleIds: [9, 'ctx', 2],
+    externals: { z: 'z-ext', a: 'a-ext' },
+  }
+
+  const firstRuntimeSource = getRuntimeSource({
+    chunkIds: [20, 3, 'vendor', 'app'],
+    identifiers: {
+      ...commonIdentifiers,
+      identifiersForModuleIds: [
+        ['b', [20, 3]],
+        ['a', ['z', 'a']],
+      ],
+    },
+  })
+
+  const secondRuntimeSource = getRuntimeSource({
+    chunkIds: ['app', 'vendor', 3, 20],
+    identifiers: {
+      ...commonIdentifiers,
+      identifiersForModuleIds: [
+        ['a', ['a', 'z']],
+        ['b', [3, 20]],
+      ],
+    },
+  })
+
+  t.is(firstRuntimeSource, secondRuntimeSource)
+})


### PR DESCRIPTION
## Summary

Stabilizes the `@lavamoat/webpack` runtime data that is serialized into emitted bundles for module/resource lookup and chunk validation.

The plugin currently embeds `idmap` and `kch` in the runtime using the order supplied by webpack/build-time traversal. Those values are runtime lookup tables, so their order does not affect behavior, but it does affect emitted bundle bytes. This sorts only those two lookup structures at the serialization boundary:

- `idmap`, including each resource's module ID list
- `kch` known chunk IDs

The patch intentionally leaves `unenforceable`, `ctxm`, and `externals` unchanged because they are not part of the observed local nondeterminism this fix targets.

## Validation

- `npm run build`
- `npm run --workspace=packages/webpack test` (96 tests passed)
- `npm run lint` (passed with existing warnings)
