### PR TITLE
chore: configure min-release-age exclusions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,17 @@
-## Ignore all lifecycle scripts by default. 
+## Ignore all lifecycle scripts by default.
 ignore-scripts=true
 # Avoid installing packages published in last 2 days
 min-release-age=3
+
+# exclude our packages and Endo packages
+min-release-age-exclude[]=@endo/*
+min-release-age-exclude[]=@lavamoat/*
+min-release-age-exclude[]=lavamoat
+min-release-age-exclude[]=lavamoat-browserify
+min-release-age-exclude[]=lavamoat-core
+min-release-age-exclude[]=lavamoat-tofu
+min-release-age-exclude[]=ses
+
 ## Don't install packages from git urls, which can
 ## be used to bypass the above two settings
 allow-git=none


### PR DESCRIPTION
This excludes our packages and Endo packages from the `min-release-age` restriction.