### PR TITLE
remove support for Node.js v20.x

### DIFF
--- a/.config/tsconfig.workspace.json
+++ b/.config/tsconfig.workspace.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "composite": true,
     "allowSyntheticDefaultImports": true,

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,25 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - node-version: 20.x
-            workspaces: >-
-              --workspace=packages/aa
-              --workspace=packages/allow-scripts
-              --workspace=packages/browserify
-              --workspace=packages/core
-              --workspace=packages/git-safe-dependencies
-              --workspace=packages/lavamoat-node
-              --workspace=packages/lavapack
-              --workspace=packages/laverna
-              --workspace=packages/node
-              --workspace=packages/preinstall-always-fail
-              --workspace=packages/react-native-lockdown
-              --workspace=packages/tofu
-              --workspace=packages/types
-              --workspace=packages/webpack
-              --workspace=packages/yarn-plugin-allow-scripts
-          - node-version: 22.x
-          - node-version: 24.x
+          - node-version: '^22.22.0'
+          - node-version: '^24.15.0'
     steps:
       - name: Checkout (PR)
         if: github.event_name == 'pull_request'
@@ -65,8 +48,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Build & Test
         uses: ./.github/actions/test
-        with:
-          workspaces: ${{ matrix.workspaces }}
       - name: Dirty Check
         run: node ./scripts/dirty-check.js
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "@commitlint/config-conventional": "19.8.1",
         "@endo/compartment-mapper": "2.1.0",
         "@eslint/js": "10.0.1",
-        "@tsconfig/node20": "20.1.9",
+        "@tsconfig/node22": "22.0.5",
         "@types/lint-staged": "13.3.0",
-        "@types/node": "20.19.41",
+        "@types/node": "22.19.21",
         "@types/semver": "7.7.1",
         "@types/wallabyjs": "0.0.15",
         "@types/yargs": "17.0.35",
@@ -4402,10 +4402,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4692,9 +4692,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -21128,7 +21128,7 @@
         "@endo/compartment-mapper": "2.1.0",
         "@endo/evasive-transform": "2.1.0",
         "@lavamoat/types": "^1.0.2",
-        "@types/node": "20.19.41",
+        "@types/node": "22.19.21",
         "chalk": "4.1.2",
         "lavamoat-core": "^18.0.5",
         "lavamoat-tofu": "^9.0.3",
@@ -21295,7 +21295,7 @@
         "node": "^22.5.1 || ^24.0.0"
       },
       "peerDependencies": {
-        "lavamoat-core": ">18.0.5"
+        "lavamoat-core": ">15.4.0"
       }
     },
     "packages/types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "typescript-eslint": "8.61.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "node": "^22.22.2 || ^24.15.0",
         "npm": ">=7.0.0"
       }
     },
@@ -14129,15 +14129,6 @@
         "chalk": "^4.1.0"
       }
     },
-    "node_modules/loggerr/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "node_modules/loggerr/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -20801,7 +20792,7 @@
         "@types/resolve": "1.20.6"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/allow-scripts": {
@@ -20823,7 +20814,7 @@
         "@types/npmcli__promise-spawn": "6.0.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.9.0 || ^24.0.0"
       }
     },
     "packages/allow-scripts/node_modules/ansi-regex": {
@@ -20922,7 +20913,7 @@
         "watchify": "4.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.22.2 || ^24.15.0"
       }
     },
     "packages/core": {
@@ -20943,7 +20934,7 @@
         "tmp-promise": "3.0.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/git-safe-dependencies": {
@@ -20961,7 +20952,7 @@
         "git-safe-dependencies": "src/cli.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/lavamoat-node": {
@@ -20985,7 +20976,7 @@
         "lavamoat-run-command": "src/run-command.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/lavamoat-node/node_modules/ansi-regex": {
@@ -21076,7 +21067,7 @@
         "source-map": "0.7.4"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/lavapack/node_modules/eslint-visitor-keys": {
@@ -21124,7 +21115,7 @@
         "memfs": "4.57.8"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "node": "^22.5.1 || ^24.0.0",
         "npm": ">=8.19.3"
       }
     },
@@ -21156,7 +21147,7 @@
         "memfs": "4.57.8"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "node": "^22.5.1 || ^24.0.0",
         "npm": ">=9.0.0"
       }
     },
@@ -21265,7 +21256,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/react-native-lockdown": {
@@ -21279,7 +21270,7 @@
         "@react-native/js-polyfills": "0.86.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       },
       "peerDependencies": {
         "@react-native/js-polyfills": "*"
@@ -21301,7 +21292,7 @@
         "deep-equal": "2.2.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       },
       "peerDependencies": {
         "lavamoat-core": ">18.0.5"
@@ -21315,7 +21306,7 @@
         "@babel/types": "7.29.7"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+        "node": "^22.5.1 || ^24.0.0"
       }
     },
     "packages/vog": {
@@ -21360,7 +21351,7 @@
         "webpack": "5.107.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "node": "^22.5.1 || ^24.0.0",
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
@@ -21378,7 +21369,7 @@
         "clipanion": "3.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+        "node": "^22.5.1 || ^24.0.0",
         "yarn": "^3.1.1"
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "node": "^22.22.2 || ^24.15.0",
     "npm": ">=7.0.0"
   },
   "scripts": {
@@ -44,7 +44,7 @@
     "@eslint/js": "10.0.1",
     "@tsconfig/node20": "20.1.9",
     "@types/lint-staged": "13.3.0",
-    "@types/node": "20.19.41",
+    "@types/node": "22.19.21",
     "@types/semver": "7.7.1",
     "@types/wallabyjs": "0.0.15",
     "@types/yargs": "17.0.35",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@commitlint/config-conventional": "19.8.1",
     "@endo/compartment-mapper": "2.1.0",
     "@eslint/js": "10.0.1",
-    "@tsconfig/node20": "20.1.9",
+    "@tsconfig/node22": "22.0.5",
     "@types/lint-staged": "13.3.0",
     "@types/node": "22.19.21",
     "@types/semver": "7.7.1",

--- a/packages/aa/package.json
+++ b/packages/aa/package.json
@@ -5,7 +5,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "bin": {
     "lavamoat-ls": "src/cli.js"

--- a/packages/allow-scripts/package.json
+++ b/packages/allow-scripts/package.json
@@ -11,7 +11,7 @@
   "author": "LavaMoat Team",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.9.0 || ^24.0.0"
   },
   "bin": {
     "allow-scripts": "src/cli.js"

--- a/packages/browserify/package.json
+++ b/packages/browserify/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.22.2 || ^24.15.0"
   },
   "main": "src/index.js",
   "directories": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "bin": {
     "lavamoat-sort-policy": "src/policy-sort-cli.js"

--- a/packages/git-safe-dependencies/package.json
+++ b/packages/git-safe-dependencies/package.json
@@ -14,7 +14,7 @@
   "author": "naugtur",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "bin": {
     "git-safe-dependencies": "src/cli.js",

--- a/packages/lavamoat-node/package.json
+++ b/packages/lavamoat-node/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "bin": {
     "lavamoat": "src/cli.js",

--- a/packages/lavapack/package.json
+++ b/packages/lavapack/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "main": "src/index.js",
   "files": [

--- a/packages/laverna/package.json
+++ b/packages/laverna/package.json
@@ -14,7 +14,7 @@
   "author": "boneskull",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "node": "^22.5.1 || ^24.0.0",
     "npm": ">=8.19.3"
   },
   "bin": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,7 +13,7 @@
   "author": "LavaMoat Project",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "node": "^22.5.1 || ^24.0.0",
     "npm": ">=9.0.0"
   },
   "bin": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -59,7 +59,7 @@
     "@endo/compartment-mapper": "2.1.0",
     "@endo/evasive-transform": "2.1.0",
     "@lavamoat/types": "^1.0.2",
-    "@types/node": "20.19.41",
+    "@types/node": "22.19.21",
     "chalk": "4.1.2",
     "lavamoat-core": "^18.0.5",
     "lavamoat-tofu": "^9.0.3",

--- a/packages/preinstall-always-fail/package.json
+++ b/packages/preinstall-always-fail/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "keywords": [],
   "scripts": {

--- a/packages/react-native-lockdown/package.json
+++ b/packages/react-native-lockdown/package.json
@@ -14,7 +14,7 @@
   "author": "LavaMoat Team",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "main": "./src/index.js",
   "exports": {

--- a/packages/tofu/package.json
+++ b/packages/tofu/package.json
@@ -14,7 +14,7 @@
   "author": "kumavis",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "main": "src/index.js",
   "types": "./types/types.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   "author": "boneskull",
   "license": "MIT",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0"
+    "node": "^22.5.1 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -14,7 +14,7 @@
   "author": "LavaMoat Team",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "node": "^22.5.1 || ^24.0.0",
     "npm": ">=7.0.0"
   },
   "main": "src/plugin.js",

--- a/packages/yarn-plugin-allow-scripts/package.json
+++ b/packages/yarn-plugin-allow-scripts/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": "^20.19.0 || ^22.5.1 || ^24.0.0",
+    "node": "^22.5.1 || ^24.0.0",
     "yarn": "^3.1.1"
   },
   "main": "./sources/index.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "files": [],
   // the workspaces which are consumed as libraries by other workspaces should
   // be first in this list


### PR DESCRIPTION
This PR drops support for Node.js v20.x.

It also changes the following deps:

- Removed: [@tsconfig/node20](https://npmx.dev/package/@tsconfig/node20)
- Added: [@tsconfig/node22](https://npmx.dev/package/@tsconfig/node22)
- Upgraded: [@types/node](https://npmx.dev/package/@types/node) to v22.x