### PR TITLE
fix(webpack): make runtime emission deterministic for reproducible builds

### DIFF
--- a/packages/webpack/src/buildtime/aa.js
+++ b/packages/webpack/src/buildtime/aa.js
@@ -143,16 +143,36 @@ exports.generateIdentifierLookup = ({
 
   crossReference(identifiersWithKnownPaths, usedIdentifiers)
 
-  const identifiersForModuleIds = Object.entries(
-    Object.entries(pathLookup).reduce((acc, [, { aa, moduleIds }]) => {
+  // Module/chunk ids may be numbers or strings; compare them numerically so
+  // the resulting order is stable and independent of insertion order.
+  const byId = (a, b) =>
+    String(a).localeCompare(String(b), 'en', { numeric: true })
+
+  const grouped = Object.entries(pathLookup).reduce(
+    (acc, [, { aa, moduleIds }]) => {
       const key = translate(aa)
       if (acc[key] === undefined) {
         acc[key] = []
       }
       acc[key].push(...moduleIds)
       return acc
-    }, /** @type {Record<string, (string | number)[]>} */ ({}))
+    },
+    /** @type {Record<string, (string | number)[]>} */ ({})
   )
+
+  // Sort entries by resource key and module ids within each entry. The source
+  // data is collected by iterating webpack's `compilation.chunks` Set, whose
+  // iteration order is not stable between builds; sorting here keeps the
+  // emitted runtime (LAVAMOAT.idmap) byte-for-byte reproducible.
+  const identifiersForModuleIds = Object.entries(grouped)
+    .map(
+      ([key, moduleIds]) =>
+        /** @type {[string, (string | number)[]]} */ ([
+          key,
+          [...moduleIds].sort(byId),
+        ])
+    )
+    .sort(([a], [b]) => byId(a, b))
 
   /**
    * TODO: use real policy type here

--- a/packages/webpack/src/plugin.js
+++ b/packages/webpack/src/plugin.js
@@ -427,13 +427,24 @@ class LavaMoatPlugin {
               }
             })
 
+            // These lists are derived by iterating webpack's
+            // `compilation.chunks` Set, whose iteration order is not stable
+            // between builds. Sort every module/chunk id list emitted into the
+            // runtime so the output is byte-for-byte reproducible. Module/chunk
+            // ids may be numbers or strings, so compare them numerically.
+            const byId = (a, b) =>
+              String(a).localeCompare(String(b), 'en', { numeric: true })
+
             STORE.root = identifierLookup.root
             STORE.identifiersForModuleIds =
               identifierLookup.identifiersForModuleIds
-            STORE.unenforceableModuleIds = moduleData.unenforceableModuleIds
-            STORE.contextModuleIds = moduleData.contextModules.map(
-              ({ moduleId }) => moduleId
-            )
+            STORE.chunkIds = [...STORE.chunkIds].sort(byId)
+            STORE.unenforceableModuleIds = [
+              ...moduleData.unenforceableModuleIds,
+            ].sort(byId)
+            STORE.contextModuleIds = moduleData.contextModules
+              .map(({ moduleId }) => moduleId)
+              .sort(byId)
             STORE.externals = moduleData.externals
             // narrow down the policy and map to module identifiers
             // TODO: theoretically policy could be optimized per chunk, but configuring webpack to emit a runtime chunk or have separate builds seems better for most usecases.

--- a/packages/webpack/test/aa.spec.js
+++ b/packages/webpack/test/aa.spec.js
@@ -99,3 +99,48 @@ test('aa - generateIdentifierLookup translates and narrows the policy', (t) => {
   t.is(Object.keys(translatedPolicy.resources).length, 3)
   t.snapshot(translatedPolicy.resources)
 })
+
+test('aa - identifiersForModuleIds is sorted', (t) => {
+  const { identifiersForModuleIds } = generateIdentifierLookup({
+    ...lookupFixture,
+    readableResourceIds: true,
+  })
+
+  // Entries must be sorted by resource key.
+  const keys = identifiersForModuleIds.map(([key]) => key)
+  t.deepEqual(
+    keys,
+    [...keys].sort((a, b) =>
+      String(a).localeCompare(String(b), 'en', { numeric: true })
+    )
+  )
+
+  // Module ids within each entry must be sorted.
+  for (const [, moduleIds] of identifiersForModuleIds) {
+    t.deepEqual(
+      moduleIds,
+      [...moduleIds].sort((a, b) =>
+        String(a).localeCompare(String(b), 'en', { numeric: true })
+      )
+    )
+  }
+})
+
+test('aa - identifiersForModuleIds is independent of input order', (t) => {
+  const ordered = generateIdentifierLookup({
+    ...lookupFixture,
+    readableResourceIds: true,
+  }).identifiersForModuleIds
+
+  // Reversing the order of the input paths must not change the output. The
+  // real plugin collects these by iterating webpack's `compilation.chunks`
+  // Set, whose order is not stable between builds; the lookup must normalize
+  // it so the emitted runtime is reproducible.
+  const shuffled = generateIdentifierLookup({
+    ...lookupFixture,
+    paths: [...lookupFixture.paths].reverse(),
+    readableResourceIds: true,
+  }).identifiersForModuleIds
+
+  t.deepEqual(shuffled, ordered)
+})


### PR DESCRIPTION
## Problem

Rebuilding the same source with `@lavamoat/webpack` produces a **different `runtime.js` (and the HTML/content-scripts that reference it) intermittently** — roughly a coin-flip in our testing (we observed several distinct `runtime.js` hashes for the same input). Every real code chunk is byte-identical every build; only LavaMoat's runtime metadata reshuffles.

This breaks **byte-for-byte build verification**. Concretely, it blocks Firefox Add-ons (AMO) reviewers (and our own release verification) from reproducing the published MetaMask extension from source, since reproduction requires an exact match.

## Root cause

The id lists emitted into the LavaMoat runtime are collected by iterating webpack's `compilation.chunks` — a `Set` whose iteration order is **not stable between builds** — and are serialized **without sorting**:

- `idmap` (`identifiersForModuleIds`) — `packages/webpack/src/buildtime/aa.js`. Both the entry order and the module-id order within each entry follow the chunk-Set order.
- `chunkIds` (`kch`), `unenforceableModuleIds`, `contextModuleIds` (`ctxm`) — `packages/webpack/src/plugin.js`, collected in the same `afterOptimizeChunkIds` pass.

## Fix

Sort these id lists before emitting them:

- **`aa.js`** — sort `identifiersForModuleIds` entries by resource key, and module ids within each entry.
- **`plugin.js`** — sort `chunkIds`, `unenforceableModuleIds`, and `contextModuleIds`.

Ids may be numbers or strings, so they're compared numerically (`localeCompare(..., { numeric: true })`). Runtime lookups against these structures are membership tests, so reordering is functionally safe — it only normalizes serialization order.

## Tests

- Added regression tests in `packages/webpack/test/aa.spec.js`:
  - `identifiersForModuleIds` is sorted (entries + within-entry).
  - `identifiersForModuleIds` is **independent of input order** (reversing the input paths yields identical output) — this is the key guard and fails without the fix.
- Full `@lavamoat/webpack` suite passes locally (97/97), with no snapshot changes.

## Note

This makes builds deterministic going forward. It does **not** retroactively match artifacts already published with the previous non-deterministic ordering — reproducibility applies once a release ships with this change.