### PR TITLE
feat(webpack): capture importScripts reference for use in runtime despite scuttling

### DIFF
--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -47,12 +47,12 @@ class VirtualRuntimeModule extends RuntimeModule {
  * @import {
  *   LavaMoatChunkRuntimeConfiguration,
  *   LavaMoatPluginOptions
- * } from "../buildtime/types"
+ * } from '../buildtime/types'
  */
-/** @import {LavaMoatPolicy} from "@lavamoat/types" */
-/** @import {RuntimeFragment} from "./assemble.js" */
-/** @import {Chunk} from "webpack" */
-/** @import {ProgressAPI} from "../buildtime/utils.js" */
+/** @import {LavaMoatPolicy} from '@lavamoat/types' */
+/** @import {RuntimeFragment} from './assemble.js' */
+/** @import {Chunk} from 'webpack' */
+/** @import {ProgressAPI} from '../buildtime/utils.js' */
 
 /**
  * @typedef {Object} LavaMoatRuntimeIdentifiers
@@ -88,7 +88,8 @@ module.exports = {
         'clearTimeout', // LoadScriptRuntimeModule.js
         'document', // LoadScriptRuntimeModule.js, AutoPublicPathRuntimeModule.js
         'trustedTypes', // GetTrustedTypesPolicyRuntimeModule.js
-        'self',
+        'self', // webpacks own code references it
+        'importScripts', // chunk loading in workers
       ]
       return `var ${globals.map((g) => `${g} = globalThis.${g}`).join(',')};
 const LOCKDOWN_SHIMS = [];`

--- a/packages/webpack/src/runtime/runtimeBuilder.js
+++ b/packages/webpack/src/runtime/runtimeBuilder.js
@@ -320,7 +320,19 @@ const LOCKDOWN_SHIMS = [];`
           new VirtualRuntimeModule({
             name: 'LavaMoat/defensive',
             source: getDefensiveCodingPreamble(),
-            stage: RuntimeModule.STAGE_NORMAL, // before all other runtime modules
+            // STAGE_NORMAL is the earliest stage, but other runtime modules
+            // could be registered for this stage also. Webpack uses numerical
+            // sorting to order the runtime modules, so we can register to be
+            // before any module that is not trying equally hard to be first.
+            // While the defensive preamble should not be required before
+            // scuttling occurs, it defines variables that will be hoisted and
+            // if it's not first, it'll overshadow the globals with undefined.
+            // In practice it was never problematic with webpack internal plugins,
+            // but if it happened to interfere with a different plugin or an
+            // unlucky key was added to the defensive preamble list, it'd
+            // be really hard to debug. So we use the shady -1 trick to avoid
+            // possible but unlikely issues.
+            stage: RuntimeModule.STAGE_NORMAL - 1,
             withoutClosure: true, // run in the scope of the runtime closure
           }),
         ]
@@ -433,4 +445,5 @@ const LOCKDOWN_SHIMS = [];`
       },
     }
   },
+  VirtualRuntimeModule,
 }

--- a/packages/webpack/test/e2e-defensive-preamble.spec.js
+++ b/packages/webpack/test/e2e-defensive-preamble.spec.js
@@ -1,0 +1,58 @@
+const test = /** @type {import('ava').TestFn} */ (require('ava'))
+const { scaffold, runScript } = require('./scaffold.js')
+const LavaMoatPlugin = require('../src/plugin.js')
+const { VirtualRuntimeModule } = require('../src/runtime/runtimeBuilder.js')
+
+// A key that we know defensive preamble is there to capture.
+const GLOBAL_KEY_NAME = 'importScripts'
+
+const testRuntimeModule = new VirtualRuntimeModule({
+  name: 'DefensivePreambleTest',
+  source: `
+    globalThis['${GLOBAL_KEY_NAME}'] = 44;
+    if(typeof ${GLOBAL_KEY_NAME} !== 'number' || ${GLOBAL_KEY_NAME} !== 42) {
+      throw new Error('"${GLOBAL_KEY_NAME}" is not the expected value: ' + ${GLOBAL_KEY_NAME})
+    }
+  `,
+})
+
+class DefensivePreambleTestPlugin {
+  /**
+   * @param {import('webpack').Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      'DefensivePreambleTestPlugin',
+      (compilation) => {
+        compilation.hooks.additionalChunkRuntimeRequirements.tap(
+          'DefensivePreambleTestPlugin_runtime',
+          (chunk /*, set*/) => {
+            if (chunk.hasRuntime()) {
+              compilation.addRuntimeModule(chunk, testRuntimeModule)
+            }
+          }
+        )
+      }
+    )
+  }
+}
+
+test('webpack/defensive-preamble - captured globals are independent of globalThis and available to all other runtime chunks', async (t) => {
+  const config = {
+    entry: { app: './simple.js' },
+    output: { filename: '[name].js', path: '/dist' },
+    // mode: 'development', // uncomment if you peek at the output
+    plugins: [
+      new LavaMoatPlugin({ generatePolicy: false, policy: { resources: {} } }),
+      new DefensivePreambleTestPlugin(),
+    ],
+  }
+
+  const build = await scaffold(config)
+  // t.log(build.snapshot['/dist/app.js']) // peek
+  t.notThrows(() => {
+    runScript(
+      `globalThis['${GLOBAL_KEY_NAME}']=42;` + build.snapshot['/dist/app.js']
+    )
+  })
+})


### PR DESCRIPTION
capturing importScripts as a local reference will prevent scuttling getting in the way of webpack runtime chunk loading in workers. 

Previous attempts at using lavamoat runtime in the serviceworker required a scuttling exception.