### PR TITLE
chore: avoid @internal in JS sources

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -239,6 +239,26 @@ export default defineConfig(
   },
 
   // ---------------------------------------------------------------------------
+  // 2b. Ban `@internal` in JS comments
+  //     `stripInternal` only honors `@internal` in TSDoc (`.ts`) declarations.
+  //     In JSDoc (`.js`) the tag is silently ignored, so the declaration is
+  //     NOT stripped from the emitted `.d.ts` — a false sense of privacy. Put
+  //     internal type definitions (and their `@internal` tags) in `.ts` files.
+  //
+  //    `no-restricted-syntax` cannot see comment text (esquery matches AST
+  //    nodes, not comments), so `no-warning-comments` is the correct tool.
+  // ---------------------------------------------------------------------------
+  {
+    files: ['**/*.js'],
+    rules: {
+      'no-warning-comments': [
+        'error',
+        { terms: ['@internal'], location: 'anywhere' },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
   // 3. Test file overrides
   //    Test file overrides (eslint-plugin-ava + browser globals).
   // ---------------------------------------------------------------------------

--- a/packages/aa/src/index.js
+++ b/packages/aa/src/index.js
@@ -388,7 +388,6 @@ function comparePackageLogicalPaths(aPath, bPath) {
  * @property {boolean} [includeDevDeps]
  * @property {Set<string>} [visited]
  * @property {Resolver} [resolve]
- * @internal
  */
 
 /**

--- a/packages/laverna/src/index.js
+++ b/packages/laverna/src/index.js
@@ -1,7 +1,14 @@
 /**
- * @import {LavernaOptions, LavernaCapabilities, PublishFn, Publisher, GetVersions, GlobDirent} from './types'
  * @import {ExecFileException} from 'node:child_process'
  * @import {PackageJson} from 'type-fest'
+ * @import {
+ *   GetVersions,
+ *   GlobDirent,
+ *   LavernaCapabilities,
+ *   LavernaOptions,
+ *   Publisher,
+ *   PublishFn
+ * } from './types'
  */
 
 const path = require('node:path')
@@ -429,7 +436,6 @@ exports.Laverna = class Laverna {
    * @param {string} name
    * @param {string} [version]
    * @returns {string}
-   * @internal
    */
   static pkgToString(name, version) {
     return version ? `${bold(name)}${gray('@')}${version}` : bold(name)

--- a/packages/node/src/compartment/import-hook.js
+++ b/packages/node/src/compartment/import-hook.js
@@ -2,7 +2,6 @@
  * Provides exit module hooks for Node.js builtins
  *
  * @packageDocumentation
- * @internal
  */
 
 import { Module } from 'node:module'
@@ -12,7 +11,10 @@ import { isObject } from '../util.js'
 const { freeze, keys, assign } = Object
 
 /**
- * @import {ExitModuleImportHook, ExitModuleImportNowHook} from '@endo/compartment-mapper'
+ * @import {
+ *   ExitModuleImportHook,
+ *   ExitModuleImportNowHook
+ * } from '@endo/compartment-mapper'
  * @import {ThirdPartyStaticModuleInterface} from 'ses'
  */
 
@@ -44,7 +46,6 @@ const makeStaticModuleInterface = (ns) => {
  * Import hook for exit modules, which are typically Node.js builtins
  *
  * @type {ExitModuleImportHook}
- * @internal
  */
 export const importHook = async (specifier) => {
   /** @type {unknown} */
@@ -57,7 +58,6 @@ export const importHook = async (specifier) => {
  * Import "now" hook for exit modules, which are typically Node.js builtins.
  *
  * @type {ExitModuleImportNowHook}
- * @internal
  */
 export const importNowHook = (specifier, packageLocation) => {
   const require = Module.createRequire(fileURLToPath(packageLocation))
@@ -75,7 +75,6 @@ export const importNowHook = (specifier, packageLocation) => {
  * `@endo/compartment-mapper`)
  *
  * @type {ExitModuleImportHook}
- * @internal
  */
 export const nullImportHook = async () => {
   return freeze({

--- a/packages/node/src/compartment/module-transforms.js
+++ b/packages/node/src/compartment/module-transforms.js
@@ -3,7 +3,6 @@
  * transforms provided to `@endo/compartment-mapper`.
  *
  * @packageDocumentation
- * @internal
  */
 
 import { evadeCensorSync } from '@endo/evasive-transform'
@@ -14,7 +13,10 @@ const encoder = new TextEncoder()
 const { URL } = globalThis
 
 /**
- * @import {SyncModuleTransform, Language} from '@endo/compartment-mapper'
+ * @import {
+ *   Language,
+ *   SyncModuleTransform
+ * } from '@endo/compartment-mapper'
  */
 
 /**
@@ -80,8 +82,6 @@ const createModuleTransform = (parser) => {
 
 /**
  * Standard set of module transforms for our purposes
- *
- * @internal
  */
 export const syncModuleTransforms = /** @type {const} */ ({
   cjs: createModuleTransform('cjs'),

--- a/packages/node/src/compartment/node-compartment-map.js
+++ b/packages/node/src/compartment/node-compartment-map.js
@@ -3,7 +3,6 @@
  * descriptor generated from a `node_modules` directory.
  *
  * @packageDocumentation
- * @internal
  */
 
 import { mapNodeModules } from '@endo/compartment-mapper/node-modules.js'
@@ -14,14 +13,22 @@ import { DEFAULT_ENDO_OPTIONS } from './options.js'
 import { defaultReadPowers } from './power.js'
 
 /**
- * @import {CanonicalName,
- *  CompartmentMapDescriptor,
- *  PackageCompartmentMapDescriptor,
- *  PackageCompartmentDescriptorName,
- * MapNodeModulesOptions} from '@endo/compartment-mapper'
- * @import {MakeNodeCompartmentMapOptions, MakeNodeCompartmentMapResult} from '../internal.js'
- * @import {Entries, PackageJson} from 'type-fest';
- * @import {Loggerr} from 'loggerr';
+ * @import {
+ *   CanonicalName,
+ *   CompartmentMapDescriptor,
+ *   MapNodeModulesOptions,
+ *   PackageCompartmentDescriptorName,
+ *   PackageCompartmentMapDescriptor
+ * } from '@endo/compartment-mapper'
+ * @import {Loggerr} from 'loggerr'
+ * @import {
+ *   Entries,
+ *   PackageJson
+ * } from 'type-fest'
+ * @import {
+ *   MakeNodeCompartmentMapOptions,
+ *   MakeNodeCompartmentMapResult
+ * } from '../internal.js'
  */
 
 const DEFAULT_CONDITIONS = /** @type {const} */ (['node'])
@@ -80,7 +87,6 @@ const createPackageJsonMap = (
  * @param {string | URL} entrypointPath
  * @param {MakeNodeCompartmentMapOptions} [options]
  * @returns {Promise<MakeNodeCompartmentMapResult>}
- * @internal
  */
 export const makeNodeCompartmentMap = async (
   entrypointPath,

--- a/packages/node/src/compartment/options.js
+++ b/packages/node/src/compartment/options.js
@@ -2,7 +2,6 @@
  * Provides {@link DEFAULT_ENDO_OPTIONS}
  *
  * @packageDocumentation
- * @internal
  */
 
 import { defaultParserForLanguage } from '@endo/compartment-mapper/import-parsers.js'
@@ -12,7 +11,7 @@ import { syncModuleTransforms } from './module-transforms.js'
 import parseNative from './parse-native.js'
 
 /**
- * @import {CaptureLiteOptions} from '@endo/compartment-mapper';
+ * @import {CaptureLiteOptions} from '@endo/compartment-mapper'
  * @import {ExecuteOptions} from '../types.js'
  */
 
@@ -22,7 +21,6 @@ const { freeze } = Object
  * Common options for `@endo/compartment-mapper` functions
  *
  * @satisfies {CaptureLiteOptions | ExecuteOptions}
- * @internal
  */
 export const DEFAULT_ENDO_OPTIONS = freeze(
   /** @type {const} */ ({

--- a/packages/node/src/compartment/parse-native.js
+++ b/packages/node/src/compartment/parse-native.js
@@ -16,7 +16,10 @@ import { hrLabel } from '../format.js'
 const { freeze, keys } = Object
 
 /**
- * @import {ParseFn, ParserImplementation} from '@endo/compartment-mapper'
+ * @import {
+ *   ParseFn,
+ *   ParserImplementation
+ * } from '@endo/compartment-mapper'
  * @import {ThirdPartyStaticModuleInterface} from 'ses'
  * @import {LavaMoatEndoPackagePolicy} from '../types.js'
  */
@@ -80,7 +83,6 @@ const parseNative = (
  * Parser for native Node.js modules
  *
  * @type {ParserImplementation}
- * @internal
  */
 export default {
   parse: parseNative,

--- a/packages/node/src/exec/default-attenuator.js
+++ b/packages/node/src/exec/default-attenuator.js
@@ -2,7 +2,6 @@
  * Provides the default global and module attenuator
  *
  * @packageDocumentation
- * @internal
  */
 
 import { endowmentsToolkit } from 'lavamoat-core'
@@ -17,8 +16,11 @@ import { AttenuationError } from '../error.js'
 import { isObjectyObject } from '../util.js'
 
 /**
+ * @import {
+ *   GlobalAttenuatorFn,
+ *   ModuleAttenuatorFn
+ * } from '@endo/compartment-mapper'
  * @import {MakeGlobalsAttenuatorOptions} from '../internal.js'
- * @import {GlobalAttenuatorFn, ModuleAttenuatorFn} from '@endo/compartment-mapper'
  * @import {GlobalAttenuatorParams} from '../types.js'
  */
 
@@ -44,7 +46,6 @@ const {
  *     Record<string, unknown>
  *   >
  * }}
- * @internal
  */
 export const makeAttenuators = ({
   policy: { resources } = { resources: {} },

--- a/packages/node/src/exec/exec-compartment-class.js
+++ b/packages/node/src/exec/exec-compartment-class.js
@@ -9,8 +9,11 @@ import { endowmentsToolkit } from 'lavamoat-core'
 const wrapFunctionConstructor = endowmentsToolkit.defaultCreateFunctionWrapper
 
 /**
- * @import {SomeGlobalThis, ContextTestFn} from '../internal.js'
  * @import {CompartmentOptions} from 'ses'
+ * @import {
+ *   ContextTestFn,
+ *   SomeGlobalThis
+ * } from '../internal.js'
  */
 
 /**
@@ -23,7 +26,6 @@ const wrapFunctionConstructor = endowmentsToolkit.defaultCreateFunctionWrapper
  * @param {SomeGlobalThis} originalGlobalThis Needed to provide a real
  *   {@link Math} and {@link Date}
  * @returns {typeof Compartment}
- * @internal
  */
 export const makeExecutionCompartment = (originalGlobalThis) => {
   return class ExecutionCompartment extends Compartment {

--- a/packages/node/src/format.js
+++ b/packages/node/src/format.js
@@ -52,7 +52,6 @@ const colorSplit = (
  *
  * @param {string | URL} filepath Path to display
  * @returns {string} Human-readable path
- * @internal
  */
 export const hrPath = (filepath) => {
   filepath = toPath(filepath)
@@ -85,7 +84,6 @@ export const hrPath = (filepath) => {
  *
  * @param {string} name
  * @returns {string}
- * @internal
  */
 export const hrLabel = (name, dim = false) =>
   colorSplit(name, {
@@ -99,6 +97,5 @@ export const hrLabel = (name, dim = false) =>
  *
  * @param {string} value
  * @returns {string}
- * @internal
  */
 export const hrCode = chalk.cyan.bold

--- a/packages/node/src/fs.js
+++ b/packages/node/src/fs.js
@@ -10,7 +10,10 @@ import nodePath from 'node:path'
 
 /**
  * @import {PathLike} from 'node:fs'
- * @import {WithFs, WithReadFile} from './types.js'
+ * @import {
+ *   WithFs,
+ *   WithReadFile
+ * } from './types.js'
  */
 
 /**
@@ -20,7 +23,6 @@ import nodePath from 'node:path'
  * @param {string | URL} filepath
  * @param {WithReadFile} opts
  * @returns {Promise<T>} JSON data
- * @internal
  */
 export const readJsonFile = async (
   filepath,

--- a/packages/node/src/policy-converter.js
+++ b/packages/node/src/policy-converter.js
@@ -33,24 +33,26 @@ import { isArray, isBoolean } from './util.js'
 const { create, entries, fromEntries } = Object
 
 /**
- * @import {GlobalPolicy,
+ * @import {
+ *   GlobalPolicy,
+ *   LavaMoatPolicy,
  *   PackagePolicy,
- *   ResourcePolicy,
- *   LavaMoatPolicy} from '@lavamoat/types'
- * @import {LavaMoatEndoPackagePolicy,
+ *   ResourcePolicy
+ * } from '@lavamoat/types'
+ * @import {
+ *   LavaMoatEndoPackagePolicy,
  *   LavaMoatEndoPackagePolicyOptions,
  *   LavaMoatEndoPolicy,
- *   ToEndoPolicyOptions,
- *   Resources,
  *   MergedLavaMoatPolicy,
+ *   Resources,
+ *   ToEndoPolicyOptions,
  *   ToEndoPolicyOptionsWithoutPolicyOverride,
- *   UnmergedLavaMoatPolicy} from './types.js'
+ *   UnmergedLavaMoatPolicy
+ * } from './types.js'
  */
 
 /**
  * Boilerplate for Endo policies.
- *
- * @internal
  */
 export const ENDO_POLICY_BOILERPLATE = Object.freeze(
   /**
@@ -66,8 +68,6 @@ export const ENDO_POLICY_BOILERPLATE = Object.freeze(
 /**
  * The contents of {@link LavaMoatEndoPolicy.entry} when the entry is trusted
  * (`all`)
- *
- * @internal
  */
 export const ENDO_POLICY_ENTRY_TRUSTED = Object.freeze(
   /**

--- a/packages/node/src/policy-gen/inspector.js
+++ b/packages/node/src/policy-gen/inspector.js
@@ -19,9 +19,18 @@
  */
 
 /**
- * @import {BuiltinPolicy, GlobalPolicy, GlobalPolicyValue} from '@lavamoat/types'
  * @import {ParseResult} from '@babel/parser'
- * @import {InspectMessage, InspectionResultsMessage, ErrorMessage, StructuredViolationsResult} from '../internal.js'
+ * @import {
+ *   BuiltinPolicy,
+ *   GlobalPolicy,
+ *   GlobalPolicyValue
+ * } from '@lavamoat/types'
+ * @import {
+ *   ErrorMessage,
+ *   InspectionResultsMessage,
+ *   InspectMessage,
+ *   StructuredViolationsResult
+ * } from '../internal.js'
  * @import {SourceType} from '../types.js'
  */
 
@@ -120,7 +129,6 @@ const isInspectMessage = (value) => {
  * @param {Map<string, GlobalPolicyValue>} globalMap Map from
  *   {@link inspectGlobals}
  * @returns {GlobalPolicy | null} The resulting global policy
- * @internal
  */
 const globalMapToGlobalPolicy = (globalMap) => {
   if (!globalMap.size) {

--- a/packages/node/src/policy-gen/load-for-policy.js
+++ b/packages/node/src/policy-gen/load-for-policy.js
@@ -3,7 +3,6 @@
  * descriptor for a given entrypoint.
  *
  * @packageDocumentation
- * @internal
  */
 
 import { captureFromMap } from '@endo/compartment-mapper/capture-lite.js'
@@ -38,16 +37,30 @@ import { pluralize } from '../util.js'
 import { WorkerPool } from '../worker-pool.js'
 
 /**
- * @import {LoadAndGeneratePolicyOptions,
- *   LoadCompartmentMapResult,
- *   InspectMessage,
- *   InspectionResultsMessage,
+ * @import {
+ *   CanonicalName,
+ *   ModuleSourceHookModuleSource
+ * } from '@endo/compartment-mapper'
+ * @import {
+ *   BuiltinPolicy,
+ *   GlobalPolicy,
+ *   LavaMoatPolicy,
+ *   PackagePolicy
+ * } from '@lavamoat/types'
+ * @import {
  *   ErrorMessage,
- *   StructuredViolationsResult,
- *   ReportModuleInspectionProgressFn} from '../internal.js'
- * @import {CanonicalName, ModuleSourceHookModuleSource} from '@endo/compartment-mapper'
- * @import {BuiltinPolicy, GlobalPolicy, LavaMoatPolicy, PackagePolicy} from '@lavamoat/types'
- * @import {MergedLavaMoatPolicy, FileUrlString, SourceType} from '../types.js'
+ *   InspectionResultsMessage,
+ *   InspectMessage,
+ *   LoadAndGeneratePolicyOptions,
+ *   LoadCompartmentMapResult,
+ *   ReportModuleInspectionProgressFn,
+ *   StructuredViolationsResult
+ * } from '../internal.js'
+ * @import {
+ *   FileUrlString,
+ *   MergedLavaMoatPolicy,
+ *   SourceType
+ * } from '../types.js'
  */
 
 const inspectorPath = fileURLToPath(new URL('./inspector.js', import.meta.url))
@@ -64,7 +77,6 @@ const { keys } = Object
  * @param {string | URL} entrypointPath
  * @param {LoadAndGeneratePolicyOptions} options
  * @returns {Promise<LoadCompartmentMapResult>}
- * @internal
  */
 export const loadAndGeneratePolicy = async (
   entrypointPath,

--- a/packages/node/src/policy-util.js
+++ b/packages/node/src/policy-util.js
@@ -32,11 +32,19 @@ import {
 } from './util.js'
 
 /**
- * @import {RootPolicy, LavaMoatPolicy} from '@lavamoat/types'
- * @import {MergedLavaMoatPolicy,
- *  LoadPoliciesOptions,
- *  WritableFsInterface} from './types.js'
- * @import {ReadPolicyOptions, ReadPolicyOverrideOptions} from './internal.js'
+ * @import {
+ *   LavaMoatPolicy,
+ *   RootPolicy
+ * } from '@lavamoat/types'
+ * @import {
+ *   ReadPolicyOptions,
+ *   ReadPolicyOverrideOptions
+ * } from './internal.js'
+ * @import {
+ *   LoadPoliciesOptions,
+ *   MergedLavaMoatPolicy,
+ *   WritableFsInterface
+ * } from './types.js'
  */
 
 /**
@@ -45,7 +53,6 @@ import {
  * @param {string | URL} policyPath Path to policy
  * @param {ReadPolicyOptions} [options] Options
  * @returns {Promise<LavaMoatPolicy>}
- * @internal
  */
 export const readPolicy = async (
   policyPath,
@@ -430,7 +437,6 @@ export const mergePolicies = (policyA, policyB) => ({
  * @param {string | URL} [options.policyPath] Path to the policy file
  * @param {string | URL} [options.projectRoot]
  * @returns {string}
- * @internal
  */
 const makeDefaultPath = (
   defaultDir,
@@ -469,7 +475,6 @@ const makeDefaultPath = (
  * @param {string | URL} [options.policyPath] Path to the policy file
  * @param {string | URL} [options.projectRoot]
  * @returns {string}
- * @internal
  */
 export const makeDefaultPolicyOverridePath = ({ policyPath, projectRoot }) => {
   const path = makeDefaultPath(
@@ -488,7 +493,6 @@ export const makeDefaultPolicyOverridePath = ({ policyPath, projectRoot }) => {
  * @param {string | URL} [projectRoot=process.cwd()] Project root directory.
  *   Default is `process.cwd()`
  * @returns {string}
- * @internal
  */
 export const makeDefaultPolicyPath = (projectRoot = process.cwd()) => {
   const path = makeDefaultPath(DEFAULT_POLICY_DIR, DEFAULT_POLICY_FILENAME, {

--- a/packages/node/src/report.js
+++ b/packages/node/src/report.js
@@ -12,15 +12,17 @@ import { log as defaultLog } from './log.js'
 import { isObjectyObject, pluralize, toKeypath } from './util.js'
 
 /**
- * @import {ReportInvalidOverridesOptions,
- * ReportModuleInspectionProgressFn,
- * ModuleInspectionProgressReporter,
- * ReportModuleInspectionProgressEndFn,
- * ReportSesViolationsOptions,
- * StructuredViolation,
- * StructuredViolationsResult} from './internal.js'
  * @import {CanonicalName} from '@endo/compartment-mapper'
  * @import {LavaMoatPolicy} from '@lavamoat/types'
+ * @import {
+ *   ModuleInspectionProgressReporter,
+ *   ReportInvalidOverridesOptions,
+ *   ReportModuleInspectionProgressEndFn,
+ *   ReportModuleInspectionProgressFn,
+ *   ReportSesViolationsOptions,
+ *   StructuredViolation,
+ *   StructuredViolationsResult
+ * } from './internal.js'
  */
 
 /**
@@ -78,7 +80,6 @@ const findCanonicalNameKeypath = (policy, canonicalName) => {
  *   found in the compartment map
  * @param {ReportInvalidOverridesOptions} options
  * @returns {void}
- * @internal
  */
 export const reportInvalidCanonicalNames = (
   unknownCanonicalNames,
@@ -158,7 +159,6 @@ export const reportInvalidCanonicalNames = (
  *   Map of canonical names to structured violations
  * @param {ReportSesViolationsOptions} [options]
  * @returns {void}
- * @internal
  */
 export const reportSesViolations = (
   violationsForPackage,
@@ -169,7 +169,6 @@ export const reportSesViolations = (
    *
    * @param {StructuredViolation} violation
    * @returns {string}
-   * @internal
    */
   const formatViolation = (violation) => {
     const { path, line, column, type } = violation

--- a/packages/node/src/util.js
+++ b/packages/node/src/util.js
@@ -10,9 +10,12 @@ import nodeUrl from 'node:url'
 import { assertAbsolutePath } from './fs.js'
 
 /**
- * @import {FileURLToPathFn, ReadNowPowers} from '@endo/compartment-mapper'
- * @import {RequiredReadNowPowers} from './internal.js'
+ * @import {
+ *   FileURLToPathFn,
+ *   ReadNowPowers
+ * } from '@endo/compartment-mapper'
  * @import {SetNonNullable} from 'type-fest'
+ * @import {RequiredReadNowPowers} from './internal.js'
  * @import {FileUrlString} from './types.js'
  */
 const { isArray: isArray_ } = Array
@@ -28,7 +31,6 @@ const { freeze, keys } = Object
  * This is the format that `@endo/compartment-mapper` often expects.
  * @param {URL | string} url URL or path
  * @returns {FileUrlString} URL-like string
- * @internal
  */
 export const toFileURLString = (url) =>
   /** @type {FileUrlString} */ (
@@ -46,7 +48,6 @@ export const toFileURLString = (url) =>
  *
  * @param {unknown} value
  * @returns {value is object}
- * @internal
  */
 export const isObject = (value) => Object(value) === value
 
@@ -55,7 +56,6 @@ export const isObject = (value) => Object(value) === value
  *
  * @param {unknown} value
  * @returns {value is object & {length?: never}}
- * @internal
  */
 export const isObjectyObject = (value) => isObject(value) && !isArray(value)
 
@@ -64,7 +64,6 @@ export const isObjectyObject = (value) => isObject(value) && !isArray(value)
  *
  * @param {unknown} value
  * @returns {value is string}
- * @internal
  */
 export const isString = (value) => typeof value === 'string'
 
@@ -76,7 +75,6 @@ export const isString = (value) => typeof value === 'string'
  * `Array`.
  * @param {unknown} value
  * @returns {value is any[]}
- * @internal
  */
 export const isArray = (value) => isArray_(value)
 
@@ -85,7 +83,6 @@ export const isArray = (value) => isArray_(value)
  *
  * @param {unknown} value
  * @returns {value is boolean}
- * @internal
  */
 export const isBoolean = (value) => typeof value === 'boolean'
 
@@ -104,7 +101,6 @@ export const isBoolean = (value) => typeof value === 'boolean'
  * @param {T} obj Some object
  * @param {K} prop Some property which might be in `obj`
  * @returns {obj is Omit<T, K> & {[key in K]: SetNonNullable<T, K>}}
- * @internal
  * @see {@link https://github.com/microsoft/TypeScript/issues/44253}
  */
 export const hasValue = (obj, prop) => {
@@ -129,7 +125,6 @@ export const hasValue = (obj, prop) => {
  *
  * @param {boolean} [prodOnly=false] Default is `false`
  * @returns {Set<string>}
- * @internal
  */
 export const prodOnlyToConditions = (prodOnly) =>
   prodOnly ? new Set() : new Set(['development'])
@@ -138,7 +133,6 @@ export const prodOnlyToConditions = (prodOnly) =>
  * Ordered array of every property in {@link ReadNowPowers} which is _required_.
  *
  * @satisfies {RequiredReadNowPowers}
- * @internal
  */
 const REQUIRED_READ_NOW_POWERS = freeze(
   /** @type {const} */ (['fileURLToPath', 'isAbsolute', 'maybeReadNow'])
@@ -149,7 +143,6 @@ const REQUIRED_READ_NOW_POWERS = freeze(
  *
  * @param {unknown} value
  * @returns {value is ReadNowPowers}
- * @internal
  */
 export const isReadNowPowers = (value) =>
   isObjectyObject(value) &&
@@ -163,7 +156,6 @@ export const isReadNowPowers = (value) =>
  * @param {object} [value] Object value to get keys of
  * @param {string[]} [defaultKeys=[]] Default is `[]`
  * @returns {string[]}
- * @internal
  */
 export const keysOr = (value, defaultKeys = []) =>
   value ? keys(value) : defaultKeys
@@ -175,7 +167,6 @@ export const keysOr = (value, defaultKeys = []) =>
  *
  * @param {unknown} value
  * @returns {value is (...args: any[]) => any}
- * @internal
  */
 export const isFunction = (value) => typeof value === 'function'
 
@@ -184,7 +175,6 @@ export const isFunction = (value) => typeof value === 'function'
  *
  * @param {unknown} value
  * @returns {value is string | URL}
- * @internal
  */
 export const isPathLike = (value) => isString(value) || value instanceof URL
 
@@ -195,7 +185,6 @@ export const isPathLike = (value) => isString(value) || value instanceof URL
  *   `file://` scheme
  * @param {FileURLToPathFn} [fileURLToPath] `fileURLToPath` implementation
  * @returns {string} A filepath
- * @internal
  */
 export const toPath = (value, fileURLToPath = nodeUrl.fileURLToPath) => {
   return value instanceof URL || value.startsWith('file://')
@@ -211,7 +200,6 @@ export const toPath = (value, fileURLToPath = nodeUrl.fileURLToPath) => {
  *   path.
  * @param {string} [assertionMessage] Custom assertion message
  * @returns {string} Absolute path
- * @internal
  */
 export const toAbsolutePath = (pathLike, assertionMessage) => {
   const path = toPath(pathLike)
@@ -292,7 +280,6 @@ export const toKeypath = (path) => {
  * @param {string} singular The singular form of the word
  * @param {string} [plural] The plural form (defaults to `singular + 's'`)
  * @returns {string} The appropriate form of the word
- * @internal
  */
 export const pluralize = (count, singular, plural = `${singular}s`) =>
   count === 1 ? singular : plural

--- a/packages/node/src/worker-pool.js
+++ b/packages/node/src/worker-pool.js
@@ -2,14 +2,16 @@
  * Generic worker pool for managing worker threads
  *
  * @packageDocumentation
- * @internal
  */
 
 import { availableParallelism } from 'node:os'
 import { Worker } from 'node:worker_threads'
 
 /**
- * @import {BaseMessage, WorkerPoolOptions} from './internal.js'
+ * @import {
+ *   BaseMessage,
+ *   WorkerPoolOptions
+ * } from './internal.js'
  */
 
 /**

--- a/packages/node/test/unit/exec/exec-macros.js
+++ b/packages/node/test/unit/exec/exec-macros.js
@@ -9,9 +9,15 @@ import {
 } from '../json-fixture-util.js'
 
 /**
- * @import {TestFn, MacroDeclarationOptions} from 'ava'
  * @import {LavaMoatPolicy} from '@lavamoat/types'
- * @import {TestExecForJSONMacroOptions, TestExecMacroOptions} from '../../types.js'
+ * @import {
+ *   MacroDeclarationOptions,
+ *   TestFn
+ * } from 'ava'
+ * @import {
+ *   TestExecForJSONMacroOptions,
+ *   TestExecMacroOptions
+ * } from '../../types.js'
  */
 
 /**
@@ -31,7 +37,6 @@ const DEFAULT_POLICY = Object.freeze({
  * @template [Ctx=unknown] Custom execution context, if any. Default is
  *   `unknown`
  * @param {TestFn<Ctx>} test - AVA test function
- * @internal
  */
 export const createExecMacros = (test) => {
   /**

--- a/packages/node/test/unit/policy/policy-macros.js
+++ b/packages/node/test/unit/policy/policy-macros.js
@@ -16,10 +16,19 @@ import {
 } from '../json-fixture-util.js'
 
 /**
- * @import {TestPolicyMacroOptions, TestPolicyForJSONOptions, ScaffoldFixtureResult, ScaffoldFixtureOptions, TestPolicyForFixtureOptions} from './types.js'
- * @import {SourceType} from '../../../src/types.js'
- * @import {TestFn, MacroDeclarationOptions} from 'ava'
  * @import {LavaMoatPolicy} from '@lavamoat/types'
+ * @import {
+ *   MacroDeclarationOptions,
+ *   TestFn
+ * } from 'ava'
+ * @import {SourceType} from '../../../src/types.js'
+ * @import {
+ *   ScaffoldFixtureOptions,
+ *   ScaffoldFixtureResult,
+ *   TestPolicyForFixtureOptions,
+ *   TestPolicyForJSONOptions,
+ *   TestPolicyMacroOptions
+ * } from './types.js'
  */
 
 const fixture = fixtureFinder(new URL('..', import.meta.url))
@@ -34,7 +43,6 @@ const fixture = fixtureFinder(new URL('..', import.meta.url))
  * @template [Ctx=unknown] Custom execution context, if any. Default is
  *   `unknown`
  * @param {TestFn<Ctx>} test - AVA test function
- * @internal
  */
 export function createGeneratePolicyMacros(test) {
   /**


### PR DESCRIPTION
`@internal`, when used with TS' [`stripInternal` compiler option](https://www.typescriptlang.org/tsconfig/#stripInternal), only works in TS sources.  This means `tsc` will _not_ omit the tagged symbol when generating declarations from JS sources.

While it's also recognized as a valid tag by TypeDoc (note that _we're not using TypeDoc_) with similar opt-in functionality, the discrepancy in how `tsc` handles it means we should just avoid it. To that end, I've added an ESLint rule.

In a future where we _do_ use TypeDoc, we can omit symbols from generated API docs by using `@private` coupled with `excludePrivate: true`; TS doesn't seem to attach any special meaning to `@private`.