### PR TITLE
fix(harden): avoid test flakiness by relying less on one run per process

### DIFF
--- a/packages/harden/src/index.js
+++ b/packages/harden/src/index.js
@@ -9,8 +9,9 @@ import { opinions as pnpmOpinions } from './pnpm/opinions.js'
  * @import {
  *   HardenDefaultsOptions,
  *   HardenResult,
+ *   Opinion,
  *   PrintApi
- * } from "./tools/types.js"
+ * } from './tools/types.js'
  */
 
 /**
@@ -56,13 +57,13 @@ export async function hardenDefaults(options) {
   let opinions
   switch (pmName) {
     case 'npm':
-      opinions = npmOpinions
+      opinions = shallowCopy(npmOpinions)
       break
     case 'yarn':
-      opinions = yarnOpinions
+      opinions = shallowCopy(yarnOpinions)
       break
     case 'pnpm':
-      opinions = pnpmOpinions
+      opinions = shallowCopy(pnpmOpinions)
       break
     default:
       throw new Error(`Unsupported package manager: ${pmName}`)
@@ -122,4 +123,12 @@ export async function hardenDefaults(options) {
           .join('\n')
 
   return { result, summary }
+}
+
+/**
+ * @param {readonly Opinion[]} from
+ * @returns Opinion[]
+ */
+function shallowCopy(from) {
+  return from.map((item) => ({ ...item }))
 }

--- a/packages/harden/src/index.js
+++ b/packages/harden/src/index.js
@@ -127,7 +127,7 @@ export async function hardenDefaults(options) {
 
 /**
  * @param {readonly Opinion[]} from
- * @returns Opinion[]
+ * @returns {Opinion[]}
  */
 function shallowCopy(from) {
   return from.map((item) => ({ ...item }))

--- a/packages/harden/src/tools/apply-change.js
+++ b/packages/harden/src/tools/apply-change.js
@@ -93,8 +93,9 @@ export async function applyOpinion(cwd, opinion, facts, decisions, print) {
  */
 export async function verifyOpinion(cwd, opinion, facts) {
   const changes = opinion.changes ? structuredClone(opinion.changes) : []
-  if (!changes) {
-    return 0 // if there are no changes or custom verifier, consider the opinion NOT applied
+  if (!changes.length) {
+    if (!opinion.verify) return 0 // an opinion without changes and verify function should not exist
+    return (await opinion.verify(changes, [], facts)) ? 1 : 0
   }
   const result = []
   for (const change of changes) {

--- a/packages/harden/src/tools/apply-change.js
+++ b/packages/harden/src/tools/apply-change.js
@@ -93,7 +93,6 @@ export async function applyOpinion(cwd, opinion, facts, decisions, print) {
  */
 export async function verifyOpinion(cwd, opinion, facts) {
   const changes = opinion.changes ? structuredClone(opinion.changes) : []
-
   if (!changes) {
     return 0 // if there are no changes or custom verifier, consider the opinion NOT applied
   }
@@ -102,9 +101,11 @@ export async function verifyOpinion(cwd, opinion, facts) {
     result.push(...(await applyChange({ cwd, change, dryRun: true })))
   }
 
+  let score = 1 - result.length / changes.length
+
   if (opinion.verify) {
-    return (await opinion.verify(changes, result, facts)) ? 1 : 0
+    score = (await opinion.verify(changes, result, facts)) ? 1 : 0
   }
 
-  return 1 - result.length / changes.length
+  return score
 }

--- a/packages/harden/src/tools/yaml-config.js
+++ b/packages/harden/src/tools/yaml-config.js
@@ -6,7 +6,7 @@ import { parseDocument } from 'yaml'
  * @import {
  *   AppliedChange,
  *   Change
- * } from "./types.js"
+ * } from './types.js'
  */
 
 const yamlDocumentCache = new Map()

--- a/packages/harden/src/yarn/opinions.js
+++ b/packages/harden/src/yarn/opinions.js
@@ -202,8 +202,10 @@ const definedOpinions = Object.freeze(
           changes[0].value = facts.directGitDeps
         }
       },
-      verify: async (changes, results, _facts) => {
-        return results.length === 0
+      verify: async (changes, results, facts) => {
+        return !!(
+          results.length === 0 || facts?.yarnConfig?.approvedGitRepositories
+        )
       },
     },
 

--- a/packages/harden/test/with-scripts.spec.js
+++ b/packages/harden/test/with-scripts.spec.js
@@ -69,6 +69,10 @@ for (const pm of PKGMGR_LIST) {
 
     t.assert(result.length > 0, 'Expected some changes for strict level')
 
+    // cache busting - calling hardenDefaults multilpe times reuses dryRun cache otherwise
+    const cwd2 = cwd + '-m'
+    await execFileAsync('mv', [cwd, cwd2])
+
     const decisions = createVerifier({
       level: 'strict',
       packageManager: pm,
@@ -76,7 +80,7 @@ for (const pm of PKGMGR_LIST) {
     })
 
     const { summary } = await hardenDefaults({
-      cwd,
+      cwd: cwd2,
       packageManager: pm,
       decisions,
       print,

--- a/packages/harden/test/with-scripts.spec.js
+++ b/packages/harden/test/with-scripts.spec.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import { promises as fsPromises } from 'node:fs'
 import { hardenDefaults } from '../src/index.js'
 import { createFallbackDecisions } from '../src/tools/default-decisions.js'
 import { createVerifier } from '../src/tools/verifier.js'
@@ -69,9 +70,9 @@ for (const pm of PKGMGR_LIST) {
 
     t.assert(result.length > 0, 'Expected some changes for strict level')
 
-    // cache busting - calling hardenDefaults multilpe times reuses dryRun cache otherwise
+    // cache busting - calling hardenDefaults multiple times reuses dryRun cache otherwise
     const cwd2 = cwd + '-m'
-    await execFileAsync('mv', [cwd, cwd2])
+    await fsPromises.rename(cwd, cwd2)
 
     const decisions = createVerifier({
       level: 'strict',


### PR DESCRIPTION
Running `hardenDefaults` many times in one process had some problems for tests:
- yaml cache is permanent, per folder
- options object was getting `detected` updates from multiple sources

fixed options issue by making a shallow copy

keeping the cache and addressing the issue in test setup