### PR TITLE
chore(deps): remove unused dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@endo/compartment-mapper": "2.4.0",
         "@eslint/js": "10.0.1",
         "@tsconfig/node22": "22.0.6",
-        "@types/lint-staged": "14.0.0",
         "@types/node": "22.20.1",
         "@types/semver": "7.7.1",
         "@types/wallabyjs": "0.0.16",
@@ -5307,17 +5306,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/lint-staged": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@types/lint-staged/-/lint-staged-14.0.0.tgz",
-      "integrity": "sha512-N8jBZIy9SWiPqO40VQdWiu7lXwzjDALPkHYDU9Z1UMPYmoFUSPLGMVXhuWNQR7dJrCFiphQ79goJPgr0rXC0Wg==",
-      "deprecated": "This is a stub types definition. lint-staged provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lint-staged": "*"
       }
     },
     "node_modules/@types/mdast": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@endo/compartment-mapper": "2.4.0",
     "@eslint/js": "10.0.1",
     "@tsconfig/node22": "22.0.6",
-    "@types/lint-staged": "14.0.0",
     "@types/node": "22.20.1",
     "@types/semver": "7.7.1",
     "@types/wallabyjs": "0.0.16",


### PR DESCRIPTION
This removes `@types/lint-staged` which is now a stub.