### PR TITLE
fix(harden): use the project root for `projectRoot` in the Yarn runner plugin

### DIFF
--- a/packages/harden/src/yarn/runner-plugin.js
+++ b/packages/harden/src/yarn/runner-plugin.js
@@ -51,7 +51,7 @@ module.exports = {
             {
               scriptName,
               scriptPayload: extra.script,
-              projectRoot: extra.cwd,
+              projectRoot: project.cwd,
               pathBinMatcher: (fragment) => {
                 return fragment.endsWith(binFolder)
               },


### PR DESCRIPTION
The Yarn 4 runner plugin passed `extra.cwd` as `projectRoot` to `makeRunScriptWrapper`. `extra.cwd` is the directory the script is executed in, which for a workspace script is the workspace directory rather than the root of the project.

This switches it to `project.cwd`, so `projectRoot` points at the actual project root regardless of which workspace the script belongs to.