### PR TITLE
feat(harden): verify lavamoat files integrity in case write to project root was allowed

### DIFF
--- a/packages/harden/src/npm/runner.cjs
+++ b/packages/harden/src/npm/runner.cjs
@@ -2,8 +2,10 @@
 /// <reference path="../runner/make-run-script-wrapper.global.d.ts" />
 
 /* global makeRunScriptWrapper */
+/* global LMFolderIntegrityCheck */
 
 const { spawnSync } = require('node:child_process')
+const { createHash } = require('node:crypto')
 const fs = require('node:fs')
 const path = require('node:path')
 const { tmpdir } = require('node:os')
@@ -55,6 +57,14 @@ const wrapper = makeRunScriptWrapper(
   }
 )
 
+const integrity = LMFolderIntegrityCheck({
+  projectRoot: pkgJsonFolder,
+  pathJoin: path.join,
+  createHash,
+  readdirSync: fs.readdirSync,
+  readFileSync: fs.readFileSync,
+})
+
 const customEnv = wrapper.processEnv(process.env)
 
 // Note: spawnSync is used here instead of process.execve because execve is
@@ -67,6 +77,9 @@ const result = spawnSync(fallbackShell, [...shellArgs, scriptPayload], {
   env: customEnv,
   cwd: pkgJsonFolder,
 })
+
+integrity.verifyAfter()
+
 if (result.error) {
   console.error(
     `[LavaMoat wrapper failed to execute "${scriptName}"] ${result.error.message}`

--- a/packages/harden/src/runner/make-run-script-wrapper.global.d.ts
+++ b/packages/harden/src/runner/make-run-script-wrapper.global.d.ts
@@ -1,4 +1,16 @@
 declare global {
+  type LMFolderIntegrityCheckOptions = {
+    projectRoot: string
+    pathJoin: (...segments: string[]) => string
+    createHash: typeof import('node:crypto').createHash
+    readdirSync: typeof import('node:fs').readdirSync
+    readFileSync: typeof import('node:fs').readFileSync
+  }
+
+  type LMFolderIntegrityCheck = {
+    verifyAfter: () => void
+  }
+
   type MakeRunScriptWrapperConfigOptions = Record<
     string,
     boolean | string | string[]
@@ -36,6 +48,10 @@ declare global {
     options: MakeRunScriptWrapperOptions,
     io: MakeRunScriptWrapperIO
   ): MakeRunScriptWrapper
+
+  function LMFolderIntegrityCheck(
+    options: LMFolderIntegrityCheckOptions
+  ): LMFolderIntegrityCheck
 }
 
 export {}

--- a/packages/harden/src/runner/run-script-wrapper.cjs
+++ b/packages/harden/src/runner/run-script-wrapper.cjs
@@ -1,10 +1,54 @@
 /// <reference path="./make-run-script-wrapper.global.d.ts" />
 
 /**
+ * @param {object} opts
+ * @param {string} opts.projectRoot
+ * @param {typeof import('node:path').join} opts.pathJoin
+ * @param {typeof import('node:crypto').createHash} opts.createHash
+ * @param {typeof import('node:fs').readdirSync} opts.readdirSync
+ * @param {typeof import('node:fs').readFileSync} opts.readFileSync
+ */
+// eslint-disable-next-line no-unused-vars
+function LMFolderIntegrityCheck({
+  projectRoot,
+  pathJoin,
+  createHash,
+  readdirSync,
+  readFileSync,
+}) {
+  const lavamoatDir = pathJoin(projectRoot, 'lavamoat')
+
+  const hashFilesInDir = () => {
+    const hash = createHash('sha1')
+    readdirSync(lavamoatDir, { withFileTypes: true })
+      .filter((f) => f.isFile())
+      .map((f) => f.name)
+      .sort()
+      .forEach((f) => hash.update(readFileSync(pathJoin(lavamoatDir, f))))
+
+    return hash.digest('hex')
+  }
+
+  const hashZero = hashFilesInDir()
+
+  return {
+    verifyAfter: () => {
+      const hashNow = hashFilesInDir()
+      if (hashNow !== hashZero) {
+        throw new Error(
+          `[LavaMoat] lavamoat folder integrity check failed. It was modified during the script run.`
+        )
+      }
+    },
+  }
+}
+
+/**
  * @param {MakeRunScriptWrapperOptions} param0
  * @param {MakeRunScriptWrapperIO} param1
  * @returns {MakeRunScriptWrapper}
  */
+// eslint-disable-next-line no-unused-vars
 function makeRunScriptWrapper(
   {
     scriptName,
@@ -268,5 +312,3 @@ function makeRunScriptWrapper(
     },
   }
 }
-
-module.exports = makeRunScriptWrapper

--- a/packages/harden/src/runner/runner-bundler.js
+++ b/packages/harden/src/runner/runner-bundler.js
@@ -3,8 +3,6 @@ import path from 'node:path'
 
 const __dirname = import.meta.dirname
 
-const EXPORT_TO_REPLACE = 'module.exports = makeRunScriptWrapper'
-
 /**
  * @param {{ packageManager: string; fileName: string }} opts
  * @returns {string}
@@ -16,16 +14,5 @@ export function bundleRunner({ packageManager, fileName }) {
   const runScriptWrapperPath = path.join(__dirname, 'run-script-wrapper.cjs')
   const runScriptWrapperCode = fs.readFileSync(runScriptWrapperPath, 'utf-8')
 
-  if (!runScriptWrapperCode.includes(EXPORT_TO_REPLACE)) {
-    throw new Error(
-      `RunScriptWrapper file does not contain the required export statement or it was altered.`
-    )
-  }
-
-  const modifiedRunScriptWrapperCode = runScriptWrapperCode.replace(
-    EXPORT_TO_REPLACE,
-    ''
-  )
-
-  return `${adapterCode}\n;;\n${modifiedRunScriptWrapperCode}`
+  return `${adapterCode}\n;;\n${runScriptWrapperCode}`
 }

--- a/packages/harden/src/yarn/runner-plugin.js
+++ b/packages/harden/src/yarn/runner-plugin.js
@@ -7,6 +7,7 @@
 /** @typedef {NonNullable<import('@yarnpkg/core').Hooks['wrapScriptExecution']>} WrapScriptExecutionHook */
 
 /* global makeRunScriptWrapper */
+/* global LMFolderIntegrityCheck */
 
 /**
  * Yarn 4 plugin factory for wrapScriptExecution hook.
@@ -18,6 +19,7 @@ module.exports = {
   name: '@yarnpkg/plugin-runner',
   factory: function (/** @type {NodeJS.Require} */ require) {
     const { tmpdir } = require('node:os')
+    const { createHash } = require('node:crypto')
     return {
       hooks: {
         /** @type {WrapScriptExecutionHook} */
@@ -69,6 +71,14 @@ module.exports = {
             }
           )
 
+          const integrity = LMFolderIntegrityCheck({
+            projectRoot: extra.cwd,
+            pathJoin: path.join,
+            createHash,
+            readdirSync: fs.readdirSync,
+            readFileSync: fs.readFileSync,
+          })
+
           // extra.env is a reference to the mutable object, but a different variable
           // containing that reference is used within execute, so we must amend not
           // replace it.
@@ -77,7 +87,13 @@ module.exports = {
             delete extra.env[key]
           }
           Object.assign(extra.env, newEnv)
-          return executor
+          return async (...args) => {
+            try {
+              return await executor(...args)
+            } finally {
+              integrity.verifyAfter()
+            }
+          }
         },
       },
     }


### PR DESCRIPTION
- not sure if necessary or overkill
- should it be recursive? risks processing tens of KB of policy.json files ;)