### PR TITLE
feat(run): add @lavamoat/run, a secure npx replacement

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,6 +10,7 @@
   "packages/node": "1.0.6",
   "packages/preinstall-always-fail": "3.0.0",
   "packages/react-native-lockdown": "1.0.0",
+  "packages/run": "0.0.0",
   "packages/tofu": "9.0.2",
   "packages/webpack": "2.2.3",
   "packages/types": "1.0.1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ npm run --workspace=packages/tofu test
 
 - `packages/core/` - Core LavaMoat runtime and policy generation
 - `packages/node/` - Node.js CLI tool for policy generation and execution
+- `packages/run/` - Secure `npx` replacement (`lavax`): fetch & run a package's bin with install scripts disabled and a per-package SES policy enforced
 - `packages/lavamoat-node/` - Legacy Node.js runtime protection
 - `packages/allow-scripts/` - Dependency install script management
 - `packages/browserify/` - Browserify integration plugin

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In order to help mitigate the risk of such an attack we are building a suite of 
 1. disable/allow dependency lifecycle scripts (eg. "postinstall") via [@lavamoat/allow-scripts][LavamoatAllowScripts]
 2. run your server or build process in [lavamoat-node][LavamoatNode]
 3. build your ui with LavaMoat for [Browserify][LavamoatBrowserify]
+4. fetch and run one-off / untrusted packages safely (an `npx` replacement) with [@lavamoat/run][LavamoatRun]
 
 Even starting with adding just step 1 - the allow-scripts is a great improvement to your supply chain security.
 
@@ -111,3 +112,4 @@ Runs on [Agoric](https://github.com/agoric/)
 [LavamoatNode]: ./packages/lavamoat-node
 [LavamoatBrowserify]: ./packages/browserify
 [LavamoatAllowScripts]: ./packages/allow-scripts
+[LavamoatRun]: ./packages/run

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -309,6 +309,7 @@ export default defineConfig(
   ...typedPackageConfigs('laverna'),
   ...typedPackageConfigs('node'),
   ...typedPackageConfigs('react-native-lockdown'),
+  ...typedPackageConfigs('run'),
   ...typedPackageConfigs('tofu', { dirs: ['src'] }),
   ...typedPackageConfigs('types'),
   ...typedPackageConfigs('vog'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -3102,6 +3102,10 @@
       "resolved": "packages/react-native-lockdown",
       "link": true
     },
+    "node_modules/@lavamoat/run": {
+      "resolved": "packages/run",
+      "link": true
+    },
     "node_modules/@lavamoat/sourcemap-validator": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@lavamoat/sourcemap-validator/-/sourcemap-validator-2.1.1.tgz",
@@ -19171,6 +19175,25 @@
       },
       "peerDependencies": {
         "@react-native/js-polyfills": "*"
+      }
+    },
+    "packages/run": {
+      "name": "@lavamoat/run",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lavamoat/node": "^1.0.6",
+        "@types/node": "20.19.41",
+        "loggerr": "4.2.0",
+        "type-fest": "4.41.0",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "lavax": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "packages/tofu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19183,6 +19183,7 @@
       "license": "MIT",
       "dependencies": {
         "@lavamoat/node": "^1.0.6",
+        "@lavamoat/types": "^1.0.1",
         "@types/node": "20.19.41",
         "loggerr": "4.2.0",
         "type-fest": "4.41.0",

--- a/packages/run/.depcheckrc.yml
+++ b/packages/run/.depcheckrc.yml
@@ -4,3 +4,5 @@ ignores:
 
   # types-only
   - 'type-fest'
+  # types-only (referenced from JSDoc `@import`, which depcheck cannot see)
+  - '@lavamoat/types'

--- a/packages/run/.depcheckrc.yml
+++ b/packages/run/.depcheckrc.yml
@@ -1,0 +1,6 @@
+ignores:
+  # test runner (resolved from monorepo root)
+  - 'ava'
+
+  # types-only
+  - 'type-fest'

--- a/packages/run/CHANGELOG.md
+++ b/packages/run/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/packages/run/LICENSE
+++ b/packages/run/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Consensys Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -1,0 +1,133 @@
+# @lavamoat/run
+
+> Warning: This software is _alpha_ quality. Expect bugs and breaking changes!
+
+**A secure replacement for `npx`.**
+
+`npx <pkg>` will happily download an arbitrary package from the registry and
+execute it on your machine with **full ambient authority** — and it runs the
+package's lifecycle (install) scripts _the instant it is fetched_, before any
+of its code is even invoked. This is one of the most direct software
+supply-chain attack vectors in the JavaScript ecosystem.
+
+`lavax` (the bin shipped by `@lavamoat/run`) does the same job — fetch a package
+and run its bin — but applies [LavaMoat][]'s security principles:
+
+1. **Install scripts are disabled by default.** Packages are installed with
+   `--ignore-scripts` (the same protection as
+   [`@lavamoat/allow-scripts`][allow-scripts]), so `preinstall`/`install`/
+   `postinstall` code never runs. Opt back in per-invocation with
+   `--allow-scripts`.
+2. **The bin runs inside [Hardened JavaScript][] (SES `lockdown()`).** The
+   fetched code cannot tamper with shared intrinsics (`Object`, `Array`,
+   `Promise`, …), neutralizing most prototype-pollution attacks.
+3. **Per-package least authority.** Execution is delegated to
+   [`@lavamoat/node`][node]. A LavaMoat policy is generated on first use and
+   enforced on every run: each package only gets the globals and builtins it
+   actually needs. The fetched package is always treated as an **untrusted
+   root**.
+4. **Isolation & transparency.** Packages are installed into a per-spec sandbox
+   under a cache directory (never your project), and the generated policy is
+   written there for you to review.
+
+## Installation
+
+`@lavamoat/run` requires Node.js v20.19.0 or newer.
+
+```sh
+npm install -g @lavamoat/run
+```
+
+## Usage
+
+```text
+lavax [options] <spec> [args..]
+```
+
+Everything after `<spec>` is forwarded verbatim to the package's bin — exactly
+like `npx`:
+
+```sh
+# fetch & run "cowsay", forwarding `Hello!` to it
+lavax cowsay Hello!
+
+# pin a version
+lavax cowsay@1.5.0 Moo
+
+# scoped package, choosing a specific bin
+lavax --call some-bin @scope/tool --flag value
+
+# run a local package by path
+lavax ./my-cli --some-flag
+```
+
+On the first run of a given spec, `lavax` will:
+
+1. install the package into a sandbox (scripts disabled),
+2. generate a LavaMoat policy for its bin,
+3. run the bin under SES with that policy enforced.
+
+Subsequent runs of the same spec reuse the cached install and policy.
+
+### Options
+
+| Option              | Description                                                                |
+| ------------------- | -------------------------------------------------------------------------- |
+| `-c, --call <name>` | Bin name to run when the package exposes more than one                     |
+| `--allow-scripts`   | **DANGEROUS:** allow lifecycle (install) scripts to run during install     |
+| `--regenerate`      | Regenerate the policy instead of reusing the cached one                    |
+| `--force`           | Reinstall the package even if a cached install exists                      |
+| `--dev`             | Include dev dependencies / use the `development` condition                 |
+| `--registry <url>`  | npm registry URL to install from                                           |
+| `--cache <dir>`     | Cache base directory (default: `$LAVAMOAT_RUN_CACHE` or `~/.lavamoat/run`) |
+| `-p, --policy <p>`  | Path to a policy file (default: within the cache directory)                |
+| `--verbose`         | Enable verbose logging                                                     |
+| `--quiet`           | Disable all but error logging                                              |
+
+### Environment variables
+
+- `LAVAMOAT_RUN_CACHE` — overrides the cache base directory.
+- `LAVAMOAT_DEBUG` — enables debug logging (as in `@lavamoat/node`).
+
+## How it relates to other LavaMoat tools
+
+`@lavamoat/run` is glue: it combines the protections of
+[`@lavamoat/allow-scripts`][allow-scripts] (no install scripts) and
+[`@lavamoat/node`][node] (SES + per-package policy) into a single
+`npx`-shaped command for **ad-hoc execution of packages you don't necessarily
+trust.**
+
+## Programmatic API
+
+```js
+import { lavax } from '@lavamoat/run'
+
+await lavax('cowsay', ['Hello!'], { quiet: true })
+```
+
+> Importing `@lavamoat/run` imports `@lavamoat/node`, which calls SES
+> `lockdown()`. If you only need the pure helpers (e.g. `parseSpec`), import the
+> relevant submodule directly to avoid `lockdown()`.
+
+## Known limitations
+
+`@lavamoat/run` inherits the capabilities — and the rough edges — of
+`@lavamoat/node` (which is itself _alpha_):
+
+- Some packages perform dynamic `require()`s or mutate primordials and will
+  need a hand-written [policy override][policy-guide] to run. The generated
+  policy is only a starting point.
+- Packages relying on native addons typically need `--allow-scripts` (which
+  disables a core protection — use only for packages you trust).
+- The policy is generated via static analysis ("trust on first use"); review it
+  in the sandbox's `lavamoat/node/policy.json` before relying on it.
+
+## License
+
+©️ 2024 Consensys Software. Licensed MIT
+
+[LavaMoat]: https://github.com/LavaMoat/LavaMoat
+[Hardened JavaScript]: https://hardenedjs.org
+[node]: https://github.com/LavaMoat/LavaMoat/tree/main/packages/node
+[allow-scripts]: https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts
+[policy-guide]: https://lavamoat.github.io/guides/policy/

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -121,6 +121,14 @@ await lavax('cowsay', ['Hello!'], { quiet: true })
   disables a core protection — use only for packages you trust).
 - The policy is generated via static analysis ("trust on first use"); review it
   in the sandbox's `lavamoat/node/policy.json` before relying on it.
+- The bin is loaded as a JavaScript module under `@lavamoat/node`. Packages
+  whose bin is a non-JavaScript script (a shell script, Python, etc. — legal in
+  npm via the shebang) cannot be run this way.
+- A spec is **pinned on first use**: a mutable spec (`pkg@latest`, a git branch,
+  or a local path) reuses the first install and the first generated policy
+  until you re-fetch with `--force` (and `--regenerate` for the policy). This is
+  the trade-off of the cache; pin an exact version when you need freshness.
+- `--registry` must be an `http(s)` URL.
 
 ## License
 

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -42,10 +42,12 @@
   "scripts": {
     "lint:deps": "depcheck",
     "test": "npm run test:run",
+    "test:cover": "c8 --check-coverage ava",
     "test:run": "ava"
   },
   "dependencies": {
     "@lavamoat/node": "^1.0.6",
+    "@lavamoat/types": "^1.0.1",
     "@types/node": "20.19.41",
     "loggerr": "4.2.0",
     "type-fest": "4.41.0",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@lavamoat/run",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "A secure npx replacement: fetch and run a package's bin under LavaMoat (install scripts disabled, per-package SES policy enforced)",
+  "repository": {
+    "directory": "packages/run",
+    "type": "git",
+    "url": "git+https://github.com/LavaMoat/LavaMoat.git"
+  },
+  "homepage": "https://lavamoat.github.io",
+  "bugs": "https://github.com/LavaMoat/LavaMoat/issues",
+  "author": "LavaMoat Project",
+  "license": "MIT",
+  "engines": {
+    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "npm": ">=9.0.0"
+  },
+  "bin": {
+    "lavax": "src/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "types": "./types/src/index.d.ts"
+    },
+    "./cli": {
+      "import": "./src/cli.js",
+      "types": "./types/src/cli.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "src",
+    "types",
+    "!*.tsbuildinfo"
+  ],
+  "scripts": {
+    "lint:deps": "depcheck",
+    "test": "npm run test:run",
+    "test:run": "ava"
+  },
+  "dependencies": {
+    "@lavamoat/node": "^1.0.6",
+    "@types/node": "20.19.41",
+    "loggerr": "4.2.0",
+    "type-fest": "4.41.0",
+    "yargs": "17.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/*.spec.js"
+    ],
+    "timeout": "60s"
+  }
+}

--- a/packages/run/src/args.js
+++ b/packages/run/src/args.js
@@ -1,0 +1,85 @@
+/**
+ * Splits a raw argument vector into `lavax`'s own options, the package spec,
+ * and the arguments to forward to the package's bin.
+ *
+ * `lavax` follows the same contract as `npx`: every token after the `<spec>`
+ * positional belongs to the package's bin, _not_ to `lavax`. This cannot be
+ * expressed with yargs' option parser alone (separate-token option values
+ * conflict with `halt-at-non-option`), so we split first and hand yargs only
+ * the leading options plus the spec.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * `lavax` options which consume a following token as their value when written
+ * in separate-token form (e.g. `--cache /tmp/x`).
+ */
+const VALUE_OPTIONS = new Set([
+  '-c',
+  '--call',
+  '--registry',
+  '--cache',
+  '-p',
+  '--policy',
+])
+
+/**
+ * The result of {@link splitArgs}.
+ *
+ * @typedef SplitArgs
+ * @property {string[]} optionTokens Tokens that are `lavax`'s own options
+ * @property {string | undefined} spec The package spec, if present
+ * @property {string[]} forwardedArgs Arguments to forward to the bin
+ */
+
+/**
+ * Splits `argv` at the package spec.
+ *
+ * @param {string[]} argv Argument vector (already stripped of `node` and the
+ *   script path)
+ * @returns {SplitArgs}
+ */
+export const splitArgs = (argv) => {
+  /** @type {string[]} */
+  const optionTokens = []
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]
+
+    // An explicit `--` ends option parsing: the next token is the spec and the
+    // remainder is forwarded verbatim.
+    if (token === '--') {
+      return {
+        optionTokens,
+        spec: argv[i + 1],
+        forwardedArgs: argv.slice(i + 2),
+      }
+    }
+
+    if (token.startsWith('-')) {
+      optionTokens.push(token)
+      const next = argv[i + 1]
+      if (
+        VALUE_OPTIONS.has(token) &&
+        next !== undefined &&
+        !next.startsWith('-')
+      ) {
+        optionTokens.push(next)
+        i++
+      }
+      continue
+    }
+
+    // First non-option token is the spec; everything after is forwarded.
+    let forwardedArgs = argv.slice(i + 1)
+    if (forwardedArgs[0] === '--') {
+      forwardedArgs = forwardedArgs.slice(1)
+    }
+    return { optionTokens, spec: token, forwardedArgs }
+  }
+
+  return { optionTokens, spec: undefined, forwardedArgs: [] }
+}

--- a/packages/run/src/cli.js
+++ b/packages/run/src/cli.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * CLI entry point for `lavax` — a secure `npx` replacement.
+ *
+ * @remarks
+ * Importing {@link lavax} (from `./run.js`) imports `@lavamoat/node`, which
+ * invokes SES `lockdown()` before any other module evaluates. This is
+ * deliberate.
+ * @packageDocumentation
+ */
+
+import { lavax } from './run.js'
+
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { splitArgs } from './args.js'
+import { readJsonFile } from './fs.js'
+import { log } from './log.js'
+
+/**
+ * @import {PackageJson} from 'type-fest'
+ */
+
+const BEHAVIOR_GROUP = 'Behavior Options:'
+const PATH_GROUP = 'Path Options:'
+
+/**
+ * Main entry point to the CLI.
+ *
+ * @param {string[]} [args] CLI arguments
+ * @returns {Promise<void>}
+ */
+const main = async (args = hideBin(process.argv)) => {
+  const pkgJson = /** @type {PackageJson} */ (
+    await readJsonFile(new URL('../package.json', import.meta.url))
+  )
+  const version = `${pkgJson.version}`
+
+  // Everything after `<spec>` is forwarded to the package's bin, so we split
+  // the argv ourselves and hand yargs only the leading options plus the spec.
+  const { optionTokens, spec, forwardedArgs } = splitArgs(args)
+  const yargsArgs = spec === undefined ? optionTokens : [...optionTokens, spec]
+
+  await yargs(yargsArgs)
+    .scriptName('lavax')
+    .usage(
+      '$0 [options] <spec> [args..]\n\nFetch and run a package’s bin under LavaMoat: install scripts are\ndisabled and a per-package SES policy is generated and enforced.'
+    )
+    .version(version)
+    .command(
+      '$0 <spec>',
+      'Securely fetch and run a package bin',
+      (yargs) =>
+        yargs.positional('spec', {
+          describe:
+            'Package spec to fetch and run (e.g. "cowsay", "cowsay@1.5.0", "@scope/pkg")',
+          type: 'string',
+          demandOption: true,
+        }),
+      async (argv) => {
+        if (argv.verbose) {
+          log.setLevel('debug')
+        } else if (argv.quiet) {
+          log.setLevel('error')
+        }
+
+        try {
+          await lavax(/** @type {string} */ (argv.spec), forwardedArgs, {
+            call: /** @type {string | undefined} */ (argv.call),
+            regenerate: /** @type {boolean | undefined} */ (argv.regenerate),
+            force: /** @type {boolean | undefined} */ (argv.force),
+            allowScripts: /** @type {boolean | undefined} */ (
+              argv['allow-scripts']
+            ),
+            prodOnly: !argv.dev,
+            registry: /** @type {string | undefined} */ (argv.registry),
+            cacheDir: /** @type {string | undefined} */ (argv.cache),
+            policyPath: /** @type {string | undefined} */ (argv.policy),
+            quiet: /** @type {boolean | undefined} */ (argv.quiet),
+          })
+        } catch (err) {
+          log.error(/** @type {Error} */ (err))
+          process.exitCode = 1
+        }
+      }
+    )
+    .options({
+      call: {
+        alias: 'c',
+        type: 'string',
+        describe: 'Bin name to run (when the package exposes more than one)',
+        group: BEHAVIOR_GROUP,
+      },
+      'allow-scripts': {
+        type: 'boolean',
+        default: false,
+        describe:
+          'DANGEROUS: allow lifecycle (install) scripts to run during install',
+        group: BEHAVIOR_GROUP,
+      },
+      regenerate: {
+        type: 'boolean',
+        default: false,
+        describe: 'Regenerate the LavaMoat policy instead of reusing the cache',
+        group: BEHAVIOR_GROUP,
+      },
+      force: {
+        type: 'boolean',
+        default: false,
+        describe: 'Reinstall the package even if a cached install exists',
+        group: BEHAVIOR_GROUP,
+      },
+      dev: {
+        type: 'boolean',
+        default: false,
+        describe: 'Include dev dependencies / use the "development" condition',
+        group: BEHAVIOR_GROUP,
+      },
+      registry: {
+        type: 'string',
+        describe: 'npm registry URL to install from',
+        group: PATH_GROUP,
+      },
+      cache: {
+        type: 'string',
+        normalize: true,
+        describe:
+          'Cache base directory (default: $LAVAMOAT_RUN_CACHE or ~/.lavamoat/run)',
+        group: PATH_GROUP,
+      },
+      policy: {
+        alias: 'p',
+        type: 'string',
+        normalize: true,
+        describe: 'Path to a policy file (default: within the cache directory)',
+        group: PATH_GROUP,
+      },
+      verbose: {
+        type: 'boolean',
+        describe: 'Enable verbose logging',
+        group: BEHAVIOR_GROUP,
+      },
+      quiet: {
+        type: 'boolean',
+        describe: 'Disable all but error logging',
+        group: BEHAVIOR_GROUP,
+      },
+    })
+    .conflicts('quiet', 'verbose')
+    .epilog(
+      `Security model:
+  • Install scripts are disabled by default (override with --allow-scripts)
+  • The package bin runs inside Hardened JavaScript (SES lockdown)
+  • Access to globals & builtins is restricted by a generated per-package policy
+
+  🌋 https://github.com/LavaMoat/LavaMoat`
+    )
+    .fail((msg, err, yargs) => {
+      if (err) {
+        log.error(err)
+      } else {
+        yargs.showHelp()
+        log.notice(msg)
+      }
+      process.exit(1)
+    })
+    .strict(false)
+    .demandCommand(1)
+    .parseAsync()
+}
+
+void main()

--- a/packages/run/src/constants.js
+++ b/packages/run/src/constants.js
@@ -1,0 +1,52 @@
+/**
+ * Constants shared across `@lavamoat/run`.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * The `package.json` filename.
+ */
+export const PACKAGE_JSON = 'package.json'
+
+/**
+ * Environment variable used to override the cache directory base.
+ */
+export const CACHE_DIR_ENV_VAR = 'LAVAMOAT_RUN_CACHE'
+
+/**
+ * Name of the synthetic `package.json` `name` field written into each sandbox
+ * directory.
+ *
+ * @remarks
+ * The sandbox is a throwaway "project" into which a single package is
+ * installed; it exists only to give `npm` and `@endo/compartment-mapper` a
+ * well-formed root to work from.
+ */
+export const SANDBOX_PACKAGE_NAME = '@lavamoat/run-sandbox'
+
+/**
+ * Filename of the marker file written to a sandbox directory after a successful
+ * install. Its contents are the raw package spec that was installed.
+ */
+export const INSTALL_MARKER_FILENAME = '.lavamoat-run-installed'
+
+/**
+ * Default subdirectory (relative to the user's home directory) used as the
+ * cache base when {@link CACHE_DIR_ENV_VAR} is unset.
+ */
+export const DEFAULT_CACHE_SUBDIR = ['.lavamoat', 'run']
+
+/**
+ * Relative path (within a sandbox directory) at which the generated policy is
+ * stored. Mirrors `@lavamoat/node`'s default policy location.
+ */
+export const POLICY_RELATIVE_PATH = ['lavamoat', 'node', 'policy.json']
+
+/**
+ * `@lavamoat/run` treats every fetched package as untrusted; the root
+ * compartment is therefore never trusted.
+ */
+export const TRUST_ROOT = false

--- a/packages/run/src/error.js
+++ b/packages/run/src/error.js
@@ -1,0 +1,111 @@
+/**
+ * Custom error classes thrown by `@lavamoat/run`.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Enum of error codes thrown by this package.
+ */
+export const ErrorCodes = Object.freeze(
+  /** @type {const} */ ({
+    SpecParse: 'LMR_SPEC_PARSE',
+    Install: 'LMR_INSTALL',
+    NoBinScript: 'LMR_NO_BIN_SCRIPT',
+    AmbiguousBinScript: 'LMR_AMBIGUOUS_BIN_SCRIPT',
+    UnknownPackage: 'LMR_UNKNOWN_PACKAGE',
+  })
+)
+
+/**
+ * Base class for all errors thrown by `@lavamoat/run`.
+ */
+export class LavaMoatRunError extends Error {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'LavaMoatRunError'
+    /** @type {string} */
+    this.code = 'LMR_ERROR'
+  }
+}
+
+/**
+ * Thrown when a package spec cannot be parsed.
+ */
+export class SpecParseError extends LavaMoatRunError {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'SpecParseError'
+    this.code = ErrorCodes.SpecParse
+  }
+}
+
+/**
+ * Thrown when installing a package fails.
+ */
+export class InstallError extends LavaMoatRunError {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'InstallError'
+    this.code = ErrorCodes.Install
+  }
+}
+
+/**
+ * Thrown when a package provides no executable bin script.
+ */
+export class NoBinScriptError extends LavaMoatRunError {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'NoBinScriptError'
+    this.code = ErrorCodes.NoBinScript
+  }
+}
+
+/**
+ * Thrown when a package exposes multiple bin scripts and none was selected.
+ */
+export class AmbiguousBinScriptError extends LavaMoatRunError {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'AmbiguousBinScriptError'
+    this.code = ErrorCodes.AmbiguousBinScript
+  }
+}
+
+/**
+ * Thrown when the installed package name cannot be determined.
+ */
+export class UnknownPackageError extends LavaMoatRunError {
+  /**
+   * @param {string} message
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'UnknownPackageError'
+    this.code = ErrorCodes.UnknownPackage
+  }
+}

--- a/packages/run/src/error.js
+++ b/packages/run/src/error.js
@@ -30,7 +30,7 @@ export class LavaMoatRunError extends Error {
   constructor(message, options) {
     super(message, options)
     this.name = 'LavaMoatRunError'
-    /** @type {string} */
+    /** @type {(typeof ErrorCodes)[keyof typeof ErrorCodes] | 'LMR_ERROR'} */
     this.code = 'LMR_ERROR'
   }
 }

--- a/packages/run/src/fs.js
+++ b/packages/run/src/fs.js
@@ -1,0 +1,44 @@
+/**
+ * Small filesystem helpers.
+ *
+ * @packageDocumentation
+ */
+
+import nodeFs from 'node:fs/promises'
+
+/**
+ * @import {JsonValue} from 'type-fest'
+ */
+
+/**
+ * Reads and parses a JSON file.
+ *
+ * @param {string | URL} filepath Path to a JSON file
+ * @param {{ readFile?: typeof nodeFs.readFile }} [options] Options
+ * @returns {Promise<JsonValue>} Parsed JSON
+ * @internal
+ */
+export const readJsonFile = async (
+  filepath,
+  { readFile = nodeFs.readFile } = {}
+) => {
+  const raw = await readFile(filepath, 'utf8')
+  return JSON.parse(raw)
+}
+
+/**
+ * Returns `true` if a path exists and is readable.
+ *
+ * @param {string | URL} filepath Path to check
+ * @param {{ access?: typeof nodeFs.access }} [options] Options
+ * @returns {Promise<boolean>}
+ * @internal
+ */
+export const pathExists = async (filepath, { access = nodeFs.access } = {}) => {
+  try {
+    await access(filepath)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/run/src/index.js
+++ b/packages/run/src/index.js
@@ -1,0 +1,28 @@
+/**
+ * Programmatic API for `@lavamoat/run`.
+ *
+ * @remarks
+ * Importing this module imports `@lavamoat/node` (via {@link lavax}), which
+ * invokes SES `lockdown()`. If you only need the pure helpers (spec parsing,
+ * etc.) and want to avoid `lockdown()`, import the relevant submodule
+ * directly.
+ * @packageDocumentation
+ */
+
+export { lavax } from './run.js'
+export { splitArgs } from './args.js'
+export {
+  cacheDirFor,
+  computeCacheBase,
+  parseSpec,
+  slugifySpec,
+  unscopedName,
+} from './spec.js'
+export { buildNpmArgs, installPackage } from './install.js'
+export {
+  getInstalledPackageName,
+  normalizeBin,
+  resolveBin,
+} from './resolve-bin.js'
+export * from './error.js'
+export * as constants from './constants.js'

--- a/packages/run/src/index.js
+++ b/packages/run/src/index.js
@@ -18,7 +18,12 @@ export {
   slugifySpec,
   unscopedName,
 } from './spec.js'
-export { buildNpmArgs, installPackage } from './install.js'
+export {
+  assertValidRegistry,
+  buildNpmArgs,
+  installPackage,
+  sanitizeNpmEnv,
+} from './install.js'
 export {
   getInstalledPackageName,
   normalizeBin,

--- a/packages/run/src/install.js
+++ b/packages/run/src/install.js
@@ -25,7 +25,68 @@ import { InstallError } from './error.js'
 const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 
 /**
+ * Environment variables that could re-enable lifecycle scripts or inject code
+ * into the `npm` child process, defeating the protections this module exists to
+ * provide. They are stripped from the install subprocess environment.
+ *
+ * - `npm_config_ignore_scripts` could flip the default if the CLI flag were ever
+ *   omitted (the CLI flag wins today, but defense-in-depth).
+ * - `NODE_OPTIONS` / `npm_config_node_options` can `--require` arbitrary modules
+ *   into the node process that runs `npm`, an arbitrary-code-execution vector.
+ * - `npm_config_script_shell` selects the shell used for any script that does
+ *   run.
+ */
+const STRIPPED_ENV_VARS = [
+  'npm_config_ignore_scripts',
+  'npm_config_node_options',
+  'npm_config_script_shell',
+  'NODE_OPTIONS',
+]
+
+/**
+ * Validates a registry URL, rejecting anything that is not `http(s):`.
+ *
+ * An unvalidated `--registry` value lets an attacker redirect the fetch (e.g.
+ * `file://` or a string `npm` interprets specially), defeating the entire
+ * fetch-trust chain.
+ *
+ * @param {string} registry Registry URL
+ * @returns {void}
+ */
+export const assertValidRegistry = (registry) => {
+  let url
+  try {
+    url = new URL(registry)
+  } catch {
+    throw new InstallError(`Invalid --registry URL: "${registry}"`)
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new InstallError(
+      `Invalid --registry URL "${registry}": only http(s) registries are allowed`
+    )
+  }
+}
+
+/**
+ * Returns a copy of `env` with variables that could subvert the install removed.
+ *
+ * @param {NodeJS.ProcessEnv} env Source environment
+ * @returns {NodeJS.ProcessEnv}
+ */
+export const sanitizeNpmEnv = (env) => {
+  const out = { ...env }
+  for (const key of STRIPPED_ENV_VARS) {
+    delete out[key]
+  }
+  return out
+}
+
+/**
  * Builds the argument vector passed to `npm`.
+ *
+ * The spec is placed last, after a literal `--`, so a spec beginning with `-`
+ * can never be interpreted as an `npm` flag (e.g. smuggling in
+ * `--ignore-scripts=false` or `--registry=…`).
  *
  * @param {string} spec Package spec to install
  * @param {Omit<InstallOptions, 'cwd' | 'spawn'>} [options] Options
@@ -35,14 +96,16 @@ export const buildNpmArgs = (
   spec,
   { allowScripts = false, registry, quiet = false } = {}
 ) => {
-  const args = ['install', spec, '--no-audit', '--no-fund']
+  const args = ['install', '--no-audit', '--no-fund']
   if (!allowScripts) {
     args.push('--ignore-scripts')
   }
   if (registry) {
+    assertValidRegistry(registry)
     args.push('--registry', registry)
   }
   args.push('--loglevel', quiet ? 'silent' : 'warn')
+  args.push('--', spec)
   return args
 }
 
@@ -66,6 +129,7 @@ export const installPackage = async (
       cwd,
       stdio: quiet ? ['ignore', 'ignore', 'inherit'] : 'inherit',
       shell: false,
+      env: sanitizeNpmEnv(process.env),
     })
     child.on('error', (err) => {
       reject(

--- a/packages/run/src/install.js
+++ b/packages/run/src/install.js
@@ -68,7 +68,8 @@ export const assertValidRegistry = (registry) => {
 }
 
 /**
- * Returns a copy of `env` with variables that could subvert the install removed.
+ * Returns a copy of `env` with variables that could subvert the install
+ * removed.
  *
  * @param {NodeJS.ProcessEnv} env Source environment
  * @returns {NodeJS.ProcessEnv}

--- a/packages/run/src/install.js
+++ b/packages/run/src/install.js
@@ -1,0 +1,90 @@
+/**
+ * Installs a single package into a sandbox directory using `npm`, with
+ * lifecycle (install) scripts disabled by default.
+ *
+ * Disabling install scripts is the same protection provided by
+ * `@lavamoat/allow-scripts`, and it neutralizes the single biggest attack
+ * vector of `npx`: arbitrary `preinstall`/`install`/`postinstall` code running
+ * the instant a package is fetched.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+import { spawn as defaultSpawn } from 'node:child_process'
+import { InstallError } from './error.js'
+
+/**
+ * @import {InstallOptions} from './types.js'
+ */
+
+/**
+ * The `npm` executable name for the current platform.
+ */
+const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+/**
+ * Builds the argument vector passed to `npm`.
+ *
+ * @param {string} spec Package spec to install
+ * @param {Omit<InstallOptions, 'cwd' | 'spawn'>} [options] Options
+ * @returns {string[]}
+ */
+export const buildNpmArgs = (
+  spec,
+  { allowScripts = false, registry, quiet = false } = {}
+) => {
+  const args = ['install', spec, '--no-audit', '--no-fund']
+  if (!allowScripts) {
+    args.push('--ignore-scripts')
+  }
+  if (registry) {
+    args.push('--registry', registry)
+  }
+  args.push('--loglevel', quiet ? 'silent' : 'warn')
+  return args
+}
+
+/**
+ * Installs `spec` into the sandbox directory `cwd`.
+ *
+ * The sandbox directory is expected to already contain a `package.json`.
+ *
+ * @param {string} spec Package spec to install
+ * @param {InstallOptions} options Options
+ * @returns {Promise<void>}
+ */
+export const installPackage = async (
+  spec,
+  { cwd, allowScripts = false, registry, quiet = false, spawn = defaultSpawn }
+) => {
+  const args = buildNpmArgs(spec, { allowScripts, registry, quiet })
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(NPM_BIN, args, {
+      cwd,
+      stdio: quiet ? ['ignore', 'ignore', 'inherit'] : 'inherit',
+      shell: false,
+    })
+    child.on('error', (err) => {
+      reject(
+        new InstallError(
+          `Failed to spawn "${NPM_BIN}"; is npm installed and on your PATH?`,
+          { cause: err }
+        )
+      )
+    })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(undefined)
+      } else {
+        reject(
+          new InstallError(
+            `Installation of "${spec}" failed: npm exited with code ${code}`
+          )
+        )
+      }
+    })
+  })
+}

--- a/packages/run/src/log.js
+++ b/packages/run/src/log.js
@@ -1,0 +1,33 @@
+/**
+ * Provides a {@link log logger} which writes exclusively to `stderr`.
+ *
+ * @remarks
+ * As with `@lavamoat/node`, the "output" of `@lavamoat/run` is the output of
+ * the program it executes; everything `@lavamoat/run` emits about its own
+ * behavior must go to `stderr` so it never pollutes the program's `stdout`.
+ * @packageDocumentation
+ */
+
+import { Loggerr } from 'loggerr'
+
+/**
+ * The `@lavamoat/run` logger.
+ *
+ * Every log level is routed to {@link process.stderr}.
+ */
+export const log = new Loggerr({
+  formatter: 'cli',
+  streams: [
+    process.stderr,
+    process.stderr,
+    process.stderr,
+    process.stderr,
+    process.stderr,
+    process.stderr,
+    process.stderr,
+    process.stderr,
+  ],
+  level: process.env.LAVAMOAT_DEBUG ? Loggerr.DEBUG : Loggerr.INFO,
+})
+
+export { Loggerr }

--- a/packages/run/src/resolve-bin.js
+++ b/packages/run/src/resolve-bin.js
@@ -1,0 +1,189 @@
+/**
+ * Resolves which bin script of an installed package to execute and where it
+ * lives on disk.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+import path from 'node:path'
+import { PACKAGE_JSON } from './constants.js'
+import {
+  AmbiguousBinScriptError,
+  NoBinScriptError,
+  UnknownPackageError,
+} from './error.js'
+import { pathExists, readJsonFile } from './fs.js'
+import { unscopedName } from './spec.js'
+
+/**
+ * @import {JsonValue} from 'type-fest'
+ * @import {ResolvedBin} from './types.js'
+ */
+
+/**
+ * Normalizes a package's `bin` field into a map of `{ binName: relativePath }`.
+ *
+ * Mirrors npm's semantics: a string `bin` maps to the package's unscoped name.
+ *
+ * @param {string} packageName Package name
+ * @param {unknown} bin The raw `bin` field
+ * @returns {Record<string, string>}
+ */
+export const normalizeBin = (packageName, bin) => {
+  if (typeof bin === 'string') {
+    return { [unscopedName(packageName)]: bin }
+  }
+  if (bin && typeof bin === 'object' && !Array.isArray(bin)) {
+    /** @type {Record<string, string>} */
+    const out = {}
+    for (const [key, value] of Object.entries(bin)) {
+      if (typeof value === 'string') {
+        out[key] = value
+      }
+    }
+    return out
+  }
+  return {}
+}
+
+/**
+ * Reads the sandbox's `package.json` and determines the canonical name of the
+ * single installed package.
+ *
+ * @param {string} sandboxDir Sandbox directory
+ * @param {{
+ *   hint?: string
+ *   readJson?: typeof readJsonFile
+ * }} [options]
+ *   Options
+ * @returns {Promise<string>}
+ */
+export const getInstalledPackageName = async (
+  sandboxDir,
+  { hint, readJson = readJsonFile } = {}
+) => {
+  /** @type {JsonValue} */
+  let pkg
+  try {
+    pkg = await readJson(path.join(sandboxDir, PACKAGE_JSON))
+  } catch (err) {
+    throw new UnknownPackageError(
+      `Could not read sandbox package.json in ${sandboxDir}`,
+      { cause: err }
+    )
+  }
+  const dependencies =
+    pkg && typeof pkg === 'object' && !Array.isArray(pkg)
+      ? /** @type {Record<string, unknown>} */ (pkg).dependencies
+      : undefined
+  const keys =
+    dependencies && typeof dependencies === 'object'
+      ? Object.keys(dependencies)
+      : []
+
+  if (hint && keys.includes(hint)) {
+    return hint
+  }
+  if (keys.length === 1) {
+    return /** @type {string} */ (keys[0])
+  }
+  if (hint) {
+    return hint
+  }
+  throw new UnknownPackageError(
+    `Could not determine the installed package name in ${sandboxDir}`
+  )
+}
+
+/**
+ * Resolves the bin script to execute for `packageName` installed in
+ * `sandboxDir`.
+ *
+ * Selection order:
+ *
+ * 1. An explicit `call` name (must exist)
+ * 2. A bin whose name equals the package's unscoped name
+ * 3. The sole bin, if the package declares exactly one
+ *
+ * Otherwise an error is thrown.
+ *
+ * @param {string} sandboxDir Sandbox directory
+ * @param {string} packageName Installed package name
+ * @param {{
+ *   call?: string
+ *   readJson?: typeof readJsonFile
+ *   exists?: typeof pathExists
+ * }} [options]
+ *   Options
+ * @returns {Promise<ResolvedBin>}
+ */
+export const resolveBin = async (
+  sandboxDir,
+  packageName,
+  { call, readJson = readJsonFile, exists = pathExists } = {}
+) => {
+  const packageDir = path.join(
+    sandboxDir,
+    'node_modules',
+    ...packageName.split('/')
+  )
+  /** @type {JsonValue} */
+  let pkg
+  try {
+    pkg = await readJson(path.join(packageDir, PACKAGE_JSON))
+  } catch (err) {
+    throw new NoBinScriptError(
+      `Could not read package.json for "${packageName}"; was it installed?`,
+      { cause: err }
+    )
+  }
+
+  const bin =
+    pkg && typeof pkg === 'object' && !Array.isArray(pkg)
+      ? /** @type {Record<string, unknown>} */ (pkg).bin
+      : undefined
+  const binMap = normalizeBin(packageName, bin)
+  const binNames = Object.keys(binMap)
+
+  if (binNames.length === 0) {
+    throw new NoBinScriptError(
+      `Package "${packageName}" provides no bin script`
+    )
+  }
+
+  /** @type {string} */
+  let binName
+  if (call) {
+    if (!(call in binMap)) {
+      throw new NoBinScriptError(
+        `Package "${packageName}" has no bin named "${call}"; available: ${binNames.join(', ')}`
+      )
+    }
+    binName = call
+  } else {
+    const unscoped = unscopedName(packageName)
+    if (unscoped in binMap) {
+      binName = unscoped
+    } else if (binNames.length === 1) {
+      binName = /** @type {string} */ (binNames[0])
+    } else {
+      throw new AmbiguousBinScriptError(
+        `Package "${packageName}" exposes multiple bin scripts (${binNames.join(', ')}); choose one with --call`
+      )
+    }
+  }
+
+  const binPath = path.resolve(
+    packageDir,
+    /** @type {string} */ (binMap[binName])
+  )
+  if (!(await exists(binPath))) {
+    throw new NoBinScriptError(
+      `Bin script "${binName}" for "${packageName}" not found at ${binPath}`
+    )
+  }
+
+  return { packageName, binName, binPath }
+}

--- a/packages/run/src/resolve-bin.js
+++ b/packages/run/src/resolve-bin.js
@@ -86,14 +86,17 @@ export const getInstalledPackageName = async (
   if (hint && keys.includes(hint)) {
     return hint
   }
+  // The sole installed dependency is authoritative. Prefer it even over a
+  // `hint` that npm did not actually record as a dependency.
   if (keys.length === 1) {
     return /** @type {string} */ (keys[0])
   }
-  if (hint) {
-    return hint
-  }
+  // We do NOT fall back to an unverified `hint` here: returning a name that npm
+  // never installed would point bin resolution at an arbitrary, attacker-
+  // influenced path. Surface the ambiguity instead.
   throw new UnknownPackageError(
-    `Could not determine the installed package name in ${sandboxDir}`
+    `Could not determine the installed package name in ${sandboxDir}` +
+      (hint ? ` ("${hint}" is not among its dependencies)` : '')
   )
 }
 

--- a/packages/run/src/run.js
+++ b/packages/run/src/run.js
@@ -1,0 +1,190 @@
+/**
+ * Orchestration: fetch a package (scripts disabled) and execute its bin under
+ * `@lavamoat/node` with a generated, enforced per-package SES policy.
+ *
+ * Importing this module imports `@lavamoat/node`, which calls SES `lockdown()`.
+ * This is intentional: the entire purpose of `@lavamoat/run` is to execute
+ * untrusted code inside a hardened environment.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+import {
+  generatePolicy as defaultGeneratePolicy,
+  run as defaultRun,
+} from '@lavamoat/node'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import {
+  INSTALL_MARKER_FILENAME,
+  PACKAGE_JSON,
+  POLICY_RELATIVE_PATH,
+  SANDBOX_PACKAGE_NAME,
+  TRUST_ROOT,
+} from './constants.js'
+import { pathExists, readJsonFile } from './fs.js'
+import { installPackage } from './install.js'
+import { log } from './log.js'
+import { getInstalledPackageName, resolveBin } from './resolve-bin.js'
+import { cacheDirFor, computeCacheBase, parseSpec } from './spec.js'
+
+/**
+ * @import {LavaxOptions} from './types.js'
+ */
+
+/**
+ * Ensures the sandbox directory exists and contains a minimal `package.json`.
+ *
+ * @param {string} sandboxDir Sandbox directory
+ * @returns {Promise<string>} Path to the sandbox `package.json`
+ */
+const ensureSandbox = async (sandboxDir) => {
+  await mkdir(sandboxDir, { recursive: true })
+  const pkgPath = path.join(sandboxDir, PACKAGE_JSON)
+  if (!(await pathExists(pkgPath))) {
+    await writeFile(
+      pkgPath,
+      `${JSON.stringify(
+        { name: SANDBOX_PACKAGE_NAME, version: '0.0.0', private: true },
+        null,
+        2
+      )}\n`
+    )
+  }
+  return pkgPath
+}
+
+/**
+ * Returns `true` if `sandboxDir` already contains an install of `raw`.
+ *
+ * @param {string} sandboxDir Sandbox directory
+ * @param {string} raw Raw spec
+ * @returns {Promise<boolean>}
+ */
+const isInstalled = async (sandboxDir, raw) => {
+  const markerPath = path.join(sandboxDir, INSTALL_MARKER_FILENAME)
+  if (!(await pathExists(markerPath))) {
+    return false
+  }
+  try {
+    const contents = await readJsonFile(markerPath)
+    return contents === raw
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Securely fetches and runs a package's bin script.
+ *
+ * 1. Parses the spec and computes an isolated sandbox directory.
+ * 2. Installs the package with lifecycle scripts disabled (unless `allowScripts`).
+ * 3. Resolves the bin script to execute.
+ * 4. Generates (and caches) a LavaMoat policy on first use; reuses it after.
+ * 5. Executes the bin via `@lavamoat/node` as an untrusted root, enforcing the
+ *    policy.
+ *
+ * @template [T=unknown] Exports of the executed module. Default is `unknown`
+ * @param {string} rawSpec Package spec (e.g. `cowsay`, `cowsay@1.5.0`,
+ *   `@scope/pkg@^2`)
+ * @param {string[]} [forwardedArgs] Arguments forwarded to the bin script
+ * @param {LavaxOptions} [options] Options
+ * @returns {Promise<T>} Exports of the executed bin module
+ */
+export const lavax = async (rawSpec, forwardedArgs = [], options = {}) => {
+  const {
+    call,
+    regenerate = false,
+    force = false,
+    allowScripts = false,
+    prodOnly = true,
+    registry,
+    cacheDir,
+    policyPath: explicitPolicyPath,
+    quiet = false,
+    install = installPackage,
+    run = defaultRun,
+    generatePolicy = defaultGeneratePolicy,
+  } = options
+
+  const parsed = parseSpec(rawSpec)
+  const base = computeCacheBase({ cacheDir })
+  const sandboxDir = cacheDirFor(parsed.raw, base)
+
+  await ensureSandbox(sandboxDir)
+
+  if (force || !(await isInstalled(sandboxDir, parsed.raw))) {
+    if (allowScripts) {
+      log.warning(
+        `⚠ Lifecycle (install) scripts are ENABLED for "${parsed.raw}". This disables a core LavaMoat protection; only do this for packages you trust.`
+      )
+    }
+    if (force) {
+      await rm(path.join(sandboxDir, 'node_modules'), {
+        recursive: true,
+        force: true,
+      })
+    }
+    log.info(
+      `Installing "${parsed.raw}" (lifecycle scripts ${allowScripts ? 'enabled' : 'disabled'})…`
+    )
+    await install(parsed.raw, {
+      cwd: sandboxDir,
+      allowScripts,
+      registry,
+      quiet,
+    })
+    await writeFile(
+      path.join(sandboxDir, INSTALL_MARKER_FILENAME),
+      JSON.stringify(parsed.raw)
+    )
+  } else {
+    log.info(`Using cached install of "${parsed.raw}"`)
+  }
+
+  const packageName = await getInstalledPackageName(sandboxDir, {
+    hint: parsed.name,
+  })
+  const { binName, binPath } = await resolveBin(sandboxDir, packageName, {
+    call,
+  })
+  log.info(`Running "${binName}" from "${packageName}" under LavaMoat`)
+
+  const policyPath =
+    explicitPolicyPath ?? path.join(sandboxDir, ...POLICY_RELATIVE_PATH)
+
+  /** @type {import('@lavamoat/types').LavaMoatPolicy | undefined} */
+  let policy
+  const policyExists = await pathExists(policyPath)
+  if (regenerate || !policyExists) {
+    log.info(
+      `${policyExists ? 'Regenerating' : 'Generating'} LavaMoat policy for "${packageName}"…`
+    )
+    policy = await generatePolicy(binPath, {
+      policyPath,
+      projectRoot: sandboxDir,
+      write: true,
+      prodOnly,
+      trustRoot: TRUST_ROOT,
+    })
+  } else {
+    log.info(`Using cached policy at ${policyPath}`)
+  }
+
+  // Present `process.argv` to the executed bin as if it were run directly with
+  // `node`. Mutate in place to be safe under `lockdown()`.
+  process.argv.length = 0
+  process.argv.push(process.execPath, binPath, ...forwardedArgs)
+
+  return /** @type {Promise<T>} */ (
+    run(binPath, {
+      policy,
+      policyPath,
+      projectRoot: sandboxDir,
+      prodOnly,
+      trustRoot: TRUST_ROOT,
+    })
+  )
+}

--- a/packages/run/src/run.js
+++ b/packages/run/src/run.js
@@ -41,7 +41,11 @@ import { cacheDirFor, computeCacheBase, parseSpec } from './spec.js'
  * @returns {Promise<string>} Path to the sandbox `package.json`
  */
 const ensureSandbox = async (sandboxDir) => {
-  await mkdir(sandboxDir, { recursive: true })
+  // Restrict permissions: the cache holds fetched (untrusted) packages and the
+  // generated policy. `0o700` keeps other local users from pre-planting a
+  // `node_modules`/`policy.json` (the predictable per-spec path would otherwise
+  // be writable on a shared host or shared `LAVAMOAT_RUN_CACHE`).
+  await mkdir(sandboxDir, { recursive: true, mode: 0o700 })
   const pkgPath = path.join(sandboxDir, PACKAGE_JSON)
   if (!(await pathExists(pkgPath))) {
     await writeFile(
@@ -174,17 +178,26 @@ export const lavax = async (rawSpec, forwardedArgs = [], options = {}) => {
   }
 
   // Present `process.argv` to the executed bin as if it were run directly with
-  // `node`. Mutate in place to be safe under `lockdown()`.
+  // `node`. Mutate in place (rather than reassign) to be safe under
+  // `lockdown()`, and restore it afterwards so programmatic callers — for whom
+  // `lavax` is a normal async function — don't have their `process.argv`
+  // permanently clobbered, including when `run()` rejects.
+  const originalArgv = [...process.argv]
   process.argv.length = 0
   process.argv.push(process.execPath, binPath, ...forwardedArgs)
 
-  return /** @type {Promise<T>} */ (
-    run(binPath, {
-      policy,
-      policyPath,
-      projectRoot: sandboxDir,
-      prodOnly,
-      trustRoot: TRUST_ROOT,
-    })
-  )
+  try {
+    return await /** @type {Promise<T>} */ (
+      run(binPath, {
+        policy,
+        policyPath,
+        projectRoot: sandboxDir,
+        prodOnly,
+        trustRoot: TRUST_ROOT,
+      })
+    )
+  } finally {
+    process.argv.length = 0
+    process.argv.push(...originalArgv)
+  }
 }

--- a/packages/run/src/spec.js
+++ b/packages/run/src/spec.js
@@ -56,6 +56,15 @@ export const parseSpec = (rawSpec) => {
   if (!raw) {
     throw new SpecParseError(`Package spec must not be empty`)
   }
+  // A spec beginning with `-` would be interpreted by `npm` as a flag rather
+  // than a package name. Reject it outright so it can never be smuggled into
+  // the install step (e.g. via the programmatic API), independent of the `--`
+  // guard in buildNpmArgs.
+  if (raw.startsWith('-')) {
+    throw new SpecParseError(
+      `Package spec must not start with "-": "${raw}"`
+    )
+  }
 
   // Scoped registry specs always begin with `@scope/`. Handle them before the
   // non-registry heuristic, which would otherwise mistake `@scope/pkg` for a

--- a/packages/run/src/spec.js
+++ b/packages/run/src/spec.js
@@ -1,0 +1,155 @@
+/**
+ * Package-spec parsing and cache-directory computation.
+ *
+ * These functions are pure (modulo {@link computeCacheBase}'s use of the
+ * environment and home directory) and contain no `@lavamoat/node` dependency,
+ * so they can be unit-tested without triggering SES `lockdown()`.
+ *
+ * **All exports in this module are considered part of the public API.**
+ *
+ * @packageDocumentation
+ */
+
+import { createHash } from 'node:crypto'
+import os from 'node:os'
+import path from 'node:path'
+import { CACHE_DIR_ENV_VAR, DEFAULT_CACHE_SUBDIR } from './constants.js'
+import { SpecParseError } from './error.js'
+
+/**
+ * @import {ParsedSpec} from './types.js'
+ */
+
+/**
+ * Matches specs that are not "registry" specs (URLs, git specifiers, file
+ * paths). For these, the package name cannot be reliably derived from the spec
+ * string and must instead be read from the installed `package.json`.
+ */
+const NON_REGISTRY_SPEC_REGEXP =
+  /^(?:[./~]|[a-z]+:\/\/|git\+|git@|file:|npm:|github:|[^/]+\/[^/]+(?:#.*)?$)/i
+
+/**
+ * Parses an npm package spec into its name (when determinable) and version
+ * range.
+ *
+ * Handles the common registry forms:
+ *
+ * - `pkg`
+ * - `pkg@1.2.3`
+ * - `pkg@^1`
+ * - `pkg@latest`
+ * - `@scope/pkg`
+ * - `@scope/pkg@1.2.3`
+ *
+ * For non-registry specs (tarball URLs, git specifiers, local paths) the `name`
+ * is `undefined`; callers should reconcile it against the installed
+ * `package.json` after installation.
+ *
+ * @param {string} rawSpec Raw package spec
+ * @returns {ParsedSpec}
+ */
+export const parseSpec = (rawSpec) => {
+  if (typeof rawSpec !== 'string') {
+    throw new SpecParseError(`Package spec must be a string`)
+  }
+  const raw = rawSpec.trim()
+  if (!raw) {
+    throw new SpecParseError(`Package spec must not be empty`)
+  }
+
+  // Scoped registry specs always begin with `@scope/`. Handle them before the
+  // non-registry heuristic, which would otherwise mistake `@scope/pkg` for a
+  // `user/repo` GitHub shorthand.
+  if (raw.startsWith('@')) {
+    const slash = raw.indexOf('/')
+    if (slash === -1) {
+      // e.g. `@foo` — not a valid package name, but don't choke
+      return { name: raw, version: undefined, raw }
+    }
+    const at = raw.indexOf('@', slash)
+    if (at === -1) {
+      return { name: raw, version: undefined, raw }
+    }
+    return { name: raw.slice(0, at), version: raw.slice(at + 1), raw }
+  }
+
+  if (NON_REGISTRY_SPEC_REGEXP.test(raw)) {
+    return { name: undefined, version: undefined, raw }
+  }
+
+  const at = raw.indexOf('@')
+  if (at <= 0) {
+    return { name: raw, version: undefined, raw }
+  }
+  return { name: raw.slice(0, at), version: raw.slice(at + 1), raw }
+}
+
+/**
+ * Returns the unscoped portion of a package name (`@scope/foo` → `foo`).
+ *
+ * @param {string} name Package name
+ * @returns {string}
+ */
+export const unscopedName = (name) =>
+  name.startsWith('@') && name.includes('/')
+    ? /** @type {string} */ (name.split('/')[1])
+    : name
+
+/**
+ * Turns an arbitrary spec into a filesystem-safe slug.
+ *
+ * @param {string} raw Raw spec
+ * @returns {string}
+ */
+export const slugifySpec = (raw) => {
+  const slug = raw
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 64)
+  return slug || 'pkg'
+}
+
+/**
+ * Computes the base directory under which per-spec sandboxes are created.
+ *
+ * Precedence: explicit `cacheDir` option, then the `LAVAMOAT_RUN_CACHE`
+ * environment variable, then `~/.lavamoat/run`.
+ *
+ * @param {{
+ *   cacheDir?: string
+ *   env?: NodeJS.ProcessEnv
+ *   homedir?: () => string
+ * }} [options]
+ *   Options
+ * @returns {string}
+ */
+export const computeCacheBase = ({
+  cacheDir,
+  env = process.env,
+  homedir = os.homedir,
+} = {}) => {
+  if (cacheDir) {
+    return path.resolve(cacheDir)
+  }
+  const fromEnv = env[CACHE_DIR_ENV_VAR]
+  if (fromEnv) {
+    return path.resolve(fromEnv)
+  }
+  return path.join(homedir(), ...DEFAULT_CACHE_SUBDIR)
+}
+
+/**
+ * Computes the sandbox directory for a given spec under `base`.
+ *
+ * The directory name combines a human-readable slug with a short hash of the
+ * raw spec, so distinct specs (e.g. `cowsay@1` vs `cowsay@2`) never collide,
+ * yet repeated invocations of the same spec reuse the same sandbox.
+ *
+ * @param {string} raw Raw spec
+ * @param {string} base Base directory (see {@link computeCacheBase})
+ * @returns {string} Absolute path to the sandbox directory
+ */
+export const cacheDirFor = (raw, base) => {
+  const hash = createHash('sha256').update(raw).digest('hex').slice(0, 12)
+  return path.join(base, `${slugifySpec(raw)}-${hash}`)
+}

--- a/packages/run/src/spec.js
+++ b/packages/run/src/spec.js
@@ -61,9 +61,7 @@ export const parseSpec = (rawSpec) => {
   // the install step (e.g. via the programmatic API), independent of the `--`
   // guard in buildNpmArgs.
   if (raw.startsWith('-')) {
-    throw new SpecParseError(
-      `Package spec must not start with "-": "${raw}"`
-    )
+    throw new SpecParseError(`Package spec must not start with "-": "${raw}"`)
   }
 
   // Scoped registry specs always begin with `@scope/`. Handle them before the

--- a/packages/run/src/tsconfig.json
+++ b/packages/run/src/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../.config/tsconfig.src.json",
+  "compilerOptions": {
+    "outDir": "../types",
+    "rootDir": "..",
+    "paths": {
+      "@lavamoat/node": ["../../node/types/src/index.d.ts"],
+      "@lavamoat/types": ["../../types"]
+    },
+    "target": "esnext",
+    "module": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "stripInternal": true,
+    "preserveSymlinks": true
+  },
+  "include": ["."],
+  "references": [
+    { "path": "../../node/tsconfig.json" },
+    { "path": "../../types/tsconfig.json" }
+  ]
+}

--- a/packages/run/src/types.js
+++ b/packages/run/src/types.js
@@ -1,0 +1,65 @@
+/**
+ * Shared type definitions for `@lavamoat/run`.
+ *
+ * This module has no runtime exports; it exists to host JSDoc `@typedef`s
+ * consumed elsewhere via `@import`.
+ *
+ * @packageDocumentation
+ */
+
+export {}
+
+/**
+ * A parsed package spec.
+ *
+ * @typedef ParsedSpec
+ * @property {string | undefined} name Package name, if determinable from the
+ *   spec alone
+ * @property {string | undefined} version Version range / dist-tag, if present
+ * @property {string} raw The original (trimmed) spec
+ */
+
+/**
+ * Options for {@link import('./install.js').installPackage}.
+ *
+ * @typedef InstallOptions
+ * @property {string} cwd Sandbox directory to install into
+ * @property {boolean} [allowScripts] Allow lifecycle (install) scripts to run.
+ *   Defaults to `false` — the core LavaMoat protection.
+ * @property {string} [registry] Npm registry URL override
+ * @property {boolean} [quiet] Suppress npm's own output
+ * @property {typeof import('node:child_process').spawn} [spawn] Injectable
+ *   `spawn` implementation (for testing)
+ */
+
+/**
+ * The result of resolving a package's bin script.
+ *
+ * @typedef ResolvedBin
+ * @property {string} packageName Canonical installed package name
+ * @property {string} binName Selected bin name
+ * @property {string} binPath Absolute path to the bin script
+ */
+
+/**
+ * Options for {@link import('./run.js').lavax}.
+ *
+ * @typedef LavaxOptions
+ * @property {string} [call] Explicit bin name to run (overrides the default)
+ * @property {boolean} [regenerate] Force regeneration of the policy
+ * @property {boolean} [force] Reinstall even if a cached install exists
+ * @property {boolean} [allowScripts] Allow lifecycle (install) scripts to run
+ *   (dangerous; defaults to `false`)
+ * @property {boolean} [prodOnly] Exclude dev dependencies / use production
+ *   conditions. Defaults to `true`.
+ * @property {string} [registry] Npm registry URL override
+ * @property {string} [cacheDir] Override the cache base directory
+ * @property {string} [policyPath] Override the policy file path
+ * @property {boolean} [quiet] Suppress npm's own output during install
+ * @property {(spec: string, options: InstallOptions) => Promise<void>} [install]
+ *   Injectable installer (for testing)
+ * @property {typeof import('@lavamoat/node').run} [run] Injectable runner (for
+ *   testing)
+ * @property {typeof import('@lavamoat/node').generatePolicy} [generatePolicy]
+ *   Injectable policy generator (for testing)
+ */

--- a/packages/run/test/e2e/cli.spec.js
+++ b/packages/run/test/e2e/cli.spec.js
@@ -1,5 +1,8 @@
 import test from 'ava'
 import { execFile } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { readJsonFile } from '../../src/fs.js'
@@ -52,4 +55,18 @@ test('--version matches package descriptor', async (t) => {
 test('missing spec exits non-zero', async (t) => {
   const { code } = await runCLI([])
   t.is(code, 1)
+})
+
+test('rejects a non-http(s) registry without hitting the network', async (t) => {
+  const cache = await mkdtemp(path.join(os.tmpdir(), 'lavamoat-run-e2e-'))
+  t.teardown(() => rm(cache, { recursive: true, force: true }))
+  const { code, stderr } = await runCLI([
+    '--cache',
+    cache,
+    '--registry',
+    'ftp://evil.example.com',
+    'cowsay',
+  ])
+  t.is(code, 1)
+  t.regex(stderr, /registry/i)
 })

--- a/packages/run/test/e2e/cli.spec.js
+++ b/packages/run/test/e2e/cli.spec.js
@@ -1,0 +1,55 @@
+import test from 'ava'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { readJsonFile } from '../../src/fs.js'
+
+/**
+ * @import {PackageJson} from 'type-fest'
+ */
+
+const execFileAsync = promisify(execFile)
+
+const CLI_PATH = fileURLToPath(new URL('../../src/cli.js', import.meta.url))
+
+/**
+ * Runs the `lavax` CLI.
+ *
+ * @param {string[]} args
+ * @returns {Promise<{ stdout: string; stderr: string; code: number }>}
+ */
+const runCLI = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [CLI_PATH, ...args],
+      { encoding: 'utf8' }
+    )
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = /** @type {any} */ (err)
+    return { stdout: e.stdout, stderr: e.stderr, code: e.code }
+  }
+}
+
+test('--help prints usage and the security model', async (t) => {
+  const { stdout, code } = await runCLI(['--help'])
+  t.is(code, 0)
+  t.regex(stdout, /lavax/)
+  t.regex(stdout, /install/i)
+  t.regex(stdout, /policy/i)
+})
+
+test('--version matches package descriptor', async (t) => {
+  const { stdout, code } = await runCLI(['--version'])
+  t.is(code, 0)
+  const { version } = /** @type {PackageJson} */ (
+    await readJsonFile(new URL('../../package.json', import.meta.url))
+  )
+  t.is(stdout.trim(), `${version}`)
+})
+
+test('missing spec exits non-zero', async (t) => {
+  const { code } = await runCLI([])
+  t.is(code, 1)
+})

--- a/packages/run/test/tsconfig.json
+++ b/packages/run/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "paths": {
+      "@lavamoat/node": ["../../node/types/src/index.d.ts"],
+      "@lavamoat/types": ["../../types"]
+    },
+    "preserveSymlinks": true,
+    "rootDir": "..",
+    "strict": true,
+    "target": "esnext",
+    "types": ["node"]
+  },
+  "exclude": ["unit/fixture", "e2e/fixture"],
+  "extends": "../../../.config/tsconfig.test.json",
+  "include": ["."],
+  "references": [{ "path": "../src/tsconfig.json" }]
+}

--- a/packages/run/test/unit/args.spec.js
+++ b/packages/run/test/unit/args.spec.js
@@ -1,0 +1,82 @@
+import test from 'ava'
+import { splitArgs } from '../../src/args.js'
+
+test('splitArgs - bare spec', (t) => {
+  t.deepEqual(splitArgs(['cowsay']), {
+    optionTokens: [],
+    spec: 'cowsay',
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - spec with forwarded args', (t) => {
+  t.deepEqual(splitArgs(['cowsay', 'hello', 'world']), {
+    optionTokens: [],
+    spec: 'cowsay',
+    forwardedArgs: ['hello', 'world'],
+  })
+})
+
+test('splitArgs - leading boolean option', (t) => {
+  t.deepEqual(splitArgs(['--force', 'cowsay', 'hi']), {
+    optionTokens: ['--force'],
+    spec: 'cowsay',
+    forwardedArgs: ['hi'],
+  })
+})
+
+test('splitArgs - value option (separate token)', (t) => {
+  t.deepEqual(splitArgs(['--cache', '/tmp/x', 'cowsay']), {
+    optionTokens: ['--cache', '/tmp/x'],
+    spec: 'cowsay',
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - value option (equals form)', (t) => {
+  t.deepEqual(splitArgs(['--cache=/tmp/x', 'cowsay']), {
+    optionTokens: ['--cache=/tmp/x'],
+    spec: 'cowsay',
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - forwarded flags go to the bin, not lavax', (t) => {
+  t.deepEqual(splitArgs(['cowsay', '--help', '-e', 'oO']), {
+    optionTokens: [],
+    spec: 'cowsay',
+    forwardedArgs: ['--help', '-e', 'oO'],
+  })
+})
+
+test('splitArgs - explicit -- separates spec from forwarded args', (t) => {
+  t.deepEqual(splitArgs(['--force', '--', 'cowsay', '--version']), {
+    optionTokens: ['--force'],
+    spec: 'cowsay',
+    forwardedArgs: ['--version'],
+  })
+})
+
+test('splitArgs - leading -- before forwarded args is dropped once', (t) => {
+  t.deepEqual(splitArgs(['cowsay', '--', '--version']), {
+    optionTokens: [],
+    spec: 'cowsay',
+    forwardedArgs: ['--version'],
+  })
+})
+
+test('splitArgs - only options, no spec', (t) => {
+  t.deepEqual(splitArgs(['--help']), {
+    optionTokens: ['--help'],
+    spec: undefined,
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - short value option', (t) => {
+  t.deepEqual(splitArgs(['-c', 'mybin', 'pkg', 'arg']), {
+    optionTokens: ['-c', 'mybin'],
+    spec: 'pkg',
+    forwardedArgs: ['arg'],
+  })
+})

--- a/packages/run/test/unit/args.spec.js
+++ b/packages/run/test/unit/args.spec.js
@@ -80,3 +80,32 @@ test('splitArgs - short value option', (t) => {
     forwardedArgs: ['arg'],
   })
 })
+
+test('splitArgs - value option immediately followed by another option', (t) => {
+  // `--cache` has no value here; `--force` is the next option and must not be
+  // consumed as `--cache`'s value.
+  t.deepEqual(splitArgs(['--cache', '--force', 'cowsay']), {
+    optionTokens: ['--cache', '--force'],
+    spec: 'cowsay',
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - equals form for short alias', (t) => {
+  t.deepEqual(splitArgs(['-c=mybin', 'pkg']), {
+    optionTokens: ['-c=mybin'],
+    spec: 'pkg',
+    forwardedArgs: [],
+  })
+})
+
+test('splitArgs - separate-token registry and policy value options', (t) => {
+  t.deepEqual(
+    splitArgs(['--registry', 'https://r.example.com', '-p', 'pol.json', 'pkg']),
+    {
+      optionTokens: ['--registry', 'https://r.example.com', '-p', 'pol.json'],
+      spec: 'pkg',
+      forwardedArgs: [],
+    }
+  )
+})

--- a/packages/run/test/unit/install.spec.js
+++ b/packages/run/test/unit/install.spec.js
@@ -1,0 +1,71 @@
+import test from 'ava'
+import { EventEmitter } from 'node:events'
+import { buildNpmArgs, installPackage } from '../../src/install.js'
+import { InstallError } from '../../src/error.js'
+
+test('buildNpmArgs - disables scripts by default', (t) => {
+  const args = buildNpmArgs('cowsay')
+  t.true(args.includes('--ignore-scripts'))
+  t.is(args[0], 'install')
+  t.true(args.includes('cowsay'))
+})
+
+test('buildNpmArgs - omits --ignore-scripts when allowScripts', (t) => {
+  const args = buildNpmArgs('cowsay', { allowScripts: true })
+  t.false(args.includes('--ignore-scripts'))
+})
+
+test('buildNpmArgs - includes registry', (t) => {
+  const args = buildNpmArgs('cowsay', { registry: 'https://r.example.com' })
+  const i = args.indexOf('--registry')
+  t.true(i !== -1)
+  t.is(args[i + 1], 'https://r.example.com')
+})
+
+test('buildNpmArgs - quiet sets silent loglevel', (t) => {
+  const args = buildNpmArgs('cowsay', { quiet: true })
+  const i = args.indexOf('--loglevel')
+  t.is(args[i + 1], 'silent')
+})
+
+/**
+ * Builds a fake `spawn` that records calls and drives a child via `behavior`.
+ *
+ * @param {(child: EventEmitter) => void} behavior
+ */
+const makeSpawn = (behavior) => {
+  /** @type {{ cmd: string; args: string[] }[]} */
+  const calls = []
+  /** @type {any} */
+  const spawn = (/** @type {string} */ cmd, /** @type {string[]} */ args) => {
+    const child = new EventEmitter()
+    calls.push({ cmd, args })
+    setImmediate(() => behavior(child))
+    return child
+  }
+  return { spawn, calls }
+}
+
+test('installPackage - resolves on exit code 0', async (t) => {
+  const { spawn, calls } = makeSpawn((child) => child.emit('close', 0))
+  await t.notThrowsAsync(installPackage('cowsay', { cwd: '/sandbox', spawn }))
+  t.true(calls[0].args.includes('--ignore-scripts'))
+})
+
+test('installPackage - rejects on non-zero exit code', async (t) => {
+  const { spawn } = makeSpawn((child) => child.emit('close', 1))
+  await t.throwsAsync(installPackage('cowsay', { cwd: '/sandbox', spawn }), {
+    instanceOf: InstallError,
+    message: /exited with code 1/,
+  })
+})
+
+test('installPackage - rejects when spawn errors', async (t) => {
+  const { spawn } = makeSpawn((child) =>
+    child.emit('error', new Error('ENOENT'))
+  )
+  await t.throwsAsync(installPackage('cowsay', { cwd: '/sandbox', spawn }), {
+    instanceOf: InstallError,
+    message: /Failed to spawn/,
+  })
+})

--- a/packages/run/test/unit/install.spec.js
+++ b/packages/run/test/unit/install.spec.js
@@ -1,6 +1,11 @@
 import test from 'ava'
 import { EventEmitter } from 'node:events'
-import { buildNpmArgs, installPackage } from '../../src/install.js'
+import {
+  assertValidRegistry,
+  buildNpmArgs,
+  installPackage,
+  sanitizeNpmEnv,
+} from '../../src/install.js'
 import { InstallError } from '../../src/error.js'
 
 test('buildNpmArgs - disables scripts by default', (t) => {
@@ -8,6 +13,50 @@ test('buildNpmArgs - disables scripts by default', (t) => {
   t.true(args.includes('--ignore-scripts'))
   t.is(args[0], 'install')
   t.true(args.includes('cowsay'))
+})
+
+test('buildNpmArgs - spec is placed last, after a "--" guard', (t) => {
+  const args = buildNpmArgs('cowsay')
+  t.is(args[args.length - 1], 'cowsay')
+  t.is(args[args.length - 2], '--')
+  // A "-"-leading spec is therefore inert as an npm flag.
+  const evil = buildNpmArgs('--ignore-scripts=false')
+  t.is(evil[evil.length - 1], '--ignore-scripts=false')
+  t.is(evil[evil.length - 2], '--')
+})
+
+test('buildNpmArgs - rejects a non-http(s) registry', (t) => {
+  t.throws(() => buildNpmArgs('cowsay', { registry: 'file:///etc' }), {
+    instanceOf: InstallError,
+  })
+  t.throws(() => buildNpmArgs('cowsay', { registry: 'not a url' }), {
+    instanceOf: InstallError,
+  })
+})
+
+test('assertValidRegistry - accepts http(s), rejects others', (t) => {
+  t.notThrows(() => assertValidRegistry('https://r.example.com'))
+  t.notThrows(() => assertValidRegistry('http://localhost:4873'))
+  t.throws(() => assertValidRegistry('ftp://r.example.com'), {
+    instanceOf: InstallError,
+  })
+})
+
+test('sanitizeNpmEnv - strips script/code-injection vars, keeps the rest', (t) => {
+  const cleaned = sanitizeNpmEnv({
+    PATH: '/usr/bin',
+    NODE_OPTIONS: '--require /evil.js',
+    npm_config_ignore_scripts: 'false',
+    npm_config_node_options: '--require /evil.js',
+    npm_config_script_shell: '/bin/evil',
+    npm_config_registry: 'https://r.example.com',
+  })
+  t.is(cleaned.PATH, '/usr/bin')
+  t.is(cleaned.npm_config_registry, 'https://r.example.com')
+  t.is(cleaned.NODE_OPTIONS, undefined)
+  t.is(cleaned.npm_config_ignore_scripts, undefined)
+  t.is(cleaned.npm_config_node_options, undefined)
+  t.is(cleaned.npm_config_script_shell, undefined)
 })
 
 test('buildNpmArgs - omits --ignore-scripts when allowScripts', (t) => {

--- a/packages/run/test/unit/resolve-bin.spec.js
+++ b/packages/run/test/unit/resolve-bin.spec.js
@@ -1,0 +1,143 @@
+import test from 'ava'
+import path from 'node:path'
+import {
+  getInstalledPackageName,
+  normalizeBin,
+  resolveBin,
+} from '../../src/resolve-bin.js'
+import {
+  AmbiguousBinScriptError,
+  NoBinScriptError,
+  UnknownPackageError,
+} from '../../src/error.js'
+
+test('normalizeBin - string maps to unscoped name', (t) => {
+  t.deepEqual(normalizeBin('cowsay', './cli.js'), { cowsay: './cli.js' })
+})
+
+test('normalizeBin - scoped string maps to unscoped name', (t) => {
+  t.deepEqual(normalizeBin('@scope/foo', 'bin.js'), { foo: 'bin.js' })
+})
+
+test('normalizeBin - object passes through string values', (t) => {
+  t.deepEqual(normalizeBin('pkg', { a: 'a.js', b: 'b.js' }), {
+    a: 'a.js',
+    b: 'b.js',
+  })
+})
+
+test('normalizeBin - undefined yields empty map', (t) => {
+  t.deepEqual(normalizeBin('pkg', undefined), {})
+})
+
+/**
+ * @param {unknown} value
+ * @returns {any}
+ */
+const asReadJson = (value) => async () => value
+
+/** @type {any} */
+const existsTrue = async () => true
+/** @type {any} */
+const existsFalse = async () => false
+
+test('getInstalledPackageName - prefers matching hint', async (t) => {
+  const readJson = asReadJson({ dependencies: { cowsay: '^1', other: '^2' } })
+  t.is(
+    await getInstalledPackageName('/sb', { hint: 'cowsay', readJson }),
+    'cowsay'
+  )
+})
+
+test('getInstalledPackageName - single dependency', async (t) => {
+  const readJson = asReadJson({ dependencies: { cowsay: '^1' } })
+  t.is(await getInstalledPackageName('/sb', { readJson }), 'cowsay')
+})
+
+test('getInstalledPackageName - falls back to hint when not in deps', async (t) => {
+  const readJson = asReadJson({ dependencies: {} })
+  t.is(await getInstalledPackageName('/sb', { hint: 'x', readJson }), 'x')
+})
+
+test('getInstalledPackageName - throws when indeterminate', async (t) => {
+  const readJson = asReadJson({ dependencies: { a: '1', b: '2' } })
+  await t.throwsAsync(getInstalledPackageName('/sb', { readJson }), {
+    instanceOf: UnknownPackageError,
+  })
+})
+
+test('resolveBin - single string bin', async (t) => {
+  const readJson = asReadJson({ name: 'cowsay', bin: './cli.js' })
+  const result = await resolveBin('/sb', 'cowsay', {
+    readJson,
+    exists: existsTrue,
+  })
+  t.is(result.binName, 'cowsay')
+  t.is(
+    result.binPath,
+    path.resolve('/sb', 'node_modules', 'cowsay', './cli.js')
+  )
+})
+
+test('resolveBin - object bin matching unscoped name', async (t) => {
+  const readJson = asReadJson({
+    name: '@scope/foo',
+    bin: { foo: 'foo.js', helper: 'helper.js' },
+  })
+  const result = await resolveBin('/sb', '@scope/foo', {
+    readJson,
+    exists: existsTrue,
+  })
+  t.is(result.binName, 'foo')
+})
+
+test('resolveBin - sole bin chosen when name does not match', async (t) => {
+  const readJson = asReadJson({ name: 'pkg', bin: { only: 'only.js' } })
+  const result = await resolveBin('/sb', 'pkg', {
+    readJson,
+    exists: existsTrue,
+  })
+  t.is(result.binName, 'only')
+})
+
+test('resolveBin - explicit call', async (t) => {
+  const readJson = asReadJson({ name: 'pkg', bin: { a: 'a.js', b: 'b.js' } })
+  const result = await resolveBin('/sb', 'pkg', {
+    call: 'b',
+    readJson,
+    exists: existsTrue,
+  })
+  t.is(result.binName, 'b')
+})
+
+test('resolveBin - throws on unknown call', async (t) => {
+  const readJson = asReadJson({ name: 'pkg', bin: { a: 'a.js' } })
+  await t.throwsAsync(
+    resolveBin('/sb', 'pkg', { call: 'nope', readJson, exists: existsTrue }),
+    { instanceOf: NoBinScriptError }
+  )
+})
+
+test('resolveBin - throws when no bin', async (t) => {
+  const readJson = asReadJson({ name: 'pkg' })
+  await t.throwsAsync(
+    resolveBin('/sb', 'pkg', { readJson, exists: existsTrue }),
+    { instanceOf: NoBinScriptError }
+  )
+})
+
+test('resolveBin - throws on ambiguous bins', async (t) => {
+  const readJson = asReadJson({ name: 'pkg', bin: { a: 'a.js', b: 'b.js' } })
+  await t.throwsAsync(
+    resolveBin('/sb', 'pkg', { readJson, exists: existsTrue }),
+    { instanceOf: AmbiguousBinScriptError }
+  )
+})
+
+test('resolveBin - throws when bin file missing', async (t) => {
+  const readJson = asReadJson({ name: 'pkg', bin: './cli.js' })
+  await t.throwsAsync(
+    resolveBin('/sb', 'pkg', { readJson, exists: existsFalse }),
+    { instanceOf: NoBinScriptError }
+  )
+})

--- a/packages/run/test/unit/resolve-bin.spec.js
+++ b/packages/run/test/unit/resolve-bin.spec.js
@@ -54,9 +54,20 @@ test('getInstalledPackageName - single dependency', async (t) => {
   t.is(await getInstalledPackageName('/sb', { readJson }), 'cowsay')
 })
 
-test('getInstalledPackageName - falls back to hint when not in deps', async (t) => {
+test('getInstalledPackageName - sole dependency wins over a non-matching hint', async (t) => {
+  const readJson = asReadJson({ dependencies: { cowsay: '^1' } })
+  t.is(
+    await getInstalledPackageName('/sb', { hint: 'not-installed', readJson }),
+    'cowsay'
+  )
+})
+
+test('getInstalledPackageName - throws on a hint absent from dependencies', async (t) => {
   const readJson = asReadJson({ dependencies: {} })
-  t.is(await getInstalledPackageName('/sb', { hint: 'x', readJson }), 'x')
+  await t.throwsAsync(getInstalledPackageName('/sb', { hint: 'x', readJson }), {
+    instanceOf: UnknownPackageError,
+    message: /"x" is not among its dependencies/,
+  })
 })
 
 test('getInstalledPackageName - throws when indeterminate', async (t) => {

--- a/packages/run/test/unit/run.spec.js
+++ b/packages/run/test/unit/run.spec.js
@@ -84,15 +84,15 @@ test.serial(
     // install: lifecycle scripts disabled by default
     t.is(calls.install.length, 1)
     t.is(calls.install[0].spec, 'cowsay')
-    t.is(calls.install[0].options.allowScripts, false)
+    t.false(calls.install[0].options.allowScripts)
 
     // policy + run: untrusted root, prodOnly by default
     t.is(calls.generatePolicy.length, 1)
-    t.is(calls.generatePolicy[0].options.trustRoot, false)
-    t.is(calls.generatePolicy[0].options.prodOnly, true)
+    t.false(calls.generatePolicy[0].options.trustRoot)
+    t.true(calls.generatePolicy[0].options.prodOnly)
     t.is(calls.run.length, 1)
-    t.is(calls.run[0].options.trustRoot, false)
-    t.is(calls.run[0].options.prodOnly, true)
+    t.false(calls.run[0].options.trustRoot)
+    t.true(calls.run[0].options.prodOnly)
 
     // forwarded args are presented to the bin via process.argv
     t.deepEqual(calls.run[0].argv.slice(2), ['Hello!'])
@@ -108,7 +108,7 @@ test.serial(
 
     await lavax('cowsay', [], { ...options, cacheDir, allowScripts: true })
 
-    t.is(calls.install[0].options.allowScripts, true)
+    t.true(calls.install[0].options.allowScripts)
   }
 )
 
@@ -119,8 +119,8 @@ test.serial('lavax - prodOnly:false flows to policy and run', async (t) => {
 
   await lavax('cowsay', [], { ...options, cacheDir, prodOnly: false })
 
-  t.is(calls.generatePolicy[0].options.prodOnly, false)
-  t.is(calls.run[0].options.prodOnly, false)
+  t.false(calls.generatePolicy[0].options.prodOnly)
+  t.false(calls.run[0].options.prodOnly)
 })
 
 test.serial('lavax - reuses the cached install on a second run', async (t) => {

--- a/packages/run/test/unit/run.spec.js
+++ b/packages/run/test/unit/run.spec.js
@@ -1,0 +1,185 @@
+import test from 'ava'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { lavax } from '../../src/run.js'
+
+/**
+ * Creates a fresh temp cache base directory.
+ *
+ * @returns {Promise<string>}
+ */
+const makeTmp = () => mkdtemp(path.join(os.tmpdir(), 'lavamoat-run-test-'))
+
+/**
+ * Builds injectable fakes that record calls and emulate just enough of `npm`
+ * and `@lavamoat/node` for `lavax`'s filesystem-driven steps to succeed without
+ * any network access.
+ *
+ * @param {{ binName?: string }} [opts]
+ */
+const makeFakes = ({ binName = 'cowsay' } = {}) => {
+  const calls = {
+    /** @type {any[]} */ install: [],
+    /** @type {any[]} */ generatePolicy: [],
+    /** @type {any[]} */ run: [],
+  }
+
+  /** @type {any} */
+  const install = async (
+    /** @type {string} */ spec,
+    /** @type {any} */ options
+  ) => {
+    calls.install.push({ spec, options })
+    const { cwd } = options
+    // Emulate npm: record the dependency in the sandbox package.json and
+    // populate node_modules with a minimal installed package + bin.
+    const pkgPath = path.join(cwd, 'package.json')
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf8'))
+    pkg.dependencies = { [binName]: '^1.0.0' }
+    await writeFile(pkgPath, JSON.stringify(pkg))
+    const modDir = path.join(cwd, 'node_modules', binName)
+    await mkdir(modDir, { recursive: true })
+    await writeFile(
+      path.join(modDir, 'package.json'),
+      JSON.stringify({ name: binName, bin: { [binName]: 'cli.js' } })
+    )
+    await writeFile(path.join(modDir, 'cli.js'), '// bin\n')
+  }
+
+  /** @type {any} */
+  const generatePolicy = async (
+    /** @type {string} */ binPath,
+    /** @type {any} */ options
+  ) => {
+    calls.generatePolicy.push({ binPath, options })
+    if (options.write && options.policyPath) {
+      await mkdir(path.dirname(options.policyPath), { recursive: true })
+      await writeFile(options.policyPath, JSON.stringify({ resources: {} }))
+    }
+    return { resources: {} }
+  }
+
+  /** @type {any} */
+  const run = async (
+    /** @type {string} */ binPath,
+    /** @type {any} */ options
+  ) => {
+    calls.run.push({ binPath, options, argv: [...process.argv] })
+    return { ran: binPath }
+  }
+
+  return { calls, options: { install, run, generatePolicy } }
+}
+
+test.serial(
+  'lavax - propagates secure defaults to install, policy, and run',
+  async (t) => {
+    const cacheDir = await makeTmp()
+    t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+    const { calls, options } = makeFakes()
+
+    await lavax('cowsay', ['Hello!'], { ...options, cacheDir })
+
+    // install: lifecycle scripts disabled by default
+    t.is(calls.install.length, 1)
+    t.is(calls.install[0].spec, 'cowsay')
+    t.is(calls.install[0].options.allowScripts, false)
+
+    // policy + run: untrusted root, prodOnly by default
+    t.is(calls.generatePolicy.length, 1)
+    t.is(calls.generatePolicy[0].options.trustRoot, false)
+    t.is(calls.generatePolicy[0].options.prodOnly, true)
+    t.is(calls.run.length, 1)
+    t.is(calls.run[0].options.trustRoot, false)
+    t.is(calls.run[0].options.prodOnly, true)
+
+    // forwarded args are presented to the bin via process.argv
+    t.deepEqual(calls.run[0].argv.slice(2), ['Hello!'])
+  }
+)
+
+test.serial('lavax - allowScripts flows through to the installer', async (t) => {
+  const cacheDir = await makeTmp()
+  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+  const { calls, options } = makeFakes()
+
+  await lavax('cowsay', [], { ...options, cacheDir, allowScripts: true })
+
+  t.is(calls.install[0].options.allowScripts, true)
+})
+
+test.serial('lavax - prodOnly:false flows to policy and run', async (t) => {
+  const cacheDir = await makeTmp()
+  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+  const { calls, options } = makeFakes()
+
+  await lavax('cowsay', [], { ...options, cacheDir, prodOnly: false })
+
+  t.is(calls.generatePolicy[0].options.prodOnly, false)
+  t.is(calls.run[0].options.prodOnly, false)
+})
+
+test.serial('lavax - reuses the cached install on a second run', async (t) => {
+  const cacheDir = await makeTmp()
+  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+  const { calls, options } = makeFakes()
+
+  await lavax('cowsay', [], { ...options, cacheDir })
+  await lavax('cowsay', [], { ...options, cacheDir })
+
+  t.is(calls.install.length, 1)
+})
+
+test.serial('lavax - force reinstalls even when cached', async (t) => {
+  const cacheDir = await makeTmp()
+  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+  const { calls, options } = makeFakes()
+
+  await lavax('cowsay', [], { ...options, cacheDir })
+  await lavax('cowsay', [], { ...options, cacheDir, force: true })
+
+  t.is(calls.install.length, 2)
+})
+
+test.serial('lavax - reuses the cached policy unless regenerate', async (t) => {
+  const cacheDir = await makeTmp()
+  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+  const { calls, options } = makeFakes()
+
+  await lavax('cowsay', [], { ...options, cacheDir }) // generates
+  await lavax('cowsay', [], { ...options, cacheDir }) // cached
+  t.is(calls.generatePolicy.length, 1)
+  // the cached policy is still enforced: run receives its path
+  t.truthy(calls.run[1].options.policyPath)
+
+  await lavax('cowsay', [], { ...options, cacheDir, regenerate: true })
+  t.is(calls.generatePolicy.length, 2)
+})
+
+test.serial(
+  'lavax - restores process.argv after run and on rejection',
+  async (t) => {
+    const cacheDir = await makeTmp()
+    t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+    const before = [...process.argv]
+
+    const { options } = makeFakes()
+    await lavax('cowsay', ['x'], { ...options, cacheDir })
+    t.deepEqual(process.argv, before)
+
+    const failing = {
+      ...makeFakes().options,
+      run: /** @type {any} */ (
+        async () => {
+          throw new Error('boom')
+        }
+      ),
+    }
+    await t.throwsAsync(
+      lavax('cowsay', ['y'], { ...failing, cacheDir, force: true }),
+      { message: 'boom' }
+    )
+    t.deepEqual(process.argv, before)
+  }
+)

--- a/packages/run/test/unit/run.spec.js
+++ b/packages/run/test/unit/run.spec.js
@@ -99,15 +99,18 @@ test.serial(
   }
 )
 
-test.serial('lavax - allowScripts flows through to the installer', async (t) => {
-  const cacheDir = await makeTmp()
-  t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
-  const { calls, options } = makeFakes()
+test.serial(
+  'lavax - allowScripts flows through to the installer',
+  async (t) => {
+    const cacheDir = await makeTmp()
+    t.teardown(() => rm(cacheDir, { recursive: true, force: true }))
+    const { calls, options } = makeFakes()
 
-  await lavax('cowsay', [], { ...options, cacheDir, allowScripts: true })
+    await lavax('cowsay', [], { ...options, cacheDir, allowScripts: true })
 
-  t.is(calls.install[0].options.allowScripts, true)
-})
+    t.is(calls.install[0].options.allowScripts, true)
+  }
+)
 
 test.serial('lavax - prodOnly:false flows to policy and run', async (t) => {
   const cacheDir = await makeTmp()

--- a/packages/run/test/unit/spec.spec.js
+++ b/packages/run/test/unit/spec.spec.js
@@ -1,0 +1,138 @@
+import test from 'ava'
+import path from 'node:path'
+import {
+  cacheDirFor,
+  computeCacheBase,
+  parseSpec,
+  slugifySpec,
+  unscopedName,
+} from '../../src/spec.js'
+import { SpecParseError } from '../../src/error.js'
+
+test('parseSpec - bare name', (t) => {
+  t.deepEqual(parseSpec('cowsay'), {
+    name: 'cowsay',
+    version: undefined,
+    raw: 'cowsay',
+  })
+})
+
+test('parseSpec - name with version', (t) => {
+  t.deepEqual(parseSpec('cowsay@1.5.0'), {
+    name: 'cowsay',
+    version: '1.5.0',
+    raw: 'cowsay@1.5.0',
+  })
+})
+
+test('parseSpec - name with dist-tag', (t) => {
+  t.deepEqual(parseSpec('cowsay@latest'), {
+    name: 'cowsay',
+    version: 'latest',
+    raw: 'cowsay@latest',
+  })
+})
+
+test('parseSpec - scoped name', (t) => {
+  t.deepEqual(parseSpec('@lavamoat/node'), {
+    name: '@lavamoat/node',
+    version: undefined,
+    raw: '@lavamoat/node',
+  })
+})
+
+test('parseSpec - scoped name with version', (t) => {
+  t.deepEqual(parseSpec('@lavamoat/node@1.0.6'), {
+    name: '@lavamoat/node',
+    version: '1.0.6',
+    raw: '@lavamoat/node@1.0.6',
+  })
+})
+
+test('parseSpec - scoped name with range', (t) => {
+  t.deepEqual(parseSpec('@scope/pkg@^2.0.0'), {
+    name: '@scope/pkg',
+    version: '^2.0.0',
+    raw: '@scope/pkg@^2.0.0',
+  })
+})
+
+test('parseSpec - trims whitespace', (t) => {
+  t.deepEqual(parseSpec('  cowsay@1  '), {
+    name: 'cowsay',
+    version: '1',
+    raw: 'cowsay@1',
+  })
+})
+
+test('parseSpec - non-registry tarball URL has undefined name', (t) => {
+  const url = 'https://example.com/pkg.tgz'
+  t.deepEqual(parseSpec(url), { name: undefined, version: undefined, raw: url })
+})
+
+test('parseSpec - git specifier has undefined name', (t) => {
+  const spec = 'git+https://github.com/user/repo.git'
+  t.is(parseSpec(spec).name, undefined)
+})
+
+test('parseSpec - github shorthand has undefined name', (t) => {
+  t.is(parseSpec('user/repo').name, undefined)
+})
+
+test('parseSpec - local path has undefined name', (t) => {
+  t.is(parseSpec('./local-pkg').name, undefined)
+})
+
+test('parseSpec - throws on empty', (t) => {
+  t.throws(() => parseSpec('   '), { instanceOf: SpecParseError })
+})
+
+test('parseSpec - throws on non-string', (t) => {
+  // @ts-expect-error testing bad input
+  t.throws(() => parseSpec(42), { instanceOf: SpecParseError })
+})
+
+test('unscopedName - unscoped', (t) => {
+  t.is(unscopedName('cowsay'), 'cowsay')
+})
+
+test('unscopedName - scoped', (t) => {
+  t.is(unscopedName('@lavamoat/node'), 'node')
+})
+
+test('slugifySpec - sanitizes unsafe characters', (t) => {
+  t.is(slugifySpec('@scope/pkg@^2.0.0'), 'scope-pkg-2.0.0')
+})
+
+test('slugifySpec - never empty', (t) => {
+  t.is(slugifySpec('///'), 'pkg')
+})
+
+test('computeCacheBase - explicit cacheDir wins', (t) => {
+  t.is(computeCacheBase({ cacheDir: '/tmp/foo' }), path.resolve('/tmp/foo'))
+})
+
+test('computeCacheBase - falls back to env var', (t) => {
+  t.is(
+    computeCacheBase({ env: { LAVAMOAT_RUN_CACHE: '/tmp/bar' } }),
+    path.resolve('/tmp/bar')
+  )
+})
+
+test('computeCacheBase - default uses homedir', (t) => {
+  t.is(
+    computeCacheBase({ env: {}, homedir: () => '/home/tester' }),
+    path.join('/home/tester', '.lavamoat', 'run')
+  )
+})
+
+test('cacheDirFor - deterministic and under base', (t) => {
+  const a = cacheDirFor('cowsay@1.5.0', '/base')
+  const b = cacheDirFor('cowsay@1.5.0', '/base')
+  t.is(a, b)
+  t.is(path.dirname(a), '/base')
+})
+
+test('cacheDirFor - distinct specs differ', (t) => {
+  t.not(cacheDirFor('cowsay@1', '/base'), cacheDirFor('cowsay@2', '/base'))
+})

--- a/packages/run/test/unit/spec.spec.js
+++ b/packages/run/test/unit/spec.spec.js
@@ -92,6 +92,13 @@ test('parseSpec - throws on non-string', (t) => {
   t.throws(() => parseSpec(42), { instanceOf: SpecParseError })
 })
 
+test('parseSpec - rejects a spec starting with "-"', (t) => {
+  t.throws(() => parseSpec('-rf'), { instanceOf: SpecParseError })
+  t.throws(() => parseSpec('--ignore-scripts=false'), {
+    instanceOf: SpecParseError,
+  })
+})
+
 test('unscopedName - unscoped', (t) => {
   t.is(unscopedName('cowsay'), 'cowsay')
 })

--- a/packages/run/tsconfig.json
+++ b/packages/run/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../.config/tsconfig.workspace.json",
+  "references": [
+    { "path": "./src/tsconfig.json" },
+    { "path": "./test/tsconfig.json" }
+  ],
+  "files": []
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,6 +35,10 @@
     "packages/react-native-lockdown": {
       "package-name": "@lavamoat/react-native-lockdown"
     },
+    "packages/run": {
+      "package-name": "@lavamoat/run",
+      "initial-version": "0.0.1"
+    },
     "packages/tofu": {
       "package-name": "lavamoat-tofu"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
       "path": "packages/node"
     },
     {
+      "path": "packages/run"
+    },
+    {
       "path": "packages/react-native-lockdown"
     }
   ]


### PR DESCRIPTION
@lavamoat/run ships the `lavax` bin: an npx-style command that fetches and runs a package's bin while applying LavaMoat's security principles.

- install scripts are disabled by default (override with --allow-scripts), matching @lavamoat/allow-scripts
- the bin runs under @lavamoat/node: SES lockdown plus a generated, enforced per-package policy, treating the fetched package as an untrusted root
- packages install into an isolated per-spec sandbox cache; the policy is generated on first use (trust-on-first-use) and reused thereafter
- everything after <spec> is forwarded to the bin, like npx

Wires the package into the monorepo (tsconfig refs, eslint typed config, release-please) and documents it in the root README and AGENTS.md.


Claude-Session: https://claude.ai/code/session_01NSridaT397M7CiBua4Jxpc