### PR TITLE
feat(tofu): Inspect globals passed as function arguments

### DIFF
--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -94,6 +94,18 @@ function inspectGlobals(
       if (globalRefs.includes(keyPath[0])) {
         keyPath.shift()
       }
+
+      // inspect globals passed to functions
+      if (parent.type === 'CallExpression') {
+        const narrowedUsages = inspectFunctionArgumentUsage(path, parent)
+        if (narrowedUsages) {
+          narrowedUsages.forEach(({ keys, use }) => {
+            maybeAddGlobalUsage([...keyPath, ...keys].join('.'), use)
+          })
+          return
+        }
+      }
+
       // inspect for destructuring
       let destructuredPaths
       if (
@@ -156,6 +168,39 @@ function inspectGlobals(
       ...getPathFromMemberExpressionChain(memberExpressions),
     ]
     return { identifierUse, path, parent: parentOfMembershipChain }
+  }
+
+  /**
+   * @param {import('@babel/traverse').NodePath<import('@babel/types').Identifier | import('@babel/types').ThisExpression>} path
+   * @param {import('@babel/types').CallExpression} callExpression
+   * @returns {{ keys: string[], use: GlobalPolicyValue }[] | null}
+   */
+  function inspectFunctionArgumentUsage(path, callExpression) {
+    const argIndex = callExpression.arguments.indexOf(path.node)
+    if (argIndex === -1 || callExpression.callee.type !== 'Identifier') {
+      return null
+    }
+    const functionPath = path.scope.getBinding(callExpression.callee.name)?.path
+    if (!functionPath?.isFunctionDeclaration()) {
+      return null
+    }
+    const param = functionPath?.node.params[argIndex]
+    // skip parameters that arent plain identifiers
+    if (param?.type !== 'Identifier') {
+      return null
+    }
+    const paramReferences = functionPath.scope.getBinding(param.name)?.referencePaths
+    if (!paramReferences || paramReferences.length === 0) {
+      return null
+    }
+    return paramReferences.map((ref) => {
+      const { path, identifierUse } = inspectIdentifierForDirectMembershipChain(
+        param.name,
+        /** @type {import('@babel/types').Identifier} */ (ref.node),
+        /** @type {import('./inspectPrimordialAssignments').MemberLikeExpression[]} */ (getParents(ref))
+      )
+      return { keys: path.slice(1), use: identifierUse }
+    })
   }
 
   /**

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -90,10 +90,6 @@ function inspectGlobals(
           parents
         )
       )
-      // if nested API lookup begins with a globalRef, drop it
-      if (globalRefs.includes(keyPath[0])) {
-        keyPath.shift()
-      }
 
       // inspect globals passed to functions
       if (parent.type === 'CallExpression') {
@@ -104,6 +100,11 @@ function inspectGlobals(
           })
           return
         }
+      }
+
+      // if nested API lookup begins with a globalRef, drop it
+      if (globalRefs.includes(keyPath[0])) {
+        keyPath.shift()
       }
 
       // inspect for destructuring

--- a/packages/tofu/src/inspectSource.js
+++ b/packages/tofu/src/inspectSource.js
@@ -134,8 +134,7 @@ function inspectGlobals(
 
   /**
    * @param {string} variableName
-   * @param {import('@babel/types').Identifier
-   *   | import('@babel/types').ThisExpression} identifierNode
+   * @param {import('@babel/types').Identifier | import('@babel/types').ThisExpression} identifierNode
    * @param {import('./inspectPrimordialAssignments').MemberLikeExpression[]} parents
    * @returns
    */
@@ -172,25 +171,52 @@ function inspectGlobals(
   }
 
   /**
-   * @param {import('@babel/traverse').NodePath<import('@babel/types').Identifier | import('@babel/types').ThisExpression>} path
+   * Collects keys used from a global in a function it is being passed to
+   *
+   * @param {import('@babel/traverse').NodePath<
+   *   import('@babel/types').Identifier | import('@babel/types').ThisExpression
+   * >} path
    * @param {import('@babel/types').CallExpression} callExpression
-   * @returns {{ keys: string[], use: GlobalPolicyValue }[] | null}
+   * @returns {{ keys: string[]; use: GlobalPolicyValue }[] | null}
    */
   function inspectFunctionArgumentUsage(path, callExpression) {
     const argIndex = callExpression.arguments.indexOf(path.node)
     if (argIndex === -1 || callExpression.callee.type !== 'Identifier') {
       return null
     }
-    const functionPath = path.scope.getBinding(callExpression.callee.name)?.path
-    if (!functionPath?.isFunctionDeclaration()) {
+    const bindingPath = path.scope.getBinding(callExpression.callee.name)?.path
+    /**
+     * @type {import('@babel/traverse').NodePath<
+     *       | import('@babel/types').FunctionDeclaration
+     *       | import('@babel/types').FunctionExpression
+     *       | import('@babel/types').ArrowFunctionExpression
+     *     >
+     *   | null}
+     */
+    let functionPath = null
+    if (bindingPath?.isFunctionDeclaration()) {
+      functionPath = bindingPath
+    } else if (bindingPath?.isVariableDeclarator()) {
+      const initPath = bindingPath.get('init')
+      if (
+        initPath?.isFunctionExpression() ||
+        initPath?.isArrowFunctionExpression()
+      ) {
+        functionPath = initPath
+      }
+    }
+    if (!functionPath) {
       return null
     }
-    const param = functionPath?.node.params[argIndex]
+
+    const param = functionPath.node.params[argIndex]
     // skip parameters that arent plain identifiers
     if (param?.type !== 'Identifier') {
       return null
     }
-    const paramReferences = functionPath.scope.getBinding(param.name)?.referencePaths
+    const paramReferences = functionPath.scope.getBinding(
+      param.name
+    )?.referencePaths
     if (!paramReferences || paramReferences.length === 0) {
       return null
     }
@@ -198,7 +224,9 @@ function inspectGlobals(
       const { path, identifierUse } = inspectIdentifierForDirectMembershipChain(
         param.name,
         /** @type {import('@babel/types').Identifier} */ (ref.node),
-        /** @type {import('./inspectPrimordialAssignments').MemberLikeExpression[]} */ (getParents(ref))
+        /** @type {import('./inspectPrimordialAssignments').MemberLikeExpression[]} */ (
+          getParents(ref)
+        )
       )
       return { keys: path.slice(1), use: identifierUse }
     })

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -443,6 +443,98 @@ testInspect(
   {}
 )
 
+testInspect(
+  'passing global to function',
+  {},
+  () => {
+    function getHref(doc) {
+      return doc.location.href;
+    }
+
+    const href = getHref(document);
+
+    console.log(href);
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'passing global to different functions',
+  {},
+  () => {
+    function getHref(doc) {
+      return doc.location.href;
+    }
+    
+    function getElement(doc) {
+      return doc.activeElement;
+    }
+
+    const href = getHref(document);
+    const element = getElement(document);
+
+    console.log(element, href);
+  },
+  {
+    'console.log': 'read',
+    'document.activeElement': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'passing multiple globals to function',
+  {},
+  () => {
+    function logHref(console, doc) {
+      console.log(doc.location.href);
+    }
+
+    logHref(console, document);
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'passing global to function with redeclaration',
+  {},
+  () => {
+    function getElement(doc) {
+      let document = doc;
+      return document.activeElement;
+    }
+
+    const element = getElement(document);
+
+    console.log(element);
+  },
+  {
+    'console.log': 'read',
+    'document': 'read',
+  }
+)
+
+testInspect(
+  'passing global to function with write',
+  {},
+  () => {
+    function overwriteElement(doc) {
+      doc.activeElement = null;
+    }
+
+    overwriteElement(document);
+  },
+  {
+    'document.activeElement': 'write',
+  }
+)
+
 function testInspect(label, opts, fn, expectedResultObj) {
   test(label, (t) => {
     const src = fnToCodeBlock(fn)

--- a/packages/tofu/test/inspectGlobals.spec.js
+++ b/packages/tofu/test/inspectGlobals.spec.js
@@ -448,12 +448,12 @@ testInspect(
   {},
   () => {
     function getHref(doc) {
-      return doc.location.href;
+      return doc.location.href
     }
 
-    const href = getHref(document);
+    const href = getHref(document)
 
-    console.log(href);
+    console.log(href)
   },
   {
     'console.log': 'read',
@@ -466,17 +466,17 @@ testInspect(
   {},
   () => {
     function getHref(doc) {
-      return doc.location.href;
+      return doc.location.href
     }
-    
+
     function getElement(doc) {
-      return doc.activeElement;
+      return doc.activeElement
     }
 
-    const href = getHref(document);
-    const element = getElement(document);
+    const href = getHref(document)
+    const element = getElement(document)
 
-    console.log(element, href);
+    console.log(element, href)
   },
   {
     'console.log': 'read',
@@ -490,10 +490,10 @@ testInspect(
   {},
   () => {
     function logHref(console, doc) {
-      console.log(doc.location.href);
+      console.log(doc.location.href)
     }
 
-    logHref(console, document);
+    logHref(console, document)
   },
   {
     'console.log': 'read',
@@ -506,17 +506,40 @@ testInspect(
   {},
   () => {
     function getElement(doc) {
-      let document = doc;
-      return document.activeElement;
+      let document = doc
+      return document.activeElement
     }
 
-    const element = getElement(document);
+    const element = getElement(document)
 
-    console.log(element);
+    console.log(element)
   },
   {
     'console.log': 'read',
-    'document': 'read',
+    document: 'read',
+  }
+)
+
+testInspect(
+  'passing global to function declared twice',
+  {},
+  () => {
+    function getElement(doc) {
+      return doc.activeElement
+    }
+
+    function nested() {
+      const element = getElement(document)
+      console.log(element)
+
+      function getElement(doc) {
+        return doc.location.href
+      }
+    }
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
   }
 )
 
@@ -525,18 +548,103 @@ testInspect(
   {},
   () => {
     function overwriteElement(doc) {
-      doc.activeElement = null;
+      doc.activeElement = null
     }
 
-    overwriteElement(document);
+    overwriteElement(document)
   },
   {
     'document.activeElement': 'write',
   }
 )
 
+testInspect(
+  'passing global to function expression callee',
+  {},
+  () => {
+    const getHref = function (doc) {
+      return doc.location.href
+    }
+
+    const href = getHref(document)
+    console.log(href)
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'passing global to arrow function callee',
+  {},
+  () => {
+    const getHref = (doc) => doc.location.href
+    const href = getHref(document)
+    console.log(href)
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'does not break when callee not readable',
+  {},
+  () => {
+    const getHref = require('./getHref')
+    const href = getHref(document)
+    console.log(href)
+  },
+  {
+    'console.log': 'read',
+    document: 'read',
+    require: 'read',
+  }
+)
+
+testInspect.bind(test.failing)(
+  'passing global to member-expression callee',
+  {},
+  () => {
+    const api = {
+      getHref(doc) {
+        return doc.location.href
+      },
+    }
+    const href = api.getHref(document)
+    console.log(href)
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
+testInspect(
+  'naive behavior: attributes usage after parameter reassignment to global argument',
+  {},
+  () => {
+    const fake = { location: { href: 'https://example.invalid' } }
+
+    function getHref(doc) {
+      doc = fake
+      return doc.location.href
+    }
+
+    const href = getHref(document)
+    console.log(href)
+  },
+  {
+    'console.log': 'read',
+    'document.location.href': 'read',
+  }
+)
+
 function testInspect(label, opts, fn, expectedResultObj) {
-  test(label, (t) => {
+  const run = typeof this === 'function' ? this : test
+  run(label, (t) => {
     const src = fnToCodeBlock(fn)
     const result = inspectGlobals(src, opts)
     const resultSorted = [...result.entries()].sort(sortBy(0))


### PR DESCRIPTION
Early attempt at inspecting globals passed as function arguments to effectively narrow global policy. 

Ideal case being able to narrow something like the following and bailing on everything else:
```js
function getHref(doc) {  
  return doc.location.href;
}

const href = getHref(document);

console.log(href);
```