### PR TITLE
fix(core): prevent the endowment logic from skipping writable fields

### DIFF
--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -168,7 +168,14 @@ function endowmentsToolkit({
             unwrapFrom || targetRef
           )
         } else {
-          instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef)
+          instrumentDynamicValueAtPath(
+            pathParts,
+            sourceRef,
+            targetRef,
+            createFunctionWrapper,
+            unwrapTo,
+            unwrapFrom || targetRef
+          )
         }
       } else {
         copyValueAtPath(
@@ -718,26 +725,54 @@ function makeWritableValueAtPath(
  * @param {string[]} pathParts
  * @param {Record<string, any>} sourceRef
  * @param {Record<string, any>} targetRef
+ * @param {DefaultWrapperFn} [wrapFn]
+ * @param {object} [unwrapTo]
+ * @param {object} [unwrapFrom]
  */
-function instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef) {
+function instrumentDynamicValueAtPath(
+  pathParts,
+  sourceRef,
+  targetRef,
+  wrapFn,
+  unwrapTo,
+  unwrapFrom
+) {
   const enumerable = Reflect.getOwnPropertyDescriptor(
     sourceRef,
     pathParts[0]
   )?.enumerable
+
+  const resolveLeaf = () => {
+    const dynamicValue = sourceRef[pathParts[0]]
+    let leaf = dynamicValue,
+      parent = sourceRef
+
+    for (let i = 1; i < pathParts.length; i++) {
+      parent = leaf
+      leaf = leaf[pathParts[i]]
+    }
+    if (typeof leaf === 'function' && pathParts.length > 1) {
+      leaf = leaf.bind(parent) // TODO: consider the risks, should not differ from unwrapping
+    }
+    return leaf
+  }
+
+  // Capture and wrap the initial leaf value once. If the top-level writable
+  // field is later replaced (by another package with write permission), the
+  // getter re-resolves and returns the new leaf unwrapped.
+  const initialTopValue = sourceRef[pathParts[0]]
+  const initialLeaf = resolveLeaf()
+  const wrappedInitialLeaf =
+    wrapFn && unwrapTo && typeof initialLeaf === 'function'
+      ? wrapFn(initialLeaf, (thisValue) => thisValue === unwrapFrom, unwrapTo)
+      : initialLeaf
+
   const dynamicGetterDesc = {
     get: () => {
-      const dynamicValue = sourceRef[pathParts[0]]
-      let leaf = dynamicValue,
-        parent = sourceRef
-
-      for (let i = 1; i < pathParts.length; i++) {
-        parent = leaf
-        leaf = leaf[pathParts[i]]
+      if (wrappedInitialLeaf !== initialLeaf && sourceRef[pathParts[0]] === initialTopValue) {
+        return wrappedInitialLeaf
       }
-      if (typeof leaf === 'function') {
-        leaf = leaf.bind(parent) // TODO: consider the risks, should not differ from unwrapping
-      }
-      return leaf
+      return resolveLeaf()
     },
     writeable: false,
     enumerable, // Initial value will have to suffice. Change will not propagate dynamically.

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -159,7 +159,14 @@ function endowmentsToolkit({
       const pathParts = path.split('.')
       if (knownWritableFields.has(pathParts[0])) {
         if (allowedWriteFields.has(pathParts[0])) {
-          makeWritableValueAtPath(pathParts[0], sourceRef, targetRef)
+          makeWritableValueAtPath(
+            pathParts[0],
+            sourceRef,
+            targetRef,
+            createFunctionWrapper,
+            unwrapTo,
+            unwrapFrom || targetRef
+          )
         } else {
           instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef)
         }
@@ -665,12 +672,30 @@ function isEmpty(value) {
  * @param {string} key
  * @param {Record<string, any>} sourceRef
  * @param {Record<string, any>} targetRef
+ * @param {DefaultWrapperFn} [wrapFn]
+ * @param {object} [unwrapTo]
+ * @param {object} [unwrapFrom]
  */
-function makeWritableValueAtPath(key, sourceRef, targetRef) {
+function makeWritableValueAtPath(
+  key,
+  sourceRef,
+  targetRef,
+  wrapFn,
+  unwrapTo,
+  unwrapFrom
+) {
   const enumerable = Reflect.getOwnPropertyDescriptor(
     sourceRef,
     key
   )?.enumerable
+  // Capture and wrap the initial value once. If the value on sourceRef is later
+  // replaced (monkey-patching), the getter returns the new value unwrapped —
+  // the replacement is expected to call the captured (already-wrapped) original.
+  const initialValue = sourceRef[key]
+  const wrappedInitialValue =
+    wrapFn && unwrapTo && typeof initialValue === 'function'
+      ? wrapFn(initialValue, (thisValue) => thisValue === unwrapFrom, unwrapTo)
+      : initialValue
   Reflect.defineProperty(targetRef, key, {
     configurable: false,
     enumerable,
@@ -678,6 +703,9 @@ function makeWritableValueAtPath(key, sourceRef, targetRef) {
       sourceRef[key] = newValue
     },
     get() {
+      if (sourceRef[key] === initialValue) {
+        return wrappedInitialValue
+      }
       return sourceRef[key]
     },
   })

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -103,26 +103,21 @@ function endowmentsToolkit({
           explicitlyBanned.push(path)
           return
         }
-        // write access handled elsewhere
+        whitelistedReads.push(path)
         if (packagePolicyValue === 'write') {
-          if (!handleGlobalWrite) {
-            return
+          if (handleGlobalWrite) {
+            if (pathParts.length > 1) {
+              throw new Error(
+                `LavaMoat - write access is only allowed at the top level, saw "${path}"`
+              )
+            }
+            allowedWriteFields.add(path)
           }
-          if (pathParts.length > 1) {
-            throw new Error(
-              `LavaMoat - write access is only allowed at the top level, saw "${path}"`
-            )
-          }
-          allowedWriteFields.add(path)
-          whitelistedReads.push(path)
-          return
-        }
-        if (packagePolicyValue !== true) {
+        } else if (packagePolicyValue !== true) {
           throw new Error(
             `LavaMoat - unrecognizable policy value (${typeof packagePolicyValue}) for path "${path}"`
           )
         }
-        whitelistedReads.push(path)
       }
     )
     // sort by length to optimize further steps
@@ -742,7 +737,11 @@ function instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef) {
 }
 
 /**
- * @import {SomeFunction, ContextTestFn, SomeParameters} from './internal.js';
+ * @import {
+ *   ContextTestFn,
+ *   SomeFunction,
+ *   SomeParameters
+ * } from './internal.js'
  */
 
 /**
@@ -769,8 +768,8 @@ function instrumentDynamicValueAtPath(pathParts, sourceRef, targetRef) {
  */
 function defaultCreateFunctionWrapper(sourceValue, unwrapTest, unwrapTo) {
   /**
-   * @returns {ReturnType<T>}
    * @this {U | Record<PropertyKey, any>}
+   * @returns {ReturnType<T>}
    */
   const newValue = function () {
     'use strict'

--- a/packages/core/src/endowmentsToolkit.js
+++ b/packages/core/src/endowmentsToolkit.js
@@ -742,37 +742,39 @@ function instrumentDynamicValueAtPath(
     pathParts[0]
   )?.enumerable
 
-  const resolveLeaf = () => {
-    const dynamicValue = sourceRef[pathParts[0]]
-    let leaf = dynamicValue,
-      parent = sourceRef
-
-    for (let i = 1; i < pathParts.length; i++) {
-      parent = leaf
-      leaf = leaf[pathParts[i]]
-    }
-    if (typeof leaf === 'function' && pathParts.length > 1) {
-      leaf = leaf.bind(parent) // TODO: consider the risks, should not differ from unwrapping
-    }
-    return leaf
-  }
-
-  // Capture and wrap the initial leaf value once. If the top-level writable
+  // Capture and wrap the initial top value once. If the top-level writable
   // field is later replaced (by another package with write permission), the
-  // getter re-resolves and returns the new leaf unwrapped.
+  // wrapping is no longer useful.
   const initialTopValue = sourceRef[pathParts[0]]
-  const initialLeaf = resolveLeaf()
-  const wrappedInitialLeaf =
-    wrapFn && unwrapTo && typeof initialLeaf === 'function'
-      ? wrapFn(initialLeaf, (thisValue) => thisValue === unwrapFrom, unwrapTo)
-      : initialLeaf
+  const wrappedInitialTopV =
+    wrapFn && unwrapTo && typeof initialTopValue === 'function'
+      ? wrapFn(
+          initialTopValue,
+          (thisValue) => thisValue === unwrapFrom,
+          unwrapTo
+        )
+      : initialTopValue
 
   const dynamicGetterDesc = {
     get: () => {
-      if (wrappedInitialLeaf !== initialLeaf && sourceRef[pathParts[0]] === initialTopValue) {
-        return wrappedInitialLeaf
+      const dynamicValue = sourceRef[pathParts[0]]
+      let leaf, parent
+      if (
+        typeof dynamicValue === 'function' &&
+        dynamicValue === initialTopValue
+      ) {
+        leaf = wrappedInitialTopV
+      } else {
+        leaf = dynamicValue
       }
-      return resolveLeaf()
+      for (let i = 1; i < pathParts.length; i++) {
+        parent = leaf
+        leaf = leaf[pathParts[i]]
+      }
+      if (typeof leaf === 'function' && pathParts.length > 1) {
+        leaf = leaf.bind(parent) // TODO: consider the risks, should not differ from unwrapping
+      }
+      return leaf
     },
     writeable: false,
     enumerable, // Initial value will have to suffice. Change will not propagate dynamically.

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -410,23 +410,24 @@ test('getEndowmentsForConfig - writable global setter propagates to original', (
   t.is(resultGlobal._onerror, undefined)
 })
 
-test('getEndowmentsForConfig - writable global function maintains this-binding', (t) => {
+test('getEndowmentsForConfig - writable global handles monkey-patching', (t) => {
   'use strict'
   const knownWritable = new Set(['fetch'])
-  const { getEndowmentsForConfig, copyWrappedGlobals } = endowmentsToolkit({
-    handleGlobalWrite: true,
-    knownWritableFields: knownWritable,
+  const { getEndowmentsForConfig, copyWrappedGlobals } = prepareTest({
+    knownWritable,
   })
 
-  // Simulate a native function that requires `this` to be the owning global
-  const browserGlobal = { _name: 'browserGlobal' }
+  // Simulate a native function
+  const browserGlobal = {}
   browserGlobal.fetch = function nativeFetch(url) {
-    if (this !== browserGlobal) {
+    // yes, fetch is funny like that.
+    if (typeof this !== 'undefined' && this !== browserGlobal) {
       throw new TypeError(
         `Illegal invocation: expected this=browserGlobal, got this=${String(this)}`
       )
     }
-    return `fetched(${url})`
+
+    return `fetched(${url}) // ${typeof this} ${this === browserGlobal}`
   }
 
   // Level 1: copyWrappedGlobals produces the root compartment's source global.
@@ -439,53 +440,88 @@ test('getEndowmentsForConfig - writable global function maintains this-binding',
     rootCompartmentGlobal // unwrapTo
   )
 
-  // Reading the function via the writable getter and calling it should rebind this
-  const result = packageCompartmentGlobal.fetch('https://example.com')
-  t.is(result, 'fetched(https://example.com)')
-})
-
-test('getEndowmentsForConfig - writable global survives monkey-patching (Sentry pattern)', (t) => {
-  'use strict'
-  const knownWritable = new Set(['fetch'])
-  const { getEndowmentsForConfig, copyWrappedGlobals } = endowmentsToolkit({
-    handleGlobalWrite: true,
-    knownWritableFields: knownWritable,
-  })
-
-  // Simulate a native function that requires `this` to be the owning global
-  const browserGlobal = { _name: 'browserGlobal' }
-  browserGlobal.fetch = function nativeFetch(url) {
-    if (this !== browserGlobal) {
-      throw new TypeError(
-        `Illegal invocation: expected this=browserGlobal, got this=${String(this)}`
-      )
-    }
-    return `fetched(${url})`
-  }
-
-  // Level 1: copyWrappedGlobals produces the root compartment's source global.
-  const rootCompartmentGlobal = copyWrappedGlobals(browserGlobal, {})
-
-  // Level 2: getEndowmentsForConfig with write policy produces the package view.
-  const packageCompartmentGlobal = getEndowmentsForConfig(
+  const anotherPackageCompartmentGlobal = getEndowmentsForConfig(
     rootCompartmentGlobal,
-    { globals: { fetch: 'write' } },
+    { globals: { fetch: true } },
     rootCompartmentGlobal // unwrapTo
   )
+
+  const directCallResult = packageCompartmentGlobal.fetch('https://example.com')
+  t.is(directCallResult, 'fetched(https://example.com) // object true')
 
   // Sentry-style instrumentation: capture original, replace with wrapper, call original
   const originalFetch = packageCompartmentGlobal.fetch
 
-  packageCompartmentGlobal.fetch = function sentryFetchWrapper(url) {
+  packageCompartmentGlobal.fetch = function sentryLikeFetchWrapper(url) {
     'use strict'
-    // In strict mode `this` is undefined when not called as a method.
-    // The captured originalFetch must still have its this-value rebound.
-    return originalFetch(url)
+    return 'patched!' + originalFetch(url)
   }
 
-  // Calling through the wrapper should not throw "Illegal invocation"
-  const result = packageCompartmentGlobal.fetch('https://example.com')
-  t.is(result, 'fetched(https://example.com)')
+  t.is(
+    packageCompartmentGlobal.fetch('https://example.com'),
+    'patched!fetched(https://example.com) // undefined false'
+  )
+  t.is(
+    anotherPackageCompartmentGlobal.fetch('https://example.com'),
+    'patched!fetched(https://example.com) // undefined false'
+  )
+
+  // bound case
+  packageCompartmentGlobal.fetch = function sentryLikeFetchWrapper(url) {
+    'use strict'
+    return originalFetch.call(packageCompartmentGlobal, url)
+  }
+
+  t.is(
+    packageCompartmentGlobal.fetch('https://example.com'),
+    'patched!fetched(https://example.com) // object true'
+  )
+  t.is(
+    anotherPackageCompartmentGlobal.fetch('https://example.com'),
+    'patched!fetched(https://example.com) // object true'
+  )
+})
+
+test('getEndowmentsForConfig - writable global is not leaky (in case AI insists on making it so again)', (t) => {
+  'use strict'
+  const knownWritable = new Set(['fetch'])
+  const { getEndowmentsForConfig, copyWrappedGlobals } = prepareTest({
+    knownWritable,
+  })
+
+  // Simulate a native function
+  const browserGlobal = {}
+  browserGlobal.fetch = function nativeFetch() {
+    //whatever
+  }
+
+  const rootCompartmentGlobal = copyWrappedGlobals(browserGlobal, {})
+
+  const packageCompartmentGlobal = getEndowmentsForConfig(
+    rootCompartmentGlobal,
+    { globals: { fetch: 'write' } },
+    rootCompartmentGlobal
+  )
+
+  const anotherPackageCompartmentGlobal = getEndowmentsForConfig(
+    rootCompartmentGlobal,
+    { globals: { fetch: true } },
+    rootCompartmentGlobal // unwrapTo
+  )
+
+  packageCompartmentGlobal.fetch = function abuseRewrapping() {
+    return [this]
+  }
+
+  const stolen = packageCompartmentGlobal.fetch()
+  t.not(stolen[0], browserGlobal)
+  t.not(stolen[0], rootCompartmentGlobal)
+  t.is(stolen[0], packageCompartmentGlobal)
+
+  const anotherStolen = anotherPackageCompartmentGlobal.fetch()
+  t.not(anotherStolen[0], browserGlobal)
+  t.not(anotherStolen[0], rootCompartmentGlobal)
+  t.is(anotherStolen[0], anotherPackageCompartmentGlobal)
 })
 
 test('getEndowmentsForConfig - specify unwrap to', (t) => {

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -454,31 +454,31 @@ test('getEndowmentsForConfig - writable global handles monkey-patching', (t) => 
 
   packageCompartmentGlobal.fetch = function sentryLikeFetchWrapper(url) {
     'use strict'
-    return 'patched!' + originalFetch(url)
+    return 'patched1!' + originalFetch(url)
   }
 
   t.is(
     packageCompartmentGlobal.fetch('https://example.com'),
-    'patched!fetched(https://example.com) // undefined false'
+    'patched1!fetched(https://example.com) // undefined false'
   )
   t.is(
     anotherPackageCompartmentGlobal.fetch('https://example.com'),
-    'patched!fetched(https://example.com) // undefined false'
+    'patched1!fetched(https://example.com) // undefined false'
   )
 
   // bound case
   packageCompartmentGlobal.fetch = function sentryLikeFetchWrapper(url) {
     'use strict'
-    return originalFetch.call(packageCompartmentGlobal, url)
+    return 'patched2!' + originalFetch.call(packageCompartmentGlobal, url)
   }
 
   t.is(
     packageCompartmentGlobal.fetch('https://example.com'),
-    'patched!fetched(https://example.com) // object true'
+    'patched2!fetched(https://example.com) // object true'
   )
   t.is(
     anotherPackageCompartmentGlobal.fetch('https://example.com'),
-    'patched!fetched(https://example.com) // object true'
+    'patched2!fetched(https://example.com) // object true'
   )
 })
 

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -371,6 +371,44 @@ test('getEndowmentsForConfig - ensure window.document getter behavior support', 
   // ava seems to be forcing sloppy mode
   t.is(getter.call(), globalThis)
 })
+test.only('getEndowmentsForConfig - ensure wrapped setters work', (t) => {
+  'use strict'
+  // compartment.globalThis.document would error because 'this' value is not window
+  const { getEndowmentsForConfig, copyWrappedGlobals } = prepareTest({
+    knownWritable: new Set(['onerror']),
+  })
+  const originalGlobal = {}
+  Object.defineProperty(originalGlobal, 'onerror', {
+    set(value) {
+      this._onerror = value
+    },
+    get() {
+      return this._onerror
+    },
+  })
+
+  // verify that the setter works on the original global
+  originalGlobal.onerror = 'initialErrorHandler'
+  t.is(originalGlobal._onerror, 'initialErrorHandler')
+
+  const sourceGlobal = copyWrappedGlobals(originalGlobal, {})
+
+  // verify that the setter works on the wrapped global
+  sourceGlobal.onerror = 'wrappedErrorHandler'
+  t.is(originalGlobal._onerror, 'wrappedErrorHandler')
+
+  const config = {
+    globals: {
+      onerror: 'write',
+    },
+  }
+  const resultGlobal = getEndowmentsForConfig(sourceGlobal, config)
+
+  resultGlobal.onerror = 'myErrorHandler'
+  // proof that the setter was called on the original global
+  t.is(originalGlobal._onerror, 'myErrorHandler')
+  t.is(resultGlobal._onerror, undefined)
+})
 
 test('getEndowmentsForConfig - specify unwrap to', (t) => {
   'use strict'

--- a/packages/core/test/endowmentsToolkit.spec.js
+++ b/packages/core/test/endowmentsToolkit.spec.js
@@ -371,7 +371,7 @@ test('getEndowmentsForConfig - ensure window.document getter behavior support', 
   // ava seems to be forcing sloppy mode
   t.is(getter.call(), globalThis)
 })
-test.only('getEndowmentsForConfig - ensure wrapped setters work', (t) => {
+test('getEndowmentsForConfig - writable global setter propagates to original', (t) => {
   'use strict'
   // compartment.globalThis.document would error because 'this' value is not window
   const { getEndowmentsForConfig, copyWrappedGlobals } = prepareTest({
@@ -408,6 +408,84 @@ test.only('getEndowmentsForConfig - ensure wrapped setters work', (t) => {
   // proof that the setter was called on the original global
   t.is(originalGlobal._onerror, 'myErrorHandler')
   t.is(resultGlobal._onerror, undefined)
+})
+
+test('getEndowmentsForConfig - writable global function maintains this-binding', (t) => {
+  'use strict'
+  const knownWritable = new Set(['fetch'])
+  const { getEndowmentsForConfig, copyWrappedGlobals } = endowmentsToolkit({
+    handleGlobalWrite: true,
+    knownWritableFields: knownWritable,
+  })
+
+  // Simulate a native function that requires `this` to be the owning global
+  const browserGlobal = { _name: 'browserGlobal' }
+  browserGlobal.fetch = function nativeFetch(url) {
+    if (this !== browserGlobal) {
+      throw new TypeError(
+        `Illegal invocation: expected this=browserGlobal, got this=${String(this)}`
+      )
+    }
+    return `fetched(${url})`
+  }
+
+  // Level 1: copyWrappedGlobals produces the root compartment's source global.
+  const rootCompartmentGlobal = copyWrappedGlobals(browserGlobal, {})
+
+  // Level 2: getEndowmentsForConfig with write policy produces the package view.
+  const packageCompartmentGlobal = getEndowmentsForConfig(
+    rootCompartmentGlobal,
+    { globals: { fetch: 'write' } },
+    rootCompartmentGlobal // unwrapTo
+  )
+
+  // Reading the function via the writable getter and calling it should rebind this
+  const result = packageCompartmentGlobal.fetch('https://example.com')
+  t.is(result, 'fetched(https://example.com)')
+})
+
+test('getEndowmentsForConfig - writable global survives monkey-patching (Sentry pattern)', (t) => {
+  'use strict'
+  const knownWritable = new Set(['fetch'])
+  const { getEndowmentsForConfig, copyWrappedGlobals } = endowmentsToolkit({
+    handleGlobalWrite: true,
+    knownWritableFields: knownWritable,
+  })
+
+  // Simulate a native function that requires `this` to be the owning global
+  const browserGlobal = { _name: 'browserGlobal' }
+  browserGlobal.fetch = function nativeFetch(url) {
+    if (this !== browserGlobal) {
+      throw new TypeError(
+        `Illegal invocation: expected this=browserGlobal, got this=${String(this)}`
+      )
+    }
+    return `fetched(${url})`
+  }
+
+  // Level 1: copyWrappedGlobals produces the root compartment's source global.
+  const rootCompartmentGlobal = copyWrappedGlobals(browserGlobal, {})
+
+  // Level 2: getEndowmentsForConfig with write policy produces the package view.
+  const packageCompartmentGlobal = getEndowmentsForConfig(
+    rootCompartmentGlobal,
+    { globals: { fetch: 'write' } },
+    rootCompartmentGlobal // unwrapTo
+  )
+
+  // Sentry-style instrumentation: capture original, replace with wrapper, call original
+  const originalFetch = packageCompartmentGlobal.fetch
+
+  packageCompartmentGlobal.fetch = function sentryFetchWrapper(url) {
+    'use strict'
+    // In strict mode `this` is undefined when not called as a method.
+    // The captured originalFetch must still have its this-value rebound.
+    return originalFetch(url)
+  }
+
+  // Calling through the wrapper should not throw "Illegal invocation"
+  const result = packageCompartmentGlobal.fetch('https://example.com')
+  t.is(result, 'fetched(https://example.com)')
 })
 
 test('getEndowmentsForConfig - specify unwrap to', (t) => {


### PR DESCRIPTION
The logic would cause writable fields to not be included in iteration and not made accessible to the writer in some cases.