### PR TITLE
fix(lavapack)!: minimum ES version now ES2023

### DIFF
--- a/packages/lavapack/src/builder-runtime.js
+++ b/packages/lavapack/src/builder-runtime.js
@@ -19,7 +19,7 @@ function markAsGenerated(output, file) {
   )
 }
 
-const ECMA_VERSION_2020 = 2020
+const ECMA_VERSION = 2023
 
 function assertEcmaVersion(code, ecmaVersion) {
   try {
@@ -45,7 +45,7 @@ async function buildRuntimeCJS() {
     getStrictScopeTerminatorShimSrc()
   )
   output = markAsGenerated(output, 'runtime-cjs-template.js')
-  assertEcmaVersion(output, ECMA_VERSION_2020)
+  assertEcmaVersion(output, ECMA_VERSION)
   await writeFile(pathJoin(__dirname, 'runtime-cjs.js'), output)
 }
 
@@ -62,7 +62,7 @@ async function buildRuntimeES(opts) {
   const statsCode = `(${makeInitStatsHook})({ onStatsReady })`
   output = stringReplace(output, '__reportStatsHook__', statsCode)
   output = markAsGenerated(output, 'runtime-template.js')
-  assertEcmaVersion(output, ECMA_VERSION_2020)
+  assertEcmaVersion(output, ECMA_VERSION)
   await writeFile(pathJoin(__dirname, 'runtime.js'), output)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The minimum supported language version guaranteed by the bundle created by `@lavamoat/lavapack` is now ES2023.

As per discussion with consumers, this should be fine as they no longer support browsers which only ship older versions of the spec.